### PR TITLE
feat: admin Swagger separation + per-user rate limit multiplier — MAIN

### DIFF
--- a/alembic/versions/2026_03_10_0001_add_rate_limit_multiplier_to_users.py
+++ b/alembic/versions/2026_03_10_0001_add_rate_limit_multiplier_to_users.py
@@ -1,0 +1,31 @@
+"""Add rate_limit_multiplier to users table
+
+Per-user scaling factor for rate limits (RPM/TPM).
+Default 1.0 means no change; 2.0 doubles the limits, 0.5 halves them.
+Managed exclusively by admin endpoints — never exposed to end users.
+
+Revision ID: add_rate_limit_mult
+Revises: drop_email_name_2026
+Create Date: 2026-03-10 00:01:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'add_rate_limit_mult'
+down_revision: Union[str, None] = 'drop_email_name_2026'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'users',
+        sa.Column('rate_limit_multiplier', sa.Float(), nullable=False, server_default='1.0'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'rate_limit_multiplier')

--- a/src/api/v1/__init__.py
+++ b/src/api/v1/__init__.py
@@ -8,7 +8,7 @@ from .chat_history.index import router as chat_history_router
 from .embeddings.index import router as embeddings_router
 from .audio.index import router as audio_router
 from .billing.index import router as billing_router
-from .billing.index import admin_router as billing_admin_router
+from .billing.admin import admin_router as billing_admin_router
 from .webhooks.stripe import stripe_webhook_router
 from .webhooks.coinbase import coinbase_webhook_router
 from .wallet.index import router as wallet_router

--- a/src/api/v1/__init__.py
+++ b/src/api/v1/__init__.py
@@ -8,6 +8,7 @@ from .chat_history.index import router as chat_history_router
 from .embeddings.index import router as embeddings_router
 from .audio.index import router as audio_router
 from .billing.index import router as billing_router
+from .billing.index import admin_router as billing_admin_router
 from .webhooks.stripe import stripe_webhook_router
 from .webhooks.coinbase import coinbase_webhook_router
 from .wallet.index import router as wallet_router
@@ -36,6 +37,10 @@ chat_history.include_router(chat_history_router)
 # Billing router
 billing = APIRouter()
 billing.include_router(billing_router)
+
+# Billing admin router (separate Swagger page at /admin/docs)
+billing_admin = APIRouter()
+billing_admin.include_router(billing_admin_router)
 
 # Webhooks router
 webhooks = APIRouter()

--- a/src/api/v1/billing/admin.py
+++ b/src/api/v1/billing/admin.py
@@ -1,0 +1,409 @@
+"""
+Admin billing API endpoints.
+Protected by X-Admin-Secret header. Served on /admin/docs Swagger page.
+"""
+from fastapi import APIRouter, Depends, HTTPException, status, Query, Header
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Optional
+import secrets
+
+from ....db.database import get_db_session
+from ....db.models import User
+from ....dependencies import get_current_user
+from ....services.billing_service import billing_service
+from ....services.staking_service import staking_service
+from ....crud import credits as credits_crud
+from ....crud import user as user_crud
+from ....schemas.billing import (
+    BalanceResponse,
+    StakingSettingsRequest,
+    StakingSettingsResponse,
+    StakingRefreshResponse,
+    ManualTopupRequest,
+    ManualTopupResponse,
+    RateLimitMultiplierRequest,
+    RateLimitMultiplierResponse,
+)
+from ....core.logging_config import get_api_logger
+from ....core.config import settings
+from ....services.cache_service import cache_service
+
+logger = get_api_logger()
+
+admin_router = APIRouter(tags=["Billing Admin"])
+
+
+# === Admin Authentication ===
+
+async def verify_billing_admin_secret(
+    x_admin_secret: Optional[str] = Header(None, alias="X-Admin-Secret")
+) -> bool:
+    """
+    Verify the admin secret for protected billing endpoints.
+    
+    Requires the X-Admin-Secret header to match BILLING_ADMIN_SECRET env variable.
+    """
+    if not settings.BILLING_ADMIN_SECRET:
+        logger.warning(
+            "Billing admin endpoint called but BILLING_ADMIN_SECRET is not configured",
+            event_type="billing_admin_not_configured"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Admin billing endpoints are not configured. Set BILLING_ADMIN_SECRET environment variable."
+        )
+    
+    if not x_admin_secret:
+        logger.warning(
+            "Billing admin endpoint called without X-Admin-Secret header",
+            event_type="billing_admin_missing_secret"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing X-Admin-Secret header"
+        )
+    
+    if not secrets.compare_digest(x_admin_secret, settings.BILLING_ADMIN_SECRET):
+        logger.warning(
+            "Billing admin endpoint called with invalid secret",
+            event_type="billing_admin_invalid_secret"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid admin secret"
+        )
+    
+    return True
+
+
+# === Staking Settings Endpoints ===
+
+@admin_router.post("/staking/settings", response_model=StakingSettingsResponse)
+async def set_staking_settings(
+    staking_request: StakingSettingsRequest,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+    _admin_verified: bool = Depends(verify_billing_admin_secret),
+):
+    """
+    Set the daily staking allowance amount.
+
+    **Admin/Dev endpoint** - Requires X-Admin-Secret header.
+
+    This updates the configured daily amount but does NOT trigger an immediate refresh.
+    The new amount will take effect on the next daily refresh.
+    """
+    try:
+        balance = await credits_crud.set_staking_daily_amount(
+            db=db,
+            user_id=current_user.id,
+            amount=staking_request.daily_amount,
+        )
+        
+        logger.info(
+            "Staking settings updated by admin",
+            user_id=current_user.id,
+            daily_amount=str(staking_request.daily_amount),
+            event_type="billing_admin_staking_settings"
+        )
+        
+        return StakingSettingsResponse(
+            daily_amount=balance.staking_daily_amount,
+            message="Staking daily amount updated",
+        )
+    except Exception as e:
+        logger.error(
+            "Error in set_staking_settings endpoint",
+            user_id=current_user.id,
+            error=str(e),
+            error_type=type(e).__name__,
+            event_type="billing_staking_settings_error"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error updating staking settings: {str(e)}"
+        )
+
+
+@admin_router.post("/staking/refresh", response_model=StakingRefreshResponse)
+async def trigger_staking_refresh(
+    db: AsyncSession = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+    _admin_verified: bool = Depends(verify_billing_admin_secret),
+):
+    """
+    Trigger the daily staking sync from Builders API.
+
+    **Admin/Dev endpoint** - Requires X-Admin-Secret header.
+
+    This operation:
+    1. Fetches all stakers from Builders API
+    2. Updates staked_amount for all linked wallets
+    3. Calculates daily credits for each user (total_staked / 100)
+    4. Creates ledger entries (transactions) for each user refresh
+    5. Updates user balances
+
+    Idempotent: Users already refreshed today will be skipped.
+    The staking bucket resets to the calculated daily amount (does not accumulate).
+    """
+    logger.info(
+        "Staking sync triggered by admin",
+        user_id=current_user.id,
+        event_type="billing_admin_staking_sync"
+    )
+    
+    try:
+        summary = await staking_service.run_daily_sync(db)
+        
+        return StakingRefreshResponse(
+            success=summary.get("success", True),
+            message="Staking sync completed successfully",
+            stakers_fetched=summary.get("stakers_fetched"),
+            total_wallets=summary.get("total_wallets"),
+            wallets_updated=summary.get("wallets_updated"),
+            users_processed=summary.get("users_processed"),
+            users_skipped=summary.get("users_skipped"),
+            users_failed=summary.get("users_failed"),
+            duration_seconds=summary.get("duration_seconds"),
+        )
+    except Exception as e:
+        logger.error(
+            "Staking sync failed",
+            user_id=current_user.id,
+            error=str(e),
+            event_type="billing_admin_staking_sync_failed"
+        )
+        return StakingRefreshResponse(
+            success=False,
+            message=f"Staking sync failed: {str(e)}",
+        )
+
+
+# === Manual Credit Adjustment ===
+
+@admin_router.post("/credits/adjust", response_model=ManualTopupResponse)
+async def adjust_credits(
+    request: ManualTopupRequest,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+    _admin_verified: bool = Depends(verify_billing_admin_secret),
+):
+    """
+    Manually adjust credits for an account (add or subtract).
+
+    **Admin/Dev endpoint** - Requires X-Admin-Secret header.
+
+    - Positive amount: Adds credits (simulates a purchase)
+    - Negative amount: Subtracts credits (admin correction/chargeback)
+    - user_id (optional): Target user ID (database primary key integer)
+    - cognito_user_id (optional): Target Cognito user ID (UUID)
+    - If neither provided, adjusts current user's credits.
+
+    This endpoint is for development/admin purposes to manage credits
+    without integrating with payment providers.
+    """
+    try:
+        target_user_id = current_user.id
+        
+        if request.user_id is not None:
+            target_user_id = request.user_id
+        elif request.cognito_user_id is not None:
+            target_user = await user_crud.get_user_by_cognito_id(db, str(request.cognito_user_id))
+            if not target_user:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"User with cognito_user_id {request.cognito_user_id} not found"
+                )
+            target_user_id = target_user.id
+        
+        entry, new_balance = await billing_service.adjust_credits(
+            db=db,
+            user_id=target_user_id,
+            amount=request.amount_usd,
+            description=request.description,
+        )
+        
+        action = "added" if request.amount_usd >= 0 else "subtracted"
+        logger.info(
+            f"Manual credit adjustment by admin: {action}",
+            user_id=str(target_user_id),
+            admin_user_id=str(current_user.id),
+            amount=str(request.amount_usd),
+            new_balance=str(new_balance),
+            event_type="billing_admin_credit_adjust"
+        )
+        
+        return ManualTopupResponse(
+            ledger_entry_id=entry.id,
+            amount_added=request.amount_usd,
+            new_paid_balance=new_balance,
+            message=f"Credits {action} successfully",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            "Error in adjust_credits endpoint",
+            user_id=current_user.id,
+            error=str(e),
+            error_type=type(e).__name__,
+            event_type="billing_credit_adjust_error"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error adjusting credits: {str(e)}"
+        )
+
+
+# === Balance Reconciliation ===
+
+@admin_router.post("/balance/reconcile", response_model=BalanceResponse)
+async def reconcile_balance(
+    user_id: Optional[int] = Query(default=None, description="Target user ID (defaults to current user)"),
+    db: AsyncSession = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+    _admin_verified: bool = Depends(verify_billing_admin_secret),
+):
+    """
+    Reconcile the cached balance against the ledger (source of truth).
+
+    **Admin/Dev endpoint** - Requires X-Admin-Secret header.
+
+    Fixes drift in `paid_pending_holds` caused by partial transaction failures
+    where the ledger entry was updated but the balance cache was not.
+
+    Recomputes `paid_pending_holds` from the sum of all pending usage_hold entries in the ledger.
+
+    Parameters:
+    - user_id: Target user ID (defaults to current user)
+    """
+    try:
+        target_user_id = user_id if user_id is not None else current_user.id
+        
+        logger.info(
+            "Balance reconciliation triggered by admin",
+            target_user_id=target_user_id,
+            admin_user_id=current_user.id,
+            event_type="billing_admin_reconcile",
+        )
+        
+        result = await billing_service.reconcile_balance(db, target_user_id)
+        return result
+    except Exception as e:
+        logger.error(
+            "Error in reconcile_balance endpoint",
+            user_id=current_user.id,
+            error=str(e),
+            error_type=type(e).__name__,
+            event_type="billing_reconcile_error",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error reconciling balance: {str(e)}",
+        )
+
+
+# === Rate Limit Multiplier ===
+
+@admin_router.post("/rate-limit/multiplier", response_model=RateLimitMultiplierResponse)
+async def set_rate_limit_multiplier(
+    request: RateLimitMultiplierRequest,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+    _admin_verified: bool = Depends(verify_billing_admin_secret),
+):
+    """
+    Set the rate limit multiplier for a user.
+
+    **Admin endpoint** - Requires X-Admin-Secret header.
+
+    The multiplier scales all RPM/TPM limits for the target user:
+    - 1.0 = default limits
+    - 2.0 = double the limits
+    - 0.5 = half the limits
+
+    Applies to all models. Takes effect on the next request.
+    """
+    try:
+        target_user = await user_crud.get_user_by_cognito_id(db, request.cognito_user_id)
+        if not target_user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"User with cognito_user_id {request.cognito_user_id} not found",
+            )
+
+        target_user.rate_limit_multiplier = request.multiplier
+        await db.commit()
+        await db.refresh(target_user)
+
+        await cache_service.delete("user", request.cognito_user_id)
+
+        logger.info(
+            "Rate limit multiplier updated by admin",
+            target_user_id=target_user.id,
+            target_cognito_id=request.cognito_user_id,
+            admin_user_id=current_user.id,
+            multiplier=request.multiplier,
+            event_type="admin_rate_limit_multiplier_set",
+        )
+
+        return RateLimitMultiplierResponse(
+            cognito_user_id=target_user.cognito_user_id,
+            user_id=target_user.id,
+            multiplier=target_user.rate_limit_multiplier,
+            message=f"Rate limit multiplier set to {request.multiplier}",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            "Error setting rate limit multiplier",
+            error=str(e),
+            error_type=type(e).__name__,
+            event_type="admin_rate_limit_multiplier_error",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error setting rate limit multiplier: {str(e)}",
+        )
+
+
+@admin_router.get("/rate-limit/multiplier/{cognito_user_id}", response_model=RateLimitMultiplierResponse)
+async def get_rate_limit_multiplier(
+    cognito_user_id: str,
+    db: AsyncSession = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+    _admin_verified: bool = Depends(verify_billing_admin_secret),
+):
+    """
+    Get the current rate limit multiplier for a user.
+
+    **Admin endpoint** - Requires X-Admin-Secret header.
+    """
+    try:
+        target_user = await user_crud.get_user_by_cognito_id(db, cognito_user_id)
+        if not target_user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"User with cognito_user_id {cognito_user_id} not found",
+            )
+
+        return RateLimitMultiplierResponse(
+            cognito_user_id=target_user.cognito_user_id,
+            user_id=target_user.id,
+            multiplier=target_user.rate_limit_multiplier,
+            message="Current rate limit multiplier",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            "Error getting rate limit multiplier",
+            error=str(e),
+            error_type=type(e).__name__,
+            event_type="admin_rate_limit_multiplier_get_error",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error getting rate limit multiplier: {str(e)}",
+        )

--- a/src/api/v1/billing/index.py
+++ b/src/api/v1/billing/index.py
@@ -42,6 +42,7 @@ from ....core.config import settings
 logger = get_api_logger()
 
 router = APIRouter(tags=["Billing"])
+admin_router = APIRouter(tags=["Billing Admin"])
 
 
 # === Admin Authentication ===
@@ -502,7 +503,7 @@ async def list_usage_for_month(
 
 # === Staking Settings Endpoints (Admin Protected) ===
 
-@router.post("/staking/settings", response_model=StakingSettingsResponse)
+@admin_router.post("/staking/settings", response_model=StakingSettingsResponse)
 async def set_staking_settings(
     staking_request: StakingSettingsRequest,
     db: AsyncSession = Depends(get_db_session),
@@ -549,7 +550,7 @@ async def set_staking_settings(
         )
 
 
-@router.post("/staking/refresh", response_model=StakingRefreshResponse)
+@admin_router.post("/staking/refresh", response_model=StakingRefreshResponse)
 async def trigger_staking_refresh(
     db: AsyncSession = Depends(get_db_session),
     current_user: User = Depends(get_current_user),
@@ -605,7 +606,7 @@ async def trigger_staking_refresh(
 
 # === Manual Credit Top-up (Admin/Dev endpoint) ===
 
-@router.post("/credits/adjust", response_model=ManualTopupResponse)
+@admin_router.post("/credits/adjust", response_model=ManualTopupResponse)
 async def adjust_credits(
     request: ManualTopupRequest,
     db: AsyncSession = Depends(get_db_session),
@@ -686,7 +687,7 @@ async def adjust_credits(
 
 # === Balance Reconciliation (Admin endpoint) ===
 
-@router.post("/balance/reconcile", response_model=BalanceResponse)
+@admin_router.post("/balance/reconcile", response_model=BalanceResponse)
 async def reconcile_balance(
     user_id: Optional[int] = Query(default=None, description="Target user ID (defaults to current user)"),
     db: AsyncSession = Depends(get_db_session),
@@ -732,6 +733,7 @@ async def reconcile_balance(
         )
 
 
-# Export router
+# Export routers
 billing_router = router
+billing_admin_router = admin_router
 

--- a/src/api/v1/billing/index.py
+++ b/src/api/v1/billing/index.py
@@ -1,22 +1,18 @@
 """
 Billing API endpoints for credits management.
-Provides REST API for viewing balance, transactions, spending metrics, and staking settings.
+Provides REST API for viewing balance, transactions, spending metrics, and overage settings.
 """
-from fastapi import APIRouter, Depends, HTTPException, Request, status, Query, Header
-from fastapi.security import APIKeyHeader
+from fastapi import APIRouter, Depends, HTTPException, Request, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
-from typing import Optional, List
-from datetime import datetime, date
+from typing import Optional
+from datetime import datetime
 from decimal import Decimal
-import secrets
 
 from ....db.database import get_db_session
 from ....db.models import User, LedgerEntryType
 from ....dependencies import get_current_user, get_api_key_user
 from ....services.billing_service import billing_service
-from ....services.staking_service import staking_service
 from ....crud import credits as credits_crud
-from ....crud import user as user_crud
 from ....schemas.billing import (
     BalanceResponse,
     LedgerEntryResponse,
@@ -26,67 +22,16 @@ from ....schemas.billing import (
     SpendingModeEnum,
     UsageListResponse,
     UsageEntryResponse,
-    StakingSettingsRequest,
-    StakingSettingsResponse,
-    StakingRefreshResponse,
-    ManualTopupRequest,
-    ManualTopupResponse,
     OverageSettingsRequest,
     OverageSettingsResponse,
     LedgerStatusEnum,
     LedgerEntryTypeEnum,
 )
 from ....core.logging_config import get_api_logger
-from ....core.config import settings
 
 logger = get_api_logger()
 
 router = APIRouter(tags=["Billing"])
-admin_router = APIRouter(tags=["Billing Admin"])
-
-
-# === Admin Authentication ===
-
-async def verify_billing_admin_secret(
-    x_admin_secret: Optional[str] = Header(None, alias="X-Admin-Secret")
-) -> bool:
-    """
-    Verify the admin secret for protected billing endpoints.
-    
-    Requires the X-Admin-Secret header to match BILLING_ADMIN_SECRET env variable.
-    """
-    if not settings.BILLING_ADMIN_SECRET:
-        logger.warning(
-            "Billing admin endpoint called but BILLING_ADMIN_SECRET is not configured",
-            event_type="billing_admin_not_configured"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Admin billing endpoints are not configured. Set BILLING_ADMIN_SECRET environment variable."
-        )
-    
-    if not x_admin_secret:
-        logger.warning(
-            "Billing admin endpoint called without X-Admin-Secret header",
-            event_type="billing_admin_missing_secret"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing X-Admin-Secret header"
-        )
-    
-    # Use constant-time comparison to prevent timing attacks
-    if not secrets.compare_digest(x_admin_secret, settings.BILLING_ADMIN_SECRET):
-        logger.warning(
-            "Billing admin endpoint called with invalid secret",
-            event_type="billing_admin_invalid_secret"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Invalid admin secret"
-        )
-    
-    return True
 
 
 # === Balance Endpoint ===
@@ -501,239 +446,7 @@ async def list_usage_for_month(
         )
 
 
-# === Staking Settings Endpoints (Admin Protected) ===
 
-@admin_router.post("/staking/settings", response_model=StakingSettingsResponse)
-async def set_staking_settings(
-    staking_request: StakingSettingsRequest,
-    db: AsyncSession = Depends(get_db_session),
-    current_user: User = Depends(get_current_user),
-    _admin_verified: bool = Depends(verify_billing_admin_secret),
-):
-    """
-    Set the daily staking allowance amount.
-    
-    **Admin/Dev endpoint** - Requires X-Admin-Secret header.
-    
-    This updates the configured daily amount but does NOT trigger an immediate refresh.
-    The new amount will take effect on the next daily refresh.
-    """
-    try:
-        balance = await credits_crud.set_staking_daily_amount(
-            db=db,
-            user_id=current_user.id,
-            amount=staking_request.daily_amount,
-        )
-        
-        logger.info(
-            "Staking settings updated by admin",
-            user_id=current_user.id,
-            daily_amount=str(staking_request.daily_amount),
-            event_type="billing_admin_staking_settings"
-        )
-        
-        return StakingSettingsResponse(
-            daily_amount=balance.staking_daily_amount,
-            message="Staking daily amount updated",
-        )
-    except Exception as e:
-        logger.error(
-            "Error in set_staking_settings endpoint",
-            user_id=current_user.id,
-            error=str(e),
-            error_type=type(e).__name__,
-            event_type="billing_staking_settings_error"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error updating staking settings: {str(e)}"
-        )
-
-
-@admin_router.post("/staking/refresh", response_model=StakingRefreshResponse)
-async def trigger_staking_refresh(
-    db: AsyncSession = Depends(get_db_session),
-    current_user: User = Depends(get_current_user),
-    _admin_verified: bool = Depends(verify_billing_admin_secret),
-):
-    """
-    Trigger the daily staking sync from Builders API.
-    
-    **Admin/Dev endpoint** - Requires X-Admin-Secret header.
-    
-    This operation:
-    1. Fetches all stakers from Builders API
-    2. Updates staked_amount for all linked wallets
-    3. Calculates daily credits for each user (total_staked / 100)
-    4. Creates ledger entries (transactions) for each user refresh
-    5. Updates user balances
-    
-    Idempotent: Users already refreshed today will be skipped.
-    The staking bucket resets to the calculated daily amount (does not accumulate).
-    """
-    logger.info(
-        "Staking sync triggered by admin",
-        user_id=current_user.id,
-        event_type="billing_admin_staking_sync"
-    )
-    
-    try:
-        summary = await staking_service.run_daily_sync(db)
-        
-        return StakingRefreshResponse(
-            success=summary.get("success", True),
-            message="Staking sync completed successfully",
-            stakers_fetched=summary.get("stakers_fetched"),
-            total_wallets=summary.get("total_wallets"),
-            wallets_updated=summary.get("wallets_updated"),
-            users_processed=summary.get("users_processed"),
-            users_skipped=summary.get("users_skipped"),
-            users_failed=summary.get("users_failed"),
-            duration_seconds=summary.get("duration_seconds"),
-        )
-    except Exception as e:
-        logger.error(
-            "Staking sync failed",
-            user_id=current_user.id,
-            error=str(e),
-            event_type="billing_admin_staking_sync_failed"
-        )
-        return StakingRefreshResponse(
-            success=False,
-            message=f"Staking sync failed: {str(e)}",
-        )
-
-
-# === Manual Credit Top-up (Admin/Dev endpoint) ===
-
-@admin_router.post("/credits/adjust", response_model=ManualTopupResponse)
-async def adjust_credits(
-    request: ManualTopupRequest,
-    db: AsyncSession = Depends(get_db_session),
-    current_user: User = Depends(get_current_user),
-    _admin_verified: bool = Depends(verify_billing_admin_secret),
-):
-    """
-    Manually adjust credits for an account (add or subtract).
-    
-    **Admin/Dev endpoint** - Requires X-Admin-Secret header.
-    
-    - Positive amount: Adds credits (simulates a purchase)
-    - Negative amount: Subtracts credits (admin correction/chargeback)
-    - user_id (optional): Target user ID (database primary key integer)
-    - cognito_user_id (optional): Target Cognito user ID (UUID)
-    - If neither provided, adjusts current user's credits.
-    
-    This endpoint is for development/admin purposes to manage credits
-    without integrating with payment providers.
-    """
-    try:
-        # Determine target user ID
-        target_user_id = current_user.id
-        
-        if request.user_id is not None:
-            target_user_id = request.user_id
-        elif request.cognito_user_id is not None:
-            # Look up user by cognito_user_id
-            target_user = await user_crud.get_user_by_cognito_id(db, str(request.cognito_user_id))
-            if not target_user:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"User with cognito_user_id {request.cognito_user_id} not found"
-                )
-            target_user_id = target_user.id
-        
-        entry, new_balance = await billing_service.adjust_credits(
-            db=db,
-            user_id=target_user_id,
-            amount=request.amount_usd,
-            description=request.description,
-        )
-        
-        action = "added" if request.amount_usd >= 0 else "subtracted"
-        logger.info(
-            f"Manual credit adjustment by admin: {action}",
-            user_id=str(target_user_id),
-            admin_user_id=str(current_user.id),
-            amount=str(request.amount_usd),
-            new_balance=str(new_balance),
-            event_type="billing_admin_credit_adjust"
-        )
-        
-        message = f"Credits {action} successfully"
-        
-        return ManualTopupResponse(
-            ledger_entry_id=entry.id,
-            amount_added=request.amount_usd,
-            new_paid_balance=new_balance,
-            message=message,
-        )
-    except HTTPException:
-        # Re-raise HTTP exceptions as-is
-        raise
-    except Exception as e:
-        logger.error(
-            "Error in adjust_credits endpoint",
-            user_id=current_user.id,
-            error=str(e),
-            error_type=type(e).__name__,
-            event_type="billing_credit_adjust_error"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error adjusting credits: {str(e)}"
-        )
-
-
-# === Balance Reconciliation (Admin endpoint) ===
-
-@admin_router.post("/balance/reconcile", response_model=BalanceResponse)
-async def reconcile_balance(
-    user_id: Optional[int] = Query(default=None, description="Target user ID (defaults to current user)"),
-    db: AsyncSession = Depends(get_db_session),
-    current_user: User = Depends(get_current_user),
-    _admin_verified: bool = Depends(verify_billing_admin_secret),
-):
-    """
-    Reconcile the cached balance against the ledger (source of truth).
-    
-    **Admin/Dev endpoint** - Requires X-Admin-Secret header.
-    
-    Fixes drift in `paid_pending_holds` caused by partial transaction failures
-    where the ledger entry was updated but the balance cache was not.
-    
-    Recomputes `paid_pending_holds` from the sum of all pending usage_hold entries in the ledger.
-    
-    Parameters:
-    - user_id: Target user ID (defaults to current user)
-    """
-    try:
-        target_user_id = user_id if user_id is not None else current_user.id
-        
-        logger.info(
-            "Balance reconciliation triggered by admin",
-            target_user_id=target_user_id,
-            admin_user_id=current_user.id,
-            event_type="billing_admin_reconcile",
-        )
-        
-        result = await billing_service.reconcile_balance(db, target_user_id)
-        return result
-    except Exception as e:
-        logger.error(
-            "Error in reconcile_balance endpoint",
-            user_id=current_user.id,
-            error=str(e),
-            error_type=type(e).__name__,
-            event_type="billing_reconcile_error",
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error reconciling balance: {str(e)}",
-        )
-
-
-# Export routers
+# Export router
 billing_router = router
-billing_admin_router = admin_router
 

--- a/src/api/v1/chat/index.py
+++ b/src/api/v1/chat/index.py
@@ -273,6 +273,7 @@ async def _check_rate_limits(
         model=model,
         estimated_tokens=estimated_tokens,
         request_id=request_id,
+        multiplier=getattr(user, "rate_limit_multiplier", 1.0) or 1.0,
     )
     
     if not result.allowed and result.status != RateLimitStatus.ERROR:

--- a/src/api/v1/embeddings/index.py
+++ b/src/api/v1/embeddings/index.py
@@ -76,6 +76,7 @@ async def create_embeddings(
             db_api_key=db_api_key,
             requested_model=requested_model,
             request_data=request_data,
+            user=user,
         )
         
         # Create billing hold
@@ -259,6 +260,7 @@ async def _check_rate_limits(
     db_api_key: APIKey,
     requested_model: Optional[str],
     request_data: EmbeddingRequest,
+    user=None,
 ) -> RateLimitResult:
     """
     Check rate limits (RPM and TPM) before processing the request.
@@ -296,6 +298,7 @@ async def _check_rate_limits(
         model=requested_model,
         estimated_tokens=estimated_tokens,
         request_id=request_id,
+        multiplier=getattr(user, "rate_limit_multiplier", 1.0) or 1.0,
     )
     
     if not result.allowed:

--- a/src/db/models/user.py
+++ b/src/db/models/user.py
@@ -4,7 +4,7 @@ User model for authentication and account management.
 PII (email, name) lives exclusively in Cognito.  The database only stores
 cognito_user_id as the identity key and application-level fields.
 """
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Float
 from sqlalchemy.orm import relationship
 from datetime import datetime
 
@@ -20,6 +20,7 @@ class User(Base):
     is_active = Column(Boolean, default=True)
     age_verified = Column(Boolean, default=False, nullable=False)
     age_verified_at = Column(DateTime, nullable=True)
+    rate_limit_multiplier = Column(Float, nullable=False, default=1.0, server_default="1.0")
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -178,6 +178,7 @@ async def get_current_user(
                     'cognito_user_id': user.cognito_user_id,
                     'created_at': user.created_at.isoformat() if user.created_at else None,
                     'updated_at': user.updated_at.isoformat() if user.updated_at else None,
+                    'rate_limit_multiplier': user.rate_limit_multiplier,
                 }
                 await cache_service.set("user", cognito_user_id, user_cache_data, ttl_seconds=600)
         
@@ -195,6 +196,7 @@ async def get_current_user(
                 'cognito_user_id': user.cognito_user_id,
                 'created_at': user.created_at.isoformat() if user.created_at else None,
                 'updated_at': user.updated_at.isoformat() if user.updated_at else None,
+                'rate_limit_multiplier': user.rate_limit_multiplier,
             }
             await cache_service.set("user", cognito_user_id, user_cache_data, ttl_seconds=600)
         
@@ -285,6 +287,7 @@ async def get_api_key_auth(
                 'cognito_user_id': test_user.cognito_user_id,
                 'created_at': test_user.created_at,
                 'updated_at': test_user.updated_at,
+                'rate_limit_multiplier': test_user.rate_limit_multiplier,
             }
             # Fetch the test user's first active API key (if any)
             result = await db.execute(
@@ -377,6 +380,7 @@ async def _build_auth_from_cache(
         cognito_user_id=ud.get("cognito_user_id"),
         created_at=datetime.fromisoformat(ud["created_at"]) if ud.get("created_at") else None,
         updated_at=datetime.fromisoformat(ud["updated_at"]) if ud.get("updated_at") else None,
+        rate_limit_multiplier=ud.get("rate_limit_multiplier", 1.0),
     )
 
     # ── Deserialize APIKey ──────────────────────────────────────────────
@@ -459,6 +463,7 @@ async def _build_auth_from_db(
             'cognito_user_id': db_user.cognito_user_id,
             'created_at': db_user.created_at,
             'updated_at': db_user.updated_at,
+            'rate_limit_multiplier': db_user.rate_limit_multiplier,
         }
         api_key_dict = {
             'id': db_api_key.id,

--- a/src/main.py
+++ b/src/main.py
@@ -13,9 +13,10 @@ import asyncio
 import os
 import uuid
 import socket
+import copy
 import platform
 
-from src.api.v1 import models, chat, auth, chat_history, embeddings, audio, billing, webhooks, wallet
+from src.api.v1 import models, chat, auth, chat_history, embeddings, audio, billing, billing_admin, webhooks, wallet
 from src.api.v1.chat.chat_exceptions import ChatError
 from src.services import session_routing_service
 from src.utils.error_sanitizer import sanitize_error_message
@@ -559,6 +560,7 @@ app.include_router(chat_history, prefix=f"{settings.API_V1_STR}/chat-history")
 app.include_router(embeddings, prefix=f"{settings.API_V1_STR}")
 app.include_router(audio, prefix=f"{settings.API_V1_STR}")
 app.include_router(billing, prefix=f"{settings.API_V1_STR}/billing")
+app.include_router(billing_admin, prefix=f"{settings.API_V1_STR}/billing")
 app.include_router(webhooks, prefix=f"{settings.API_V1_STR}/webhooks")
 app.include_router(wallet, prefix=f"{settings.API_V1_STR}/auth/wallet")
 
@@ -1075,17 +1077,14 @@ async def swagger_ui_oauth2_redirect(request: Request):
 # Note: Custom OAuth2 login endpoint removed - now using standard Swagger UI OAuth2 flow
 
 
-# Simple working docs endpoint (before route class restoration)  
-@app.get("/docs", include_in_schema=False)
-def custom_swagger_ui_html():
-    """
-    Custom Swagger UI docs 
-    """
-    return HTMLResponse(content=f"""
+def _build_swagger_html(*, title: str, openapi_url: str, app_name: str, oauth_state: str) -> str:
+    """Build Swagger UI HTML page with full OAuth2 popup flow."""
+    client_id = settings.COGNITO_CLIENT_ID
+    return f"""
     <!DOCTYPE html>
     <html>
     <head>
-        <title>Morpheus API Gateway - API Documentation</title>
+        <title>{title}</title>
         <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui.css">
     </head>
     <body>
@@ -1093,132 +1092,101 @@ def custom_swagger_ui_html():
         <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui-bundle.js"></script>
         <script>
             const ui = SwaggerUIBundle({{
-                url: '/api/v1/openapi.json',
+                url: '{openapi_url}',
                 dom_id: '#swagger-ui',
                 layout: 'BaseLayout',
                 oauth2RedirectUrl: window.location.origin + '/docs/oauth2-redirect'
             }});
-            
-            // Make UI available globally for token application
+
             window.ui = ui;
-            
+
             ui.initOAuth({{
-                clientId: '{settings.COGNITO_CLIENT_ID}',
+                clientId: '{client_id}',
                 realm: 'oauth2',
-                appName: 'Morpheus API Gateway',
+                appName: '{app_name}',
                 scopeSeparator: ' ',
                 scopes: 'openid email profile',
                 usePkceWithAuthorizationCodeGrant: false,
                 useBasicAuthenticationWithAccessCodeGrant: false,
                 additionalQueryStringParams: {{
                     'response_type': 'code',
-                    'state': 'swagger-ui-oauth2'
+                    'state': '{oauth_state}'
                 }}
             }});
-            
-            // Debug: Log OAuth2 configuration
-            console.log('🔍 OAuth2 redirect configured');
-            
+
             // Override OAuth2 authorization to use popup instead of new tab
             setTimeout(() => {{
-                console.log('🔍 Setting up OAuth2 popup override...');
-                
-                // Override the window.open function specifically for OAuth2 URLs
                 const originalWindowOpen = window.open;
                 window.open = function(url, target, features) {{
                     if (url && url.includes('/oauth2/authorize')) {{
-                        console.log('🔍 OAuth2 authorization detected, opening popup instead of tab');
-                        
-                        // Set up Swagger UI OAuth2 redirect callback for popup detection
                         window.swaggerUIRedirectOauth2 = {{
                             auth: 'OAuth2',
                             redirectUrl: window.location.origin + '/docs/oauth2-redirect',
                             callback: function(data) {{
-                                console.log('✅ OAuth2 popup callback received:', data);
                                 if (data.token && data.token.access_token) {{
-                                    console.log('✅ Applying token from popup callback...');
                                     try {{
                                         window.ui.preauthorizeApiKey('BearerAuth', data.token.access_token);
-                                        console.log('✅ Bearer token applied successfully from popup!');
                                     }} catch (e) {{
-                                        console.log('⚠️ Error applying token from popup:', e);
+                                        console.log('Error applying token from popup:', e);
                                     }}
                                 }}
                             }}
                         }};
-                        
-                        // Open popup with specific features
+
                         const popup = originalWindowOpen.call(
-                            this, 
-                            url, 
+                            this,
+                            url,
                             'oauth2_auth_popup',
-                            'width=600,height=700,scrollbars=yes,resizable=yes,status=yes,location=yes,toolbar=no,menubar=no,left=' + 
+                            'width=600,height=700,scrollbars=yes,resizable=yes,status=yes,location=yes,toolbar=no,menubar=no,left=' +
                             Math.round((screen.width - 600) / 2) + ',top=' + Math.round((screen.height - 700) / 2)
                         );
-                        
-                        // Store popup reference globally for direct access
+
                         window.oauth2Popup = popup;
-                        
-                        // Monitor popup closure and token retrieval
+
                         const checkPopup = setInterval(() => {{
                             try {{
                                 if (popup.closed) {{
                                     clearInterval(checkPopup);
-                                    console.log('🔍 OAuth2 popup closed, checking for tokens...');
-                                    
-                                    // Check for token in localStorage with extended monitoring for new user flows
+
                                     setTimeout(() => {{
                                         const token = localStorage.getItem('swagger_oauth_token');
                                         if (token) {{
-                                            console.log('✅ Token found from popup, applying to Bearer Auth...');
                                             try {{
                                                 window.ui.preauthorizeApiKey('BearerAuth', token);
-                                                console.log('✅ Bearer token applied successfully!');
                                             }} catch (e) {{
-                                                console.log('⚠️ Error applying token:', e);
+                                                console.log('Error applying token:', e);
                                             }}
                                             localStorage.removeItem('swagger_oauth_token');
                                             localStorage.removeItem('swagger_oauth_token_timestamp');
                                         }} else {{
-                                            // Extended monitoring for new user registration flows
-                                            console.log('🔍 No token found immediately - starting extended monitoring for new user flows...');
                                             let extendedChecks = 0;
-                                            const maxExtendedChecks = 10; // Check for 10 more seconds
-                                            
+                                            const maxExtendedChecks = 10;
+
                                             const extendedMonitor = setInterval(() => {{
                                                 extendedChecks++;
                                                 const delayedToken = localStorage.getItem('swagger_oauth_token');
-                                                
+
                                                 if (delayedToken) {{
-                                                    console.log('✅ Token found during extended monitoring!');
                                                     clearInterval(extendedMonitor);
-                                                    
-                                                    // Use the same multi-method approach as page load
+
                                                     try {{
-                                                        console.log('🔍 Attempting to authorize with delayed token...');
-                                                        
                                                         if (window.ui) {{
-                                                            // Method 1: Use preauthorizeApiKey for BearerAuth
                                                             try {{
                                                                 window.ui.preauthorizeApiKey('BearerAuth', delayedToken);
-                                                                console.log('✅ BearerAuth preauthorized from extended monitoring!');
                                                             }} catch (e) {{
-                                                                console.log('⚠️ preauthorizeApiKey failed:', e);
+                                                                console.log('preauthorizeApiKey failed:', e);
                                                             }}
-                                                            
-                                                            // Method 2: Try the direct authActions approach
+
                                                             if (window.ui.authActions) {{
                                                                 try {{
                                                                     window.ui.authActions.authorize({{
                                                                         'BearerAuth': delayedToken
                                                                     }});
-                                                                    console.log('✅ BearerAuth via authActions from extended monitoring!');
                                                                 }} catch (e) {{
-                                                                    console.log('⚠️ authActions.authorize failed:', e);
+                                                                    console.log('authActions.authorize failed:', e);
                                                                 }}
                                                             }}
-                                                            
-                                                            // Method 3: Safari-specific handling
+
                                                             if (navigator.userAgent.includes('Safari') && !navigator.userAgent.includes('Chrome')) {{
                                                                 setTimeout(() => {{
                                                                     try {{
@@ -1227,21 +1195,17 @@ def custom_swagger_ui_html():
                                                                                 value: delayedToken
                                                                             }}
                                                                         }});
-                                                                        console.log('✅ Safari-specific auth from extended monitoring!');
-                                                                    }} catch (e) {{
-                                                                        console.log('⚠️ Safari auth failed:', e);
-                                                                    }}
+                                                                    }} catch (e) {{ }}
                                                                 }}, 500);
                                                             }}
                                                         }}
                                                     }} catch (error) {{
-                                                        console.error('❌ Error applying delayed token:', error);
+                                                        console.error('Error applying delayed token:', error);
                                                     }}
-                                                    
+
                                                     localStorage.removeItem('swagger_oauth_token');
                                                     localStorage.removeItem('swagger_oauth_token_timestamp');
                                                 }} else if (extendedChecks >= maxExtendedChecks) {{
-                                                    console.log('⚠️ Extended monitoring timeout - no token found');
                                                     clearInterval(extendedMonitor);
                                                 }}
                                             }}, 1000);
@@ -1249,52 +1213,38 @@ def custom_swagger_ui_html():
                                     }}, 500);
                                     return;
                                 }}
-                                
-                                // Check for successful token every second
+
                                 const token = localStorage.getItem('swagger_oauth_token');
                                 if (token) {{
-                                    console.log('✅ Token detected! Closing popup and applying token...');
                                     clearInterval(checkPopup);
-                                    
-                                    // Store token for Safari handling before cleanup
+
                                     const tokenForSafari = token;
-                                    
-                                    // Apply token immediately
+
                                     try {{
                                         window.ui.preauthorizeApiKey('BearerAuth', token);
-                                        console.log('✅ Bearer token applied successfully!');
                                     }} catch (e) {{
-                                        console.log('⚠️ Error applying token:', e);
+                                        console.log('Error applying token:', e);
                                     }}
-                                    
-                                    // Close popup explicitly
+
                                     if (!popup.closed) {{
                                         popup.close();
-                                        console.log('✅ Popup closed successfully');
                                     }}
-                                    
-                                    // Clean up
+
                                     localStorage.removeItem('swagger_oauth_token');
                                     localStorage.removeItem('swagger_oauth_token_timestamp');
                                     delete window.oauth2Popup;
-                                    
-                                    // Safari-specific: Force a UI refresh to ensure token visibility
+
                                     if (navigator.userAgent.includes('Safari') && !navigator.userAgent.includes('Chrome')) {{
-                                        console.log('🍎 Safari detected - forcing UI refresh...');
                                         setTimeout(() => {{
                                             try {{
-                                                // Try multiple Safari-friendly approaches
                                                 if (window.ui && window.ui.authActions) {{
                                                     window.ui.authActions.authorize({{
                                                         'BearerAuth': {{
                                                             value: tokenForSafari
                                                         }}
                                                     }});
-                                                    console.log('✅ Safari UI refresh attempted');
                                                 }}
-                                            }} catch (e) {{
-                                                console.log('⚠️ Safari refresh attempt failed:', e);
-                                            }}
+                                            }} catch (e) {{ }}
                                         }}, 500);
                                     }}
                                 }}
@@ -1302,59 +1252,42 @@ def custom_swagger_ui_html():
                                 // Cross-origin error - popup still open, continue monitoring
                             }}
                         }}, 1000);
-                        
+
                         return popup;
                     }}
-                    
-                    // For all other URLs, use original window.open
+
                     return originalWindowOpen.call(this, url, target, features);
                 }};
-                
-                console.log('✅ OAuth2 popup override installed');
-            }}, 2000); // Wait for Swagger UI to fully initialize
-            
+            }}, 2000);
+
             // Check for OAuth token in localStorage (from new tab flow)
             setTimeout(() => {{
-                console.log('🔍 Checking for stored OAuth token...');
                 const storedToken = localStorage.getItem('swagger_oauth_token');
                 const tokenTimestamp = localStorage.getItem('swagger_oauth_token_timestamp');
-                
-                // Check token availability (reduced logging for production)
-                console.log('🔍 Checking OAuth token status...');
-                
+
                 if (storedToken && tokenTimestamp) {{
                     const tokenAge = Date.now() - parseInt(tokenTimestamp);
-                    const maxAge = 5 * 60 * 1000; // 5 minutes
-                    
+                    const maxAge = 5 * 60 * 1000;
+
                     if (tokenAge < maxAge) {{
-                        console.log('✅ Found stored OAuth token, applying automatically...');
-                        
-                        // Apply OAuth2 token to Swagger UI
                         try {{
-                            console.log('🔍 Attempting to authorize with stored token...');
-                            
                             if (window.ui) {{
-                                // Method 1: Use preauthorizeApiKey for BearerAuth (this usually works)
                                 try {{
                                     window.ui.preauthorizeApiKey('BearerAuth', storedToken);
-                                    console.log('✅ BearerAuth preauthorized!');
                                 }} catch (e) {{
-                                    console.log('⚠️ preauthorizeApiKey failed:', e);
+                                    console.log('preauthorizeApiKey failed:', e);
                                 }}
-                                
-                                // Method 2: Try the direct authActions approach
+
                                 if (window.ui.authActions) {{
                                     try {{
                                         window.ui.authActions.authorize({{
                                             'BearerAuth': storedToken
                                         }});
-                                        console.log('✅ BearerAuth via authActions!');
                                     }} catch (e) {{
-                                        console.log('⚠️ authActions.authorize failed:', e);
+                                        console.log('authActions.authorize failed:', e);
                                     }}
                                 }}
-                                
-                                // Method 3: Try to set OAuth2 authorization
+
                                 if (window.ui.authActions) {{
                                     try {{
                                         window.ui.authActions.authorize({{
@@ -1365,53 +1298,61 @@ def custom_swagger_ui_html():
                                                 }}
                                             }}
                                         }});
-                                        console.log('✅ OAuth2 via authActions!');
                                     }} catch (e) {{
-                                        console.log('⚠️ OAuth2 authActions failed:', e);
+                                        console.log('OAuth2 authActions failed:', e);
                                     }}
                                 }}
-                                
-                                // Method 4: Direct state manipulation (last resort)
+
                                 setTimeout(() => {{
                                     try {{
-                                        const state = window.ui.getState();
-                                        console.log('🔍 Current auth state:', state.getIn(['auth', 'authorized']));
-                                        
-                                        // Force update the auth state
                                         window.ui.authActions.authorizeWithPersistOption({{
                                             'BearerAuth': {{
                                                 value: storedToken
                                             }}
                                         }});
-                                        console.log('✅ State manipulation attempted!');
                                     }} catch (e) {{
-                                        console.log('⚠️ State manipulation failed:', e);
+                                        console.log('State manipulation failed:', e);
                                     }}
                                 }}, 1000);
-                                
-                            }} else {{
-                                console.error('❌ Swagger UI not available');
-                                alert('Authentication successful! Token: ' + storedToken.substring(0, 50) + '... Please manually paste in Bearer Auth field.');
                             }}
                         }} catch (error) {{
-                            console.error('❌ Error applying token:', error);
-                            alert('Authentication successful! Token: ' + storedToken.substring(0, 50) + '... Please manually paste in Bearer Auth field.');
+                            console.error('Error applying token:', error);
                         }}
-                        
-                        // Clean up localStorage
+
                         localStorage.removeItem('swagger_oauth_token');
                         localStorage.removeItem('swagger_oauth_token_timestamp');
                     }} else {{
-                        console.log('⚠️ Stored token expired, removing...');
                         localStorage.removeItem('swagger_oauth_token');
                         localStorage.removeItem('swagger_oauth_token_timestamp');
                     }}
                 }}
-            }}, 1000); // Wait for Swagger UI to fully initialize
+            }}, 1000);
         </script>
     </body>
     </html>
-    """)
+    """
+
+
+# Simple working docs endpoint (before route class restoration)
+@app.get("/docs", include_in_schema=False)
+def custom_swagger_ui_html():
+    """Custom Swagger UI docs"""
+    return HTMLResponse(content=_build_swagger_html(
+        title="Morpheus API Gateway - API Documentation",
+        openapi_url="/api/v1/openapi.json",
+        app_name="Morpheus API Gateway",
+        oauth_state="swagger-ui-oauth2",
+    ))
+
+@app.get("/admin/docs", include_in_schema=False)
+def admin_swagger_ui_html():
+    """Swagger UI for admin-only endpoints (requires X-Admin-Secret header)."""
+    return HTMLResponse(content=_build_swagger_html(
+        title="Morpheus API Gateway - Admin Documentation",
+        openapi_url="/admin/api/v1/openapi.json",
+        app_name="Morpheus API Gateway - Admin",
+        oauth_state="swagger-ui-admin-oauth2",
+    ))
 
 @app.get("/exchange-token", include_in_schema=False)
 async def exchange_oauth_token(request: Request, code: str, state: str = None):
@@ -1486,9 +1427,15 @@ async def check_db_connection(engine: AsyncEngine):
         return result.scalar() == 1
 
 # Custom OpenAPI schema generator
-def custom_openapi():
-    if app.openapi_schema:
-        return app.openapi_schema
+_full_openapi_cache = None
+_admin_openapi_cache = None
+ADMIN_TAGS = {"Billing Admin"}
+
+def _build_full_openapi():
+    """Build the complete OpenAPI schema with all routes (cached)."""
+    global _full_openapi_cache
+    if _full_openapi_cache is not None:
+        return _full_openapi_cache
 
     openapi_schema = get_openapi(
         title=app.title,
@@ -1572,19 +1519,116 @@ def custom_openapi():
                         {"APIKeyAuth": []}
                     ]
 
-    app.openapi_schema = openapi_schema
+    _full_openapi_cache = openapi_schema
+    return _full_openapi_cache
+
+
+def custom_openapi():
+    """Public OpenAPI schema — admin-tagged routes excluded."""
+    if app.openapi_schema:
+        return app.openapi_schema
+
+    schema = copy.deepcopy(_build_full_openapi())
+
+    paths_to_remove = []
+    for path_key, path_item in schema.get("paths", {}).items():
+        for method, operation in path_item.items():
+            if method in ("get", "post", "put", "delete", "patch"):
+                if set(operation.get("tags", [])) & ADMIN_TAGS:
+                    paths_to_remove.append(path_key)
+                    break
+    for path_key in paths_to_remove:
+        del schema["paths"][path_key]
+
+    app.openapi_schema = schema
     return app.openapi_schema
 
 # Set custom OpenAPI schema generator
 app.openapi = custom_openapi
 
-# Create custom OpenAPI endpoint to ensure our OAuth2 schema is used
 @app.get(f"{settings.API_V1_STR}/openapi.json", include_in_schema=False)
 async def get_custom_openapi():
-    """
-    Custom OpenAPI endpoint that ensures our OAuth2 security scheme is included
-    """
-    return custom_openapi() 
+    """Custom OpenAPI endpoint that ensures our OAuth2 security scheme is included."""
+    return custom_openapi()
+
+
+def admin_openapi():
+    """Admin-only OpenAPI schema — only admin-tagged routes (cached)."""
+    global _admin_openapi_cache
+    if _admin_openapi_cache is not None:
+        return _admin_openapi_cache
+
+    schema = copy.deepcopy(_build_full_openapi())
+
+    schema["info"]["title"] = f"{schema['info']['title']} - Admin"
+    schema["info"]["description"] = "Admin-only endpoints requiring X-Admin-Secret header."
+
+    # Keep only admin-tagged paths
+    filtered_paths = {}
+    for path_key, path_item in schema.get("paths", {}).items():
+        for method, operation in list(path_item.items()):
+            if method not in ("get", "post", "put", "delete", "patch"):
+                continue
+            if set(operation.get("tags", [])) & ADMIN_TAGS:
+                filtered_paths[path_key] = path_item
+                break
+
+    schema["paths"] = filtered_paths
+
+    # Admin endpoints require user identity (OAuth2 or Bearer) + X-Admin-Secret
+    schema["components"]["securitySchemes"] = {
+        "OAuth2": {
+            "type": "oauth2",
+            "flows": {
+                "authorizationCode": {
+                    "authorizationUrl": f"https://{settings.COGNITO_DOMAIN}/oauth2/authorize",
+                    "tokenUrl": f"https://{settings.COGNITO_DOMAIN}/oauth2/token",
+                    "scopes": {
+                        "openid": "OpenID Connect authentication",
+                        "email": "Access to email address",
+                        "profile": "Access to profile information",
+                    },
+                },
+            },
+            "description": "OAuth2 authentication via secure identity provider",
+        },
+        "BearerAuth": {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+            "description": "JWT Bearer token (user identity required for admin endpoints)",
+        },
+        "AdminSecret": {
+            "type": "apiKey",
+            "in": "header",
+            "name": "X-Admin-Secret",
+            "description": "Admin secret for protected billing endpoints",
+        },
+    }
+
+    for path_item in schema["paths"].values():
+        for method, operation in path_item.items():
+            if method in ("get", "post", "put", "delete", "patch"):
+                # Either OAuth2 or Bearer can satisfy user identity, both require AdminSecret
+                operation["security"] = [
+                    {"OAuth2": ["openid", "email", "profile"], "AdminSecret": []},
+                    {"BearerAuth": [], "AdminSecret": []},
+                ]
+                # Remove the x_admin_secret parameter auto-generated by FastAPI
+                # from the Header() dependency — it's already covered by the
+                # AdminSecret security scheme above.
+                if "parameters" in operation:
+                    operation["parameters"] = [
+                        p for p in operation["parameters"]
+                        if p.get("name", "").lower() != "x-admin-secret"
+                    ]
+
+    _admin_openapi_cache = schema
+    return _admin_openapi_cache
+
+@app.get("/admin/api/v1/openapi.json", include_in_schema=False)
+async def get_admin_openapi():
+    return admin_openapi()
 
 # API Documentation landing page
 @app.get("/api-docs", include_in_schema=False)
@@ -1616,6 +1660,7 @@ async def api_docs_landing(request: Request):
             
             <a href="/docs" class="api-link">📋 Interactive API Docs (Swagger UI)</a>
             <a href="/redoc" class="api-link">📖 API Documentation (ReDoc)</a>
+            <a href="/admin/docs" class="api-link" style="background: #dc3545;">🔒 Admin API Docs</a>
             
             <div class="description">
                 <h3>🔐 Authentication Methods</h3>

--- a/src/schemas/billing.py
+++ b/src/schemas/billing.py
@@ -343,3 +343,24 @@ class RefundResponse(BaseModel):
     amount_refunded: DecimalStr
     success: bool
     error: Optional[str] = None
+
+
+# === Rate Limit Multiplier (Admin) ===
+
+class RateLimitMultiplierRequest(BaseModel):
+    """Request for POST /billing/rate-limit/multiplier."""
+    cognito_user_id: str = Field(..., description="Target user's Cognito ID (UUID)")
+    multiplier: float = Field(
+        ...,
+        gt=0,
+        le=100,
+        description="Rate limit multiplier (1.0 = default, 2.0 = double limits, 0.5 = half limits)",
+    )
+
+
+class RateLimitMultiplierResponse(BaseModel):
+    """Response for rate limit multiplier operations."""
+    cognito_user_id: str
+    user_id: int
+    multiplier: float
+    message: str

--- a/src/services/rate_limiting/rate_limit_service.py
+++ b/src/services/rate_limiting/rate_limit_service.py
@@ -14,6 +14,7 @@ from src.core.config import settings
 from src.core.logging_config import get_core_logger
 
 from .types import (
+    RateLimitConfig,
     RateLimitResult,
     RateLimitStatus,
     RateLimitHeaders,
@@ -85,6 +86,7 @@ class RateLimitService:
         model: Optional[str] = None,
         estimated_tokens: int = 0,
         request_id: Optional[str] = None,
+        multiplier: float = 1.0,
     ) -> RateLimitResult:
         """
         Check if a request is within rate limits and increment RPM only.
@@ -98,6 +100,7 @@ class RateLimitService:
             model: The model being requested
             estimated_tokens: Estimated input tokens for TPM check (not incremented)
             request_id: Unique identifier for this request
+            multiplier: Per-user scaling factor for RPM/TPM limits (default 1.0)
             
         Returns:
             RateLimitResult with the check result
@@ -112,7 +115,17 @@ class RateLimitService:
             await self.initialize()
         
         # Get rate limit config for this model
-        config, model_group = self._rules.get_config_for_model(model)
+        base_config, model_group = self._rules.get_config_for_model(model)
+        
+        # Apply per-user multiplier to scale limits
+        if multiplier != 1.0:
+            config = RateLimitConfig(
+                rpm=max(1, int(base_config.rpm * multiplier)),
+                tpm=max(1, int(base_config.tpm * multiplier)) if base_config.tpm > 0 else 0,
+                window_seconds=base_config.window_seconds,
+            )
+        else:
+            config = base_config
         
         # Calculate window boundary and reset time
         # Window is aligned to fixed intervals (e.g., each minute boundary)
@@ -147,6 +160,7 @@ class RateLimitService:
                     rpm_limit=rpm_limit,
                     retry_after=retry_after,
                     reset_at=reset_at,
+                    multiplier=multiplier,
                     event_type="rate_limit_exceeded_rpm",
                 )
                 
@@ -181,6 +195,7 @@ class RateLimitService:
                         estimated_tokens=estimated_tokens,
                         retry_after=retry_after,
                         reset_at=reset_at,
+                        multiplier=multiplier,
                         event_type="rate_limit_exceeded_tpm",
                     )
                     


### PR DESCRIPTION
## TL;DR

Two features shipping to production: **(1)** Admin billing endpoints are now isolated onto a dedicated Swagger page at `/admin/docs`, removing them from the public API surface; **(2)** a new per-user rate-limit multiplier lets admins scale RPM/TPM limits up or down for individual users without redeploying.

---

## What Changed

### 1. Dedicated Admin Swagger Page (`/admin/docs`)
- **New file:** `src/api/v1/billing/admin.py` — all admin-protected billing endpoints (`staking/settings`, `staking/refresh`, `credits/adjust`, `balance/reconcile`, and the new rate-limit multiplier endpoints) have been extracted out of the public billing router into a standalone admin router.
- **Public `/docs`** no longer exposes any admin-tagged endpoints. The OpenAPI schema is split at build time: public routes serve from `/api/v1/openapi.json`, admin routes serve from `/admin/api/v1/openapi.json`.
- The Swagger HTML builder was refactored into a shared `_build_swagger_html()` helper to eliminate duplication and strip noisy `console.log` debug statements from the OAuth2 flow.
- A red "Admin API Docs" link was added to the `/api-docs` landing page.

### 2. Per-User Rate Limit Multiplier
- **DB migration:** `add_rate_limit_multiplier_to_users` adds a `rate_limit_multiplier FLOAT NOT NULL DEFAULT 1.0` column to the `users` table.
- **Model + cache:** `User.rate_limit_multiplier` is now persisted, included in the Redis user cache, and deserialized correctly in all auth dependency paths (`get_current_user`, `get_api_key_auth`, `_build_auth_from_cache`, `_build_auth_from_db`).
- **Rate limit service:** `check_rate_limit()` accepts a `multiplier` parameter. Limits are scaled at check time — `2.0` doubles RPM/TPM, `0.5` halves them, with a floor of 1 to prevent zero-limit lockout.
- **Admin endpoints:** `POST /billing/rate-limit/multiplier` (set) and `GET /billing/rate-limit/multiplier/{cognito_user_id}` (get), both behind `X-Admin-Secret`.
- **Schemas:** `RateLimitMultiplierRequest` / `RateLimitMultiplierResponse` added to `src/schemas/billing.py`.

### 3. Cleanup
- Removed ~230 lines of admin endpoint code from the public `billing/index.py` (moved, not deleted).
- Removed unused imports (`secrets`, `Header`, `staking_service`, `user_crud`, etc.) from the public billing module.

## Files Changed (11)
| File | Change |
|------|--------|
| `alembic/versions/2026_03_10_0001_add_rate_limit_multiplier_to_users.py` | **New** — migration |
| `src/api/v1/__init__.py` | Register `billing_admin` router |
| `src/api/v1/billing/admin.py` | **New** — all admin billing endpoints |
| `src/api/v1/billing/index.py` | Remove admin endpoints (moved to `admin.py`) |
| `src/api/v1/chat/index.py` | Minor import |
| `src/api/v1/embeddings/index.py` | Minor import |
| `src/db/models/user.py` | Add `rate_limit_multiplier` column |
| `src/dependencies.py` | Include `rate_limit_multiplier` in cache + deserialization |
| `src/main.py` | Split OpenAPI schemas, add `/admin/docs`, refactor Swagger HTML |
| `src/schemas/billing.py` | Add rate-limit multiplier request/response models |
| `src/services/rate_limiting/rate_limit_service.py` | Apply per-user multiplier to RPM/TPM checks |

## Risk Assessment
- **Low risk** — admin endpoints are a code reorganization (same logic, new file), and the rate-limit multiplier defaults to `1.0` (no behavioral change for existing users).
- Migration is additive (`ADD COLUMN ... DEFAULT 1.0`) — no data loss path.
- Public API contract is unchanged; only admin surface area is affected.

## Test Plan
- [x] Verified on TEST environment
- [x] Confirm `/docs` no longer shows admin-tagged endpoints
- [x] Confirm `/admin/docs` renders and shows only admin endpoints
- [x] Confirm `POST /billing/rate-limit/multiplier` sets value and invalidates cache
- [x] Confirm rate limits scale correctly for a user with multiplier ≠ 1.0
- [ ] Confirm migration runs cleanly against production schema

Made with [Cursor](https://cursor.com)