### PR TITLE
fix: prevent staking refresh from silently losing balance updates

### DIFF
--- a/src/services/staking_service.py
+++ b/src/services/staking_service.py
@@ -414,8 +414,10 @@ class StakingService:
                         adjustment_factor=str(adj_factor)
                     )
                     
-                    # Get current balance to check if already refreshed today
-                    balance = await credits_crud.get_or_create_balance(db, user_id)
+                    # Get current balance with row lock to ensure we modify a
+                    # session-tracked object (bypasses Redis cache) and prevent
+                    # concurrent updates from racing with us.
+                    balance = await credits_crud.get_or_create_balance(db, user_id, for_update=True)
                     
                     # Check if already refreshed today - skip balance update but still update wallet stakes
                     if balance.staking_refresh_date == today:
@@ -431,7 +433,9 @@ class StakingService:
                     
                     idempotency_key = f"staking_sync:{user_id}:{today.isoformat()}"
                     
-                    # Create ledger entry for staking refresh (transaction record)
+                    # Create ledger entry for staking refresh (transaction record).
+                    # Use auto_commit=False so the ledger row and the balance
+                    # update below are committed in a single atomic transaction.
                     if daily_amount > 0:
                         await credits_crud.create_ledger_entry(
                             db=db,
@@ -442,6 +446,7 @@ class StakingService:
                             amount_paid=Decimal("0"),
                             amount_staking=daily_amount,  # Positive for credit (in USD)
                             description=f"Daily staking rewards: {stake_in_mor:.4f} MOR staked ({stake_share*100:.4f}% share), earned {mor_earned:.6f} MOR @ ${mor_price:.2f}",
+                            auto_commit=False,
                         )
                     
                     # Update user's staking balance
@@ -452,7 +457,7 @@ class StakingService:
                     balance.is_staker = daily_amount > 0
                     balance.updated_at = datetime.utcnow()
                     
-                    # Commit all changes for this user atomically
+                    # Commit ledger entry + balance update atomically
                     await db.commit()
                     
                     users_processed += 1


### PR DESCRIPTION
## Summary

- **Bug**: The daily staking refresh cron was writing `staking_refresh` ledger entries but failing to update `credit_account_balances` for some users. Discovered via user 352 (`jabo38@hotmail.com`) who had 3,376.6 MOR staked and two staking_refresh ledger entries totaling ~$20, but `staking_daily_amount`, `staking_available`, and `staking_refresh_date` were all zero/null in the balance table. All 587 of their usage charges came from the paid balance instead of staking credit.

- **Root cause (two compounding bugs)**:
  1. `get_or_create_balance()` was called without `for_update=True`, so a Redis cache hit returned a **detached ORM object** not tracked by the SQLAlchemy session. Modifying it and calling `db.commit()` was a silent no-op for the balance row.
  2. `create_ledger_entry()` used `auto_commit=True` (default), committing the ledger row in its own transaction. If anything failed before the subsequent balance commit, the ledger entry persisted while the balance rollback left staking fields at zero.

- **Fix**:
  - Use `for_update=True` to always get a session-managed, row-locked balance from the DB (bypasses Redis cache)
  - Use `auto_commit=False` so the ledger entry and balance update are committed in a single atomic transaction

## Affected users

User 352 is confirmed affected. Users 129, 145, 263 have null `staking_refresh_date` but linked after today's midnight refresh (expected — they'll get their first refresh tonight). After this fix deploys, the next midnight staking refresh will correct user 352's balance automatically.

## Test plan

- [ ] Verify the fix by triggering a manual staking refresh via `POST /billing/staking/refresh` on dev
- [ ] Confirm user balances are updated correctly (both ledger entry and balance table in sync)
- [ ] Verify that `staking_refresh_date` is set after refresh
- [ ] Check that the `for_update=True` path correctly acquires a row lock and returns a session-tracked object
- [ ] After deploying to prd, verify user 352's balance is corrected by the next midnight refresh (or trigger manual refresh)


Made with [Cursor](https://cursor.com)