### PR TITLE
feat: add 18+ age verification consent tracking

### DIFF
--- a/alembic/versions/2026_03_03_0001_add_age_verification_to_users.py
+++ b/alembic/versions/2026_03_03_0001_add_age_verification_to_users.py
@@ -1,0 +1,30 @@
+"""Add age verification fields to users table
+
+Stores evidence of 18+ age verification consent:
+- age_verified: boolean indicating the user confirmed they are 18+
+- age_verified_at: timestamp of when the verification was submitted
+
+Revision ID: e1f2a3b4c5d6
+Revises: d7e8f9a0b1c2
+Create Date: 2026-03-03 00:01:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e1f2a3b4c5d6'
+down_revision = 'd7e8f9a0b1c2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('age_verified', sa.Boolean(), nullable=False, server_default=sa.text('false')))
+    op.add_column('users', sa.Column('age_verified_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'age_verified_at')
+    op.drop_column('users', 'age_verified')

--- a/src/api/v1/auth/index.py
+++ b/src/api/v1/auth/index.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ....crud import user as user_crud
 from ....crud import api_key as api_key_crud
 from ....db.database import get_db, get_db_session
-from ....schemas.user import UserDeletionResponse
+from ....schemas.user import UserDeletionResponse, AgeVerificationRequest
 from ....schemas.api_key import APIKeyCreate, APIKeyResponse, APIKeyDB
 from ....dependencies import CurrentUser, get_current_user
 from ....db.models import User
@@ -46,6 +46,8 @@ async def get_current_user_info(
         "email": user.email,
         "name": user.name,
         "is_active": user.is_active,
+        "age_verified": user.age_verified,
+        "age_verified_at": user.age_verified_at,
         "created_at": user.created_at,
         "updated_at": user.updated_at,
         "data_source": data_source
@@ -54,6 +56,47 @@ async def get_current_user_info(
     # Email should now be automatically updated during authentication
     
     return response_data
+
+@router.post("/verify-age", response_model=dict)
+async def verify_age(
+    body: AgeVerificationRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session)
+):
+    """
+    Submit age verification consent (18+).
+
+    The user must send `{"age_verified": true}` to confirm they are 18 or older.
+    The confirmation and the timestamp are stored as evidence of consent.
+
+    Requires JWT Bearer authentication with Cognito token.
+    """
+    verify_logger = logger.bind(endpoint="verify_age", user_id=current_user.id)
+
+    if not body.age_verified:
+        verify_logger.warning("Age verification rejected (false)",
+                             event_type="age_verification_rejected")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Age verification must be confirmed as true"
+        )
+
+    updated_user = await user_crud.set_age_verification(db, current_user.id, True)
+
+    if not updated_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found"
+        )
+
+    verify_logger.info("Age verification confirmed",
+                      age_verified_at=updated_user.age_verified_at.isoformat(),
+                      event_type="age_verification_confirmed")
+
+    return {
+        "age_verified": updated_user.age_verified,
+        "age_verified_at": updated_user.age_verified_at
+    }
 
 @router.post("/keys", response_model=APIKeyResponse)
 async def create_api_key(

--- a/src/crud/user.py
+++ b/src/crud/user.py
@@ -1,4 +1,5 @@
 from typing import Optional, List, Union
+from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -241,4 +242,47 @@ async def update_user_from_cognito(
                     cognito_user_id=db_user.cognito_user_id,
                     error=str(e),
                     event_type="cognito_user_update_error")
-        return db_user 
+        return db_user
+
+
+async def set_age_verification(db: AsyncSession, user_id: int, verified: bool) -> Optional[User]:
+    """
+    Record the user's 18+ age verification consent.
+
+    Args:
+        db: Database session
+        user_id: User ID
+        verified: Whether the user confirmed they are 18+
+
+    Returns:
+        Updated user object, or None if user not found
+    """
+    user = await get_user_by_id(db, user_id)
+    if not user:
+        logger.warning("User not found for age verification",
+                      user_id=user_id,
+                      event_type="age_verification_user_not_found")
+        return None
+
+    if user.age_verified and user.age_verified_at:
+        logger.info("Age already verified, preserving original consent timestamp",
+                    user_id=user.id,
+                    age_verified_at=user.age_verified_at.isoformat(),
+                    event_type="age_verification_already_done")
+        return user
+
+    user.age_verified = verified
+    user.age_verified_at = datetime.utcnow()
+
+    await db.commit()
+    await db.refresh(user)
+
+    logger.info("Age verification recorded",
+               user_id=user.id,
+               age_verified=verified,
+               age_verified_at=user.age_verified_at.isoformat(),
+               event_type="age_verification_updated")
+
+    await cache_service.delete("user", user.cognito_user_id)
+
+    return user

--- a/src/db/models/user.py
+++ b/src/db/models/user.py
@@ -17,6 +17,8 @@ class User(Base):
     email = Column(String, unique=True, index=True, nullable=False)  # From Cognito token
     name = Column(String, nullable=True)  # From Cognito token (given_name/family_name)
     is_active = Column(Boolean, default=True)
+    age_verified = Column(Boolean, default=False, nullable=False)
+    age_verified_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -171,6 +171,8 @@ async def get_current_user(
                 cached_user["created_at"] = datetime.fromisoformat(cached_user["created_at"])
             if cached_user.get("updated_at"):
                 cached_user["updated_at"] = datetime.fromisoformat(cached_user["updated_at"])
+            if cached_user.get("age_verified_at"):
+                cached_user["age_verified_at"] = datetime.fromisoformat(cached_user["age_verified_at"])
             user = User(**cached_user)
         else:
             # Cache miss - get from database
@@ -183,6 +185,8 @@ async def get_current_user(
                     'email': user.email,
                     'name': user.name,
                     'is_active': user.is_active,
+                    'age_verified': user.age_verified,
+                    'age_verified_at': user.age_verified_at.isoformat() if user.age_verified_at else None,
                     'cognito_user_id': user.cognito_user_id,
                     'created_at': user.created_at.isoformat() if user.created_at else None,
                     'updated_at': user.updated_at.isoformat() if user.updated_at else None,
@@ -209,6 +213,8 @@ async def get_current_user(
                 'email': user.email,
                 'name': user.name,
                 'is_active': user.is_active,
+                'age_verified': user.age_verified,
+                'age_verified_at': user.age_verified_at.isoformat() if user.age_verified_at else None,
                 'cognito_user_id': user.cognito_user_id,
                 'created_at': user.created_at.isoformat() if user.created_at else None,
                 'updated_at': user.updated_at.isoformat() if user.updated_at else None,

--- a/src/schemas/user.py
+++ b/src/schemas/user.py
@@ -19,9 +19,24 @@ class UserUpdate(UserBase):
 # Properties to return to client
 class UserResponse(UserBase):
     id: int
+    age_verified: bool = False
+    age_verified_at: Optional[datetime] = None
     
     # Configure Pydantic to work with SQLAlchemy
     model_config = ConfigDict(from_attributes=True)
+
+# Age verification consent request
+class AgeVerificationRequest(BaseModel):
+    """Schema for age verification consent submission."""
+    age_verified: bool = Field(..., description="User confirms they are 18 years or older")
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "age_verified": True
+            }
+        }
+    )
 
 # Properties for authentication
 class UserLogin(BaseModel):


### PR DESCRIPTION
## Summary

- Adds `age_verified` (boolean) and `age_verified_at` (timestamp) columns to the `users` table to store evidence of 18+ consent
- New `POST /api/v1/auth/verify-age` endpoint accepts `{"age_verified": true}` and records the consent with a UTC timestamp
- `GET /api/v1/auth/me` now returns `age_verified` and `age_verified_at` so the frontend can gate access for unverified users
- Idempotent: repeated calls preserve the original consent timestamp rather than overwriting it
- User cache updated to include the new fields across all serialization/deserialization paths

## Changes

| File | Change |
|------|--------|
| `src/db/models/user.py` | Add `age_verified` and `age_verified_at` columns |
| `alembic/versions/2026_03_03_0001_...py` | Migration with `server_default=false` for existing rows |
| `src/schemas/user.py` | Add fields to `UserResponse`, new `AgeVerificationRequest` schema |
| `src/crud/user.py` | `set_age_verification()` with idempotency guard |
| `src/api/v1/auth/index.py` | `POST /verify-age` endpoint, updated `/me` response |
| `src/dependencies.py` | Cache serialization/deserialization for new fields |

## Frontend integration

1. Call `GET /api/v1/auth/me` after login -- check `age_verified`
2. If `false`, show 18+ consent checkbox before allowing access
3. On confirm, `POST /api/v1/auth/verify-age` with `{"age_verified": true}`
4. Proceed once a successful response with `age_verified_at` is received