### PR TITLE
refactor: move pricing and rate limits from env vars to JSON config f…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 # Copy application code
 COPY ./src ./src
 COPY ./alembic ./alembic
+COPY ./models ./models
 COPY alembic.ini .
 
 # Create logs directory and initial models.json before changing ownership

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -53,6 +53,8 @@ services:
       REDIS_URL: redis://redis-local:6379/0
       # Local database
       DATABASE_URL: postgresql+asyncpg://morpheus_local:local_dev_password@db-local:5432/morpheus_local_db
+
+      ENVIRONMENT: ${ENVIRONMENT:-test}
       
       # Bypass Cognito for local testing (controlled by .env.local)
       BILLING_ADMIN_SECRET: ${BILLING_ADMIN_SECRET}
@@ -110,12 +112,8 @@ services:
       HOLD_RECONCILIATION_INTERVAL_SECONDS: ${HOLD_RECONCILIATION_INTERVAL_SECONDS:-600}
       HOLD_MAX_PENDING_SECONDS: ${HOLD_MAX_PENDING_SECONDS:-3600}
       
-      # Rate limiting settings
+      # Rate limiting (on/off toggle; limits configured in models/{env}_rate_limit.json)
       RATE_LIMIT_ENABLED: ${RATE_LIMIT_ENABLED:-true}
-      RATE_LIMIT_DEFAULT_RPM: ${RATE_LIMIT_DEFAULT_RPM:-60}
-      RATE_LIMIT_DEFAULT_TPM: ${RATE_LIMIT_DEFAULT_TPM:-100000}
-      RATE_LIMIT_WINDOW_SECONDS: ${RATE_LIMIT_WINDOW_SECONDS:-60}
-      RATE_LIMIT_MODEL_GROUPS: ${RATE_LIMIT_MODEL_GROUPS:-}
       
       # Web3/SIWE settings (ERC-4361 Sign-In with Ethereum)
       WEB3_PROVIDER_URL: ${WEB3_PROVIDER_URL:-}  # Optional: enables EIP-1271 smart contract wallet verification
@@ -133,6 +131,7 @@ services:
       - ./alembic.ini:/app/alembic.ini
       - ./tests:/app/tests
       - ./scripts:/app/scripts
+      - ./models:/app/models
     
     # Use startup script that handles migrations and verification
     command: ./scripts/start_local_dev.sh

--- a/env.example
+++ b/env.example
@@ -223,23 +223,9 @@ HOLD_MAX_PENDING_SECONDS=3600
 # =============================================================================
 # Enable/disable rate limiting globally
 RATE_LIMIT_ENABLED=true
-
-# Default rate limits (applied if no model-specific limits match)
-# Requests per minute (RPM)
-RATE_LIMIT_DEFAULT_RPM=60
-# Tokens per minute (TPM) - input + output combined
-RATE_LIMIT_DEFAULT_TPM=100000
-
-# Rate limit window in seconds (default: 60 for per-minute limits)
-RATE_LIMIT_WINDOW_SECONDS=60
-
-# Model group rate limits (optional, JSON format)
-# Override default limits for specific model groups
-# Format: [{"name": "group_name", "rpm": 30, "tpm": 50000, "models": ["model1", "model2*"], "priority": 100}]
-# Higher priority groups are matched first
-# Example:
-# RATE_LIMIT_MODEL_GROUPS=[{"name":"premium","rpm":30,"tpm":50000,"models":["gpt-4*","claude-3-opus*"],"priority":100},{"name":"fast","rpm":120,"tpm":200000,"models":["llama-3.1-8b*"],"priority":25}]
-RATE_LIMIT_MODEL_GROUPS=
+# Rate limit defaults and model groups are configured in models/{env}_rate_limit.json
+# Model pricing is configured in models/{env}_model_price.json
+# The ENVIRONMENT variable determines which file is used (see above)
 
 # =============================================================================
 # SIGNUP BONUS

--- a/models/prod_model_price.json
+++ b/models/prod_model_price.json
@@ -1,0 +1,36 @@
+{
+  "default_input_price_per_million": "0.50",
+  "default_output_price_per_million": "2.00",
+  "models": {
+    "glm-5": { "input": "1.00", "output": "3.20" },
+    "glm-4.7": { "input": "0.50", "output": "2.25" },
+    "glm-4.7-thinking": { "input": "0.45", "output": "2.00" },
+    "glm-4.7-flash": { "input": "0.10", "output": "0.50" },
+
+    "kimi-k2.5": { "input": "0.60", "output": "3.00" },
+    "kimi-k2-thinking": { "input": "0.60", "output": "3.00" },
+
+    "qwen3-235b": { "input": "0.40", "output": "3.00" },
+    "qwen-3-235b": { "input": "0.40", "output": "3.00" },
+    "qwen3-coder-480b-a35b-instruct": { "input": "0.70", "output": "2.80" },
+    "qwen3-coder-480b-a35b": { "input": "0.70", "output": "2.80" },
+    "qwen3-next-80b": { "input": "0.15", "output": "1.50" },
+
+    "minimax-m2.5": { "input": "0.30", "output": "1.20" },
+
+    "gpt-oss-120b": { "input": "0.07", "output": "0.28" },
+
+    "hermes-3-llama-3.1-405b": { "input": "1.00", "output": "3.00" },
+    "llama-3.3-70b": { "input": "0.70", "output": "2.50" },
+    "llama-3-3-70b": { "input": "0.70", "output": "2.50" },
+    "llama-3.2-3b": { "input": "0.10", "output": "0.50" },
+    "llama-3-2-3b": { "input": "0.10", "output": "0.50" },
+
+    "mistral-31-24b": { "input": "0.50", "output": "2.00" },
+    "mistral-small-24b": { "input": "0.50", "output": "2.00" },
+
+    "venice-uncensored": { "input": "0.20", "output": "0.90" },
+
+    "text-embedding-bge-m3": { "input": "0.10", "output": "0.50" }
+  }
+}

--- a/models/prod_rate_limit.json
+++ b/models/prod_rate_limit.json
@@ -1,0 +1,76 @@
+{
+  "default_rpm": 60,
+  "default_tpm": 100000,
+  "window_seconds": 60,
+  "model_groups": [
+    {
+      "name": "embedding",
+      "rpm": 500,
+      "tpm": 0,
+      "models": ["text-embedding-bge-m3"],
+      "priority": 10,
+      "description": "Embedding models with high throughput (no token limit)"
+    },
+    {
+      "name": "S",
+      "rpm": 500,
+      "tpm": 1000000,
+      "models": [
+        "llama-3.2-3b",
+        "llama-3.2-3b:web",
+        "qwen3-4b",
+        "qwen3-4b:web"
+      ],
+      "priority": 25,
+      "description": "Small models with high throughput limits"
+    },
+    {
+      "name": "M",
+      "rpm": 50,
+      "tpm": 750000,
+      "models": [
+        "llama-3.3-70b",
+        "llama-3.3-70b:web",
+        "mistral-31-24b",
+        "mistral-31-24b:web",
+        "qwen3-next-80b",
+        "qwen3-next-80b:web",
+        "venice-uncensored",
+        "venice-uncensored:web"
+      ],
+      "priority": 50,
+      "description": "Medium models with moderate limits"
+    },
+    {
+      "name": "L",
+      "rpm": 20,
+      "tpm": 500000,
+      "models": [
+        "glm-5",
+        "glm-5:web",
+        "glm-4.7",
+        "glm-4.7:web",
+        "glm-4.7-thinking",
+        "glm-4.7-thinking:web",
+        "glm-4.7-flash",
+        "glm-4.7-flash:web",
+        "kimi-k2.5",
+        "kimi-k2.5:web",
+        "kimi-k2-thinking",
+        "kimi-k2-thinking:web",
+        "qwen3-235b",
+        "qwen3-235b:web",
+        "qwen3-coder-480b-a35b-instruct",
+        "qwen3-coder-480b-a35b-instruct:web",
+        "minimax-m2.5",
+        "minimax-m2.5:web",
+        "gpt-oss-120b",
+        "gpt-oss-120b:web",
+        "hermes-3-llama-3.1-405b",
+        "hermes-3-llama-3.1-405b:web"
+      ],
+      "priority": 100,
+      "description": "Large models with conservative limits"
+    }
+  ]
+}

--- a/models/test_model_price.json
+++ b/models/test_model_price.json
@@ -1,0 +1,36 @@
+{
+  "default_input_price_per_million": "0.50",
+  "default_output_price_per_million": "2.00",
+  "models": {
+    "glm-5": { "input": "1.00", "output": "3.20" },
+    "glm-4.7": { "input": "0.50", "output": "2.25" },
+    "glm-4.7-thinking": { "input": "0.45", "output": "2.00" },
+    "glm-4.7-flash": { "input": "0.10", "output": "0.50" },
+
+    "kimi-k2.5": { "input": "0.60", "output": "3.00" },
+    "kimi-k2-thinking": { "input": "0.60", "output": "3.00" },
+
+    "qwen3-235b": { "input": "0.40", "output": "3.00" },
+    "qwen-3-235b": { "input": "0.40", "output": "3.00" },
+    "qwen3-coder-480b-a35b-instruct": { "input": "0.70", "output": "2.80" },
+    "qwen3-coder-480b-a35b": { "input": "0.70", "output": "2.80" },
+    "qwen3-next-80b": { "input": "0.15", "output": "1.50" },
+
+    "minimax-m2.5": { "input": "0.30", "output": "1.20" },
+
+    "gpt-oss-120b": { "input": "0.07", "output": "0.28" },
+
+    "hermes-3-llama-3.1-405b": { "input": "1.00", "output": "3.00" },
+    "llama-3.3-70b": { "input": "0.70", "output": "2.50" },
+    "llama-3-3-70b": { "input": "0.70", "output": "2.50" },
+    "llama-3.2-3b": { "input": "0.10", "output": "0.50" },
+    "llama-3-2-3b": { "input": "0.10", "output": "0.50" },
+
+    "mistral-31-24b": { "input": "0.50", "output": "2.00" },
+    "mistral-small-24b": { "input": "0.50", "output": "2.00" },
+
+    "venice-uncensored": { "input": "0.20", "output": "0.90" },
+
+    "text-embedding-bge-m3": { "input": "0.10", "output": "0.50" }
+  }
+}

--- a/models/test_rate_limit.json
+++ b/models/test_rate_limit.json
@@ -1,0 +1,76 @@
+{
+  "default_rpm": 60,
+  "default_tpm": 100000,
+  "window_seconds": 60,
+  "model_groups": [
+    {
+      "name": "embedding",
+      "rpm": 500,
+      "tpm": 0,
+      "models": ["text-embedding-bge-m3"],
+      "priority": 10,
+      "description": "Embedding models with high throughput (no token limit)"
+    },
+    {
+      "name": "S",
+      "rpm": 500,
+      "tpm": 1000000,
+      "models": [
+        "llama-3.2-3b",
+        "llama-3.2-3b:web",
+        "qwen3-4b",
+        "qwen3-4b:web"
+      ],
+      "priority": 25,
+      "description": "Small models with high throughput limits"
+    },
+    {
+      "name": "M",
+      "rpm": 50,
+      "tpm": 750000,
+      "models": [
+        "llama-3.3-70b",
+        "llama-3.3-70b:web",
+        "mistral-31-24b",
+        "mistral-31-24b:web",
+        "qwen3-next-80b",
+        "qwen3-next-80b:web",
+        "venice-uncensored",
+        "venice-uncensored:web"
+      ],
+      "priority": 50,
+      "description": "Medium models with moderate limits"
+    },
+    {
+      "name": "L",
+      "rpm": 20,
+      "tpm": 500000,
+      "models": [
+        "glm-5",
+        "glm-5:web",
+        "glm-4.7",
+        "glm-4.7:web",
+        "glm-4.7-thinking",
+        "glm-4.7-thinking:web",
+        "glm-4.7-flash",
+        "glm-4.7-flash:web",
+        "kimi-k2.5",
+        "kimi-k2.5:web",
+        "kimi-k2-thinking",
+        "kimi-k2-thinking:web",
+        "qwen3-235b",
+        "qwen3-235b:web",
+        "qwen3-coder-480b-a35b-instruct",
+        "qwen3-coder-480b-a35b-instruct:web",
+        "minimax-m2.5",
+        "minimax-m2.5:web",
+        "gpt-oss-120b",
+        "gpt-oss-120b:web",
+        "hermes-3-llama-3.1-405b",
+        "hermes-3-llama-3.1-405b:web"
+      ],
+      "priority": 100,
+      "description": "Large models with conservative limits"
+    }
+  ]
+}

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -265,19 +265,8 @@ class Settings(BaseSettings):
     # Rate Limiting Settings
     # Enable/disable rate limiting globally
     RATE_LIMIT_ENABLED: bool = Field(default=os.getenv("RATE_LIMIT_ENABLED", "true").lower() == "true")
-    
-    # Default rate limits (applied if no model-specific limits match)
-    # Requests per minute (RPM)
-    RATE_LIMIT_DEFAULT_RPM: int = Field(default=int(os.getenv("RATE_LIMIT_DEFAULT_RPM", "60")))
-    # Tokens per minute (TPM) - input + output combined
-    RATE_LIMIT_DEFAULT_TPM: int = Field(default=int(os.getenv("RATE_LIMIT_DEFAULT_TPM", "100000")))
-    
-    # Rate limit window in seconds (default: 60 for per-minute limits)
-    RATE_LIMIT_WINDOW_SECONDS: int = Field(default=int(os.getenv("RATE_LIMIT_WINDOW_SECONDS", "60")))
-    
-    # Model group rate limits (JSON format)
-    # Format: {"group_name": {"rpm": 30, "tpm": 50000, "models": ["model1", "model2"]}}
-    RATE_LIMIT_MODEL_GROUPS: str = Field(default=os.getenv("RATE_LIMIT_MODEL_GROUPS", ""))
+    # Rate limit defaults and model groups are loaded from models/{env}_rate_limit.json
+    # Model pricing is loaded from models/{env}_model_price.json
     
 
 

--- a/src/core/config_loader.py
+++ b/src/core/config_loader.py
@@ -1,0 +1,62 @@
+"""
+Environment-aware JSON config loader for model pricing and rate limits.
+
+Resolves the ENVIRONMENT variable to select the appropriate JSON files
+from the models/ directory at the project root.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+_MODELS_DIR = Path(__file__).resolve().parents[2] / "models"
+
+_ENV_PREFIX_MAP: Dict[str, str] = {
+    "production": "prod",
+    "prod": "prod",
+    "prd": "prod",
+    "staging": "prod",
+    "stg": "prod",
+    "stage": "prod",
+    "development": "test",
+    "dev": "test",
+    "test": "test",
+    "tst": "test",
+}
+
+_cache: Dict[str, Any] = {}
+
+
+def _get_prefix() -> str:
+    env = os.getenv("ENVIRONMENT", "development").lower().strip()
+    return _ENV_PREFIX_MAP.get(env, "test")
+
+
+def _load_json(filename: str) -> Dict[str, Any]:
+    if filename in _cache:
+        return _cache[filename]
+
+    filepath = _MODELS_DIR / filename
+    with open(filepath, "r") as f:
+        data = json.load(f)
+
+    _cache[filename] = data
+    return data
+
+
+def load_model_prices() -> Dict[str, Any]:
+    """Load the environment-appropriate model pricing config."""
+    prefix = _get_prefix()
+    return _load_json(f"{prefix}_model_price.json")
+
+
+def load_rate_limits() -> Dict[str, Any]:
+    """Load the environment-appropriate rate limit config."""
+    prefix = _get_prefix()
+    return _load_json(f"{prefix}_rate_limit.json")
+
+
+def clear_cache() -> None:
+    """Clear cached config data (useful for testing or hot-reload)."""
+    _cache.clear()

--- a/src/main.py
+++ b/src/main.py
@@ -413,10 +413,11 @@ async def startup_event():
     if settings.RATE_LIMIT_ENABLED:
         try:
             await rate_limit_service.initialize()
+            rules_info = rate_limit_service.get_rules_info()
             logger.info("Rate limiting service initialized",
                        enabled=True,
-                       default_rpm=settings.RATE_LIMIT_DEFAULT_RPM,
-                       default_tpm=settings.RATE_LIMIT_DEFAULT_TPM,
+                       default_rpm=rules_info.get("default", {}).get("rpm"),
+                       default_tpm=rules_info.get("default", {}).get("tpm"),
                        event_type="rate_limit_init_success")
         except Exception as e:
             logger.error("Failed to initialize rate limiting service",

--- a/src/services/pricing/hardcoded_provider.py
+++ b/src/services/pricing/hardcoded_provider.py
@@ -1,8 +1,7 @@
 """
-Hardcoded pricing provider implementation.
+JSON-file-backed pricing provider implementation.
 
-This is the initial implementation with static pricing defined in code.
-Will be replaced/augmented with database-backed pricing in the future.
+Loads model pricing from environment-specific JSON files in the models/ directory.
 """
 
 from typing import Optional, List, Dict, TYPE_CHECKING
@@ -14,91 +13,46 @@ if TYPE_CHECKING:
 
 from .types import ModelPricing
 from .provider import PricingProvider
-
-
-# Pricing per 1 million tokens in USD
-# Format: model_name -> (input_price, output_price)
-
-HARDCODED_PRICING: Dict[str, tuple[str, str]] = {
-    # GLM models
-    "glm-5": ("1.00", "3.20"),
-    "glm-4.7": ("0.50", "2.25"),
-    "glm-4.7-thinking": ("0.45", "2.00"),
-    "glm-4.7-flash": ("0.10", "0.50"),
-
-    # Kimi models
-    "kimi-k2.5": ("0.60", "3.00"),
-    "kimi-k2-thinking": ("0.60", "3.00"),
-
-    # Qwen models
-    "qwen3-235b": ("0.40", "3.00"),
-    "qwen-3-235b": ("0.40", "3.00"),  # Alternative format
-    "qwen3-coder-480b-a35b-instruct": ("0.70", "2.80"),
-    "qwen3-coder-480b-a35b": ("0.70", "2.80"),  # Without -instruct suffix
-    "qwen3-next-80b": ("0.15", "1.50"),
-
-    # MiniMax models
-    "minimax-m2.5": ("0.30", "1.20"),
-
-    # GPT OSS models
-    "gpt-oss-120b": ("0.07", "0.28"),
-
-    # Hermes / Llama models
-    "hermes-3-llama-3.1-405b": ("1.00", "3.00"),
-    "llama-3.3-70b": ("0.70", "2.50"),
-    "llama-3-3-70b": ("0.70", "2.50"),  # Alternative format
-    "llama-3.2-3b": ("0.10", "0.50"),
-    "llama-3-2-3b": ("0.10", "0.50"),  # Alternative format
-
-    # Mistral models
-    "mistral-31-24b": ("0.50", "2.00"),
-    "mistral-small-24b": ("0.50", "2.00"),  # Alternative format
-
-    # Venice models
-    "venice-uncensored": ("0.20", "0.90"),
-
-    # Embedding models
-    "text-embedding-bge-m3": ("0.10", "0.50"),
-}
-
-# Default pricing for unknown models (conservative high estimate)
-DEFAULT_INPUT_PRICE = Decimal("0.50")
-DEFAULT_OUTPUT_PRICE = Decimal("2.00")
+from src.core.config_loader import load_model_prices
 
 
 class HardcodedPricingProvider(PricingProvider):
     """
-    Pricing provider with statically defined prices.
-    
-    This implementation doesn't require database access and returns
-    immediately. Useful for development, testing, and as a fallback.
+    Pricing provider backed by JSON config files.
+
+    Reads per-model and default prices from models/{env}_model_price.json,
+    selected automatically based on the ENVIRONMENT variable.
     """
-    
+
     def __init__(self):
-        """Initialize with hardcoded pricing data."""
         self._pricing_cache: Dict[str, ModelPricing] = {}
+        self._default_input_price: Decimal = Decimal("0.50")
+        self._default_output_price: Decimal = Decimal("2.00")
         self._initialize_pricing()
-    
+
     def _initialize_pricing(self) -> None:
-        """Build the pricing cache from hardcoded data."""
-        effective_date = datetime(2024, 12, 1)  # Pricing effective date
-        
-        for name, (input_price, output_price) in HARDCODED_PRICING.items():
+        """Build the pricing cache from JSON config."""
+        config = load_model_prices()
+        effective_date = datetime(2024, 12, 1)
+
+        self._default_input_price = Decimal(config.get("default_input_price_per_million", "0.50"))
+        self._default_output_price = Decimal(config.get("default_output_price_per_million", "2.00"))
+
+        for name, prices in config.get("models", {}).items():
             self._pricing_cache[name.lower()] = ModelPricing(
                 model_name=name,
-                input_price_per_million=Decimal(input_price),
-                output_price_per_million=Decimal(output_price),
-                model_id=None,  # Hex32 ID not available in hardcoded pricing
+                input_price_per_million=Decimal(prices["input"]),
+                output_price_per_million=Decimal(prices["output"]),
+                model_id=None,
                 currency="USD",
                 effective_from=effective_date,
-                metadata={"source": "hardcoded", "version": "1.0"},
+                metadata={"source": "json_config", "version": "1.0"},
             )
-    
+
     @property
     def source_name(self) -> str:
-        """Return the source name for this provider."""
-        return "hardcoded"
-    
+        return "json_config"
+
     async def get_model_pricing(
         self,
         model_name: Optional[str] = None,
@@ -107,82 +61,67 @@ class HardcodedPricingProvider(PricingProvider):
     ) -> Optional[ModelPricing]:
         """
         Get pricing for a specific model.
-        
-        Hardcoded provider only supports lookup by model_name.
-        model_id (hex32) is ignored in this implementation but will be
-        used by future DatabasePricingProvider.
-        
+
         Performs case-insensitive lookup with fuzzy matching.
         """
         if model_name is None:
-            # Hardcoded provider requires model_name
             return None
-        
+
         normalized = self._normalize_model_name(model_name)
-        
-        # Direct lookup
+
         if normalized in self._pricing_cache:
             return self._pricing_cache[normalized]
-        
-        # Try fuzzy matching (handles variations like "llama-3.3-70b-instruct")
+
         pricing = self._fuzzy_match_pricing(normalized)
         if pricing:
             return pricing
-        
+
         return None
-    
+
     async def get_all_model_pricing(
         self,
         db: Optional["AsyncSession"] = None,
     ) -> List[ModelPricing]:
-        """Get pricing for all available models."""
         return list(self._pricing_cache.values())
-    
+
     async def get_default_pricing(self) -> ModelPricing:
-        """Get default pricing for unknown models."""
         return ModelPricing(
             model_name="default",
-            input_price_per_million=DEFAULT_INPUT_PRICE,
-            output_price_per_million=DEFAULT_OUTPUT_PRICE,
+            input_price_per_million=self._default_input_price,
+            output_price_per_million=self._default_output_price,
             model_id=None,
             currency="USD",
-            metadata={"source": "hardcoded_default", "version": "1.0"},
+            metadata={"source": "json_config_default", "version": "1.0"},
         )
-    
+
     def _normalize_model_name(self, model_name: str) -> str:
         """
         Normalize model name for consistent lookup.
-        
-        Handles variations like:
-        - Case differences: "Llama-3.3-70B" -> "llama-3.3-70b"
-        - Separator differences: "llama_3_3_70b" -> "llama-3-3-70b"
+
+        Handles case differences and separator/suffix variations.
         """
         normalized = model_name.lower().strip()
-        # Normalize separators
         normalized = normalized.replace("_", "-")
-        # Remove common suffixes that don't affect pricing
         for suffix in ["-instruct", "-chat", "-base"]:
             if normalized.endswith(suffix):
                 normalized = normalized[:-len(suffix)]
         return normalized
-    
+
     def _fuzzy_match_pricing(self, normalized_name: str) -> Optional[ModelPricing]:
         """
         Attempt fuzzy matching for model names.
-        
+
         Matches models with variations like:
         - "llama-3.3-70b-instruct" -> matches "llama-3.3-70b"
         - "meta-llama-3.3-70b" -> matches "llama-3.3-70b"
         """
         for known_name, pricing in self._pricing_cache.items():
-            # Check if known name is contained in the provided name
             if known_name in normalized_name:
                 return pricing
-            # Check if provided name is contained in known name
             if normalized_name in known_name:
                 return pricing
         return None
-    
+
     def add_pricing(
         self,
         model_name: str,
@@ -190,12 +129,7 @@ class HardcodedPricingProvider(PricingProvider):
         output_price: Decimal,
         model_id: Optional[str] = None,
     ) -> None:
-        """
-        Add or update pricing for a model (for testing purposes).
-        
-        In production, pricing should be managed through proper channels
-        (database or configuration).
-        """
+        """Add or update pricing for a model (for testing purposes)."""
         self._pricing_cache[model_name.lower()] = ModelPricing(
             model_name=model_name,
             input_price_per_million=input_price,
@@ -203,6 +137,5 @@ class HardcodedPricingProvider(PricingProvider):
             model_id=model_id,
             currency="USD",
             effective_from=datetime.utcnow(),
-            metadata={"source": "hardcoded_dynamic", "version": "1.0"},
+            metadata={"source": "json_config_dynamic", "version": "1.0"},
         )
-

--- a/src/services/rate_limiting/rules_service.py
+++ b/src/services/rate_limiting/rules_service.py
@@ -2,17 +2,16 @@
 Rate Limit Rules Service
 
 Manages rate limiting rules and model group configurations.
-Allows easy adjustment of rate limits without code changes.
+Loads configuration from environment-specific JSON files in the models/ directory.
 
 Note: Setting tpm=0 in a model group means no tokens/minute limit
 (unlimited tokens). The RPM limit still applies.
 """
 
-import json
 from typing import Dict, List, Optional
-from dataclasses import dataclass
 
 from src.core.config import settings
+from src.core.config_loader import load_rate_limits
 from src.core.logging_config import get_core_logger
 
 from .types import RateLimitConfig, ModelGroupConfig
@@ -20,112 +19,37 @@ from .types import RateLimitConfig, ModelGroupConfig
 logger = get_core_logger()
 
 
-# Default model group configurations
-# These can be overridden via RATE_LIMIT_MODEL_GROUPS environment variable
-DEFAULT_MODEL_GROUPS: List[Dict] = [
-    {
-        "name": "embedding",
-        "rpm": 500,
-        "tpm": 0,  # No tokens/minute limit for embeddings
-        "models": ["text-embedding-bge-m3"],
-        "priority": 10,
-        "description": "Embedding models with high throughput (no token limit)"
-    },
-    {
-        "name": "S",
-        "rpm": 500,
-        "tpm": 1000000,
-        "models": [
-            "llama-3.2-3b",
-            "llama-3.2-3b:web",
-            "qwen3-4b",
-            "qwen3-4b:web",
-        ],
-        "priority": 25,
-        "description": "Small models with high throughput limits"
-    },
-    {
-        "name": "M",
-        "rpm": 50,
-        "tpm": 750000,
-        "models": [
-            "llama-3.3-70b",
-            "llama-3.3-70b:web",
-            "mistral-31-24b",
-            "mistral-31-24b:web",
-            "qwen3-next-80b",
-            "qwen3-next-80b:web",
-            "venice-uncensored",
-            "venice-uncensored:web",
-        ],
-        "priority": 50,
-        "description": "Medium models with moderate limits"
-    },
-    {
-        "name": "L",
-        "rpm": 20,
-        "tpm": 500000,
-        "models": [
-            "glm-5",
-            "glm-5:web",
-            "glm-4.7",
-            "glm-4.7:web",
-            "glm-4.7-thinking",
-            "glm-4.7-thinking:web",
-            "glm-4.7-flash",
-            "glm-4.7-flash:web",
-            "kimi-k2.5",
-            "kimi-k2.5:web",
-            "kimi-k2-thinking",
-            "kimi-k2-thinking:web",
-            "qwen3-235b",
-            "qwen3-235b:web",
-            "qwen3-coder-480b-a35b-instruct",
-            "qwen3-coder-480b-a35b-instruct:web",
-            "minimax-m2.5",
-            "minimax-m2.5:web",
-            "gpt-oss-120b",
-            "gpt-oss-120b:web",
-            "hermes-3-llama-3.1-405b",
-            "hermes-3-llama-3.1-405b:web",
-        ],
-        "priority": 100,
-        "description": "Large models with conservative limits"
-    },
-]
-
-
 class RateLimitRulesService:
     """
     Service for managing rate limiting rules.
-    
-    Provides:
-    - Default rate limits
-    - Model group-specific rate limits
-    - Dynamic rule configuration via environment variables
-    - Model-to-group matching
+
+    Loads default limits and model-group overrides from
+    models/{env}_rate_limit.json, selected by the ENVIRONMENT variable.
     """
-    
+
     def __init__(self):
         self._default_config: Optional[RateLimitConfig] = None
         self._model_groups: List[ModelGroupConfig] = []
         self._initialized = False
-    
+
     def initialize(self) -> None:
-        """Initialize the rules service with configuration."""
+        """Initialize the rules service from JSON config."""
         if self._initialized:
             return
-        
-        # Load default configuration
+
+        config = load_rate_limits()
+
         self._default_config = RateLimitConfig(
-            rpm=settings.RATE_LIMIT_DEFAULT_RPM,
-            tpm=settings.RATE_LIMIT_DEFAULT_TPM,
-            window_seconds=settings.RATE_LIMIT_WINDOW_SECONDS,
+            rpm=config.get("default_rpm", 60),
+            tpm=config.get("default_tpm", 100000),
+            window_seconds=config.get("window_seconds", 60),
         )
-        
-        # Load model groups
-        self._load_model_groups()
-        
+
+        self._model_groups = [
+            self._parse_group_config(g)
+            for g in config.get("model_groups", [])
+        ]
+
         self._initialized = True
         logger.info(
             "Rate limit rules initialized",
@@ -134,49 +58,7 @@ class RateLimitRulesService:
             model_groups_count=len(self._model_groups),
             event_type="rate_limit_rules_init",
         )
-    
-    def _load_model_groups(self) -> None:
-        """Load model groups from configuration."""
-        groups_config = settings.RATE_LIMIT_MODEL_GROUPS
-        
-        # Try to parse from environment variable first
-        if groups_config and groups_config.strip():
-            try:
-                parsed_groups = json.loads(groups_config)
-                if isinstance(parsed_groups, list):
-                    self._model_groups = [
-                        self._parse_group_config(g) for g in parsed_groups
-                    ]
-                elif isinstance(parsed_groups, dict):
-                    # Support dict format: {"group_name": {...config...}}
-                    self._model_groups = [
-                        self._parse_group_config({**v, "name": k})
-                        for k, v in parsed_groups.items()
-                    ]
-                
-                logger.info(
-                    "Loaded model groups from environment",
-                    groups_count=len(self._model_groups),
-                    event_type="model_groups_loaded",
-                )
-                return
-            except json.JSONDecodeError as e:
-                logger.warning(
-                    "Failed to parse RATE_LIMIT_MODEL_GROUPS, using defaults",
-                    error=str(e),
-                    event_type="model_groups_parse_error",
-                )
-        
-        # Fall back to defaults
-        self._model_groups = [
-            self._parse_group_config(g) for g in DEFAULT_MODEL_GROUPS
-        ]
-        logger.info(
-            "Using default model groups",
-            groups_count=len(self._model_groups),
-            event_type="model_groups_default",
-        )
-    
+
     def _parse_group_config(self, config: Dict) -> ModelGroupConfig:
         """Parse a dictionary into a ModelGroupConfig."""
         return ModelGroupConfig(
@@ -187,45 +69,43 @@ class RateLimitRulesService:
             priority=config.get("priority", 0),
             description=config.get("description", ""),
         )
-    
+
     @property
     def default_config(self) -> RateLimitConfig:
         """Get the default rate limit configuration."""
         if not self._initialized:
             self.initialize()
         return self._default_config
-    
+
     @property
     def model_groups(self) -> List[ModelGroupConfig]:
         """Get all configured model groups."""
         if not self._initialized:
             self.initialize()
         return self._model_groups
-    
+
     def get_config_for_model(self, model_name: Optional[str]) -> tuple[RateLimitConfig, Optional[str]]:
         """
         Get the rate limit configuration for a specific model.
-        
+
         Args:
             model_name: The name of the model
-            
+
         Returns:
             Tuple of (RateLimitConfig, model_group_name or None)
         """
         if not self._initialized:
             self.initialize()
-        
+
         if not model_name:
             return self._default_config, None
-        
-        # Sort groups by priority (highest first)
+
         sorted_groups = sorted(
             self._model_groups,
             key=lambda g: g.priority,
             reverse=True
         )
-        
-        # Find matching group
+
         for group in sorted_groups:
             if group.matches_model(model_name):
                 config = RateLimitConfig(
@@ -234,28 +114,21 @@ class RateLimitRulesService:
                     window_seconds=self._default_config.window_seconds,
                 )
                 return config, group.name
-        
-        # No match, use default
+
         return self._default_config, None
-    
+
     def add_model_group(self, group: ModelGroupConfig) -> None:
         """
         Add or update a model group configuration.
-        
+
         Useful for runtime rule updates.
-        
-        Args:
-            group: The model group configuration to add
         """
         if not self._initialized:
             self.initialize()
-        
-        # Remove existing group with same name
+
         self._model_groups = [g for g in self._model_groups if g.name != group.name]
-        
-        # Add new group
         self._model_groups.append(group)
-        
+
         logger.info(
             "Model group added/updated",
             group_name=group.name,
@@ -264,23 +137,20 @@ class RateLimitRulesService:
             models_count=len(group.models),
             event_type="model_group_updated",
         )
-    
+
     def remove_model_group(self, group_name: str) -> bool:
         """
         Remove a model group configuration.
-        
-        Args:
-            group_name: The name of the group to remove
-            
+
         Returns:
             True if the group was removed, False if not found
         """
         if not self._initialized:
             self.initialize()
-        
+
         original_count = len(self._model_groups)
         self._model_groups = [g for g in self._model_groups if g.name != group_name]
-        
+
         removed = len(self._model_groups) < original_count
         if removed:
             logger.info(
@@ -288,18 +158,14 @@ class RateLimitRulesService:
                 group_name=group_name,
                 event_type="model_group_removed",
             )
-        
+
         return removed
-    
+
     def get_all_rules_info(self) -> Dict:
-        """
-        Get a summary of all rate limiting rules.
-        
-        Useful for admin/debugging endpoints.
-        """
+        """Get a summary of all rate limiting rules."""
         if not self._initialized:
             self.initialize()
-        
+
         return {
             "enabled": settings.RATE_LIMIT_ENABLED,
             "default": {
@@ -319,13 +185,15 @@ class RateLimitRulesService:
                 for g in sorted(self._model_groups, key=lambda x: -x.priority)
             ],
         }
-    
+
     def reload_rules(self) -> None:
         """
-        Reload rules from configuration.
-        
-        Useful for dynamic rule updates without restart.
+        Reload rules from JSON config.
+
+        Clears the config_loader cache so the file is re-read from disk.
         """
+        from src.core.config_loader import clear_cache
+        clear_cache()
         self._initialized = False
         self._model_groups = []
         self._default_config = None
@@ -335,5 +203,3 @@ class RateLimitRulesService:
 
 # Singleton instance
 rate_limit_rules_service = RateLimitRulesService()
-
-


### PR DESCRIPTION
…iles

## Summary

Standardizes how model pricing and rate limiting are configured by moving them from hardcoded Python dicts and environment variables into environment-specific JSON files under a new `models/` directory.

The `ENVIRONMENT` variable determines which config set is loaded:
- `production` / `prod` / `prd` / `staging` / `stg` / `stage` --> `prod_*.json`
- `development` / `dev` / `test` / `tst` --> `test_*.json`

## Changes

- **Added `models/` directory** with 4 JSON config files:
  - `test_model_price.json` / `prod_model_price.json` -- per-model token pricing (USD per 1M tokens) and default fallback prices
  - `test_rate_limit.json` / `prod_rate_limit.json` -- default RPM/TPM, window, and model group rate limit tiers (S/M/L/embedding)

- **Added `src/core/config_loader.py`** -- lightweight loader that resolves `ENVIRONMENT` to the correct file prefix, reads JSON, and caches results

## Why

- Pricing and rate limits can now be tuned by editing JSON files without touching Python code or redeploying env vars
- Test and production environments can have independent configurations that diverge as needed
- Single consistent pattern for both concerns instead of a mix of Python dicts and env-var JSON strings

The following environment variables were removed:
RATE_LIMIT_DEFAULT_RPM -- default requests per minute (was 60)
RATE_LIMIT_DEFAULT_TPM -- default tokens per minute (was 100000)
RATE_LIMIT_WINDOW_SECONDS -- rate limit window duration (was 60)
RATE_LIMIT_MODEL_GROUPS -- JSON string defining model group rate limits (S/M/L/embedding tiers)

## Test Plan

- [ ] Verify app starts locally with `ENVIRONMENT=development` and loads `test_*.json`
- [ ] Verify `ENVIRONMENT=production` loads `prod_*.json`
- [ ] Confirm `/health` endpoint reports correct rate limit rules
- [ ] Test a chat request to confirm pricing estimation and billing still work
- [ ] Confirm Docker build succeeds and `models/` directory is present in the image