### PR TITLE
fix: request aws.cognito.signin.user.admin scope in OAuth flow

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1106,7 +1106,7 @@ def custom_swagger_ui_html():
                 realm: 'oauth2',
                 appName: 'Morpheus API Gateway',
                 scopeSeparator: ' ',
-                scopes: 'openid email profile',
+                scopes: 'aws.cognito.signin.user.admin openid email profile',
                 usePkceWithAuthorizationCodeGrant: false,
                 useBasicAuthenticationWithAccessCodeGrant: false,
                 additionalQueryStringParams: {{
@@ -1517,6 +1517,7 @@ def custom_openapi():
                     "authorizationUrl": f"https://{settings.COGNITO_DOMAIN}/oauth2/authorize",
                     "tokenUrl": f"https://{settings.COGNITO_DOMAIN}/oauth2/token",
                     "scopes": {
+                        "aws.cognito.signin.user.admin": "Read own user attributes (GetUser)",
                         "openid": "OpenID Connect authentication",
                         "email": "Access to email address", 
                         "profile": "Access to profile information"
@@ -1562,7 +1563,7 @@ def custom_openapi():
                 # Auth and Automation endpoints: OAuth2/BearerAuth only (JWT tokens from Cognito)
                 elif path_key.startswith("/api/v1/auth/") or path_key.startswith("/api/v1/automation/") or path_key.startswith("/api/v1/billing/"):
                     operation["security"] = [
-                        {"OAuth2": ["openid", "email", "profile"]},
+                        {"OAuth2": ["aws.cognito.signin.user.admin", "openid", "email", "profile"]},
                         {"BearerAuth": []}
                     ]
                 # Default: All other endpoints use APIKeyAuth only


### PR DESCRIPTION
## Summary
- Adds `aws.cognito.signin.user.admin` to the OAuth scopes requested by the Swagger UI and OpenAPI security scheme definitions
- Without this scope, the access token issued by Cognito lacks the claim required by the `GetUser` API, causing `GET /me` to return `null` for email and name
- Three places updated in `src/main.py`: Swagger UI `initOAuth`, OpenAPI `securitySchemes`, and per-endpoint security requirements

## Context
The Cognito App Client already allows this scope (updated via Terraform). However, the OAuth authorization request from the API's Swagger UI was explicitly requesting only `openid email profile`, so Cognito issued tokens limited to those scopes. This fix ensures the full scope set is requested.

## Test plan
- [ ] Deploy to dev
- [ ] Log in via Swagger UI OAuth
- [ ] Verify the access token includes `aws.cognito.signin.user.admin` scope (check via jwt.io)
- [ ] Call `GET /api/v1/auth/me` and confirm email and name are returned


Made with [Cursor](https://cursor.com)