### PR TITLE
Promote test to main: gateway failover, session recovery docs, and model pricing

### DIFF
--- a/docs/failover.md
+++ b/docs/failover.md
@@ -1,0 +1,103 @@
+# Gateway-Owned Session Recovery
+
+Two separate mechanisms, both bounded to exactly one retry per request:
+
+## 1. Provider failover (different provider)
+
+Applies only when the provider becomes **unavailable during a session**:
+connection refused, dial/read timeouts, provider death, proxy 5xx,
+gateway↔proxy transport failures.
+
+1. The `routed_sessions` row is marked `FAILED` (it will never be routed to
+   again) and closed on the proxy-router in the background (best-effort;
+   close works against a dead provider via the self-signed user report, and
+   the proxy-router's expiry handler is the backstop).
+2. The model must have **more than one** rated bid
+   (`GET blockchain/models/{id}/bids/rated`), otherwise the original error
+   is surfaced with no retry.
+3. A fresh session is opened by model: the proxy-router tries bids
+   best-first with a per-bid provider handshake, so the dead provider is
+   skipped automatically and the session lands on the surviving provider.
+4. The prompt is retried once. If the retry fails, a clean error (real HTTP
+   status) is returned.
+
+## 2. Expired-session renewal (same model, healthy provider)
+
+Applies when the proxy reports `session expired` (the session TTL'd out;
+the provider is fine). This is NOT failover:
+
+1. The old `routed_sessions` row is marked `EXPIRED` (its DB expires_at may
+   still be in the future) and closed in the background.
+2. A new session is routed for the same model — no alternate-bid
+   requirement; works on single-bid models. Bid ranking is deterministic,
+   so this typically lands on the same provider.
+3. The prompt is retried once.
+
+No recovery for: `session not found`, user/4xx errors, AI-engine errors,
+TEE attestation failures, client-cancelled requests.
+
+Kill switch: `CHAT_FAILOVER_ENABLED=false` (env) disables the failover
+mechanism (renewal is independent of the flag).
+
+## Streaming
+
+Recovery happens only **before the first provider byte reaches the client**.
+Once tokens are flowing, a failure terminates the stream with an SSE error
+chunk (`data: {"error": ...}`) and the billing hold is voided. We deliberately
+do not restart half-delivered answers.
+
+Known limitation: if a provider dies mid-stream after sending data, the
+proxy-router currently ends the stream as if successful (HTTP 200, truncated,
+no error marker); the gateway cannot distinguish this from normal completion.
+
+## Billing
+
+Exactly one usage hold per request (created before session resolution);
+recovery retries run inside the request handler against the same hold.
+Finalize happens only for a 200 outcome; every failure path voids. Session
+accounting: `index.py` (non-streaming) / `_stream_cleanup` (streaming)
+releases the original session, the retry path releases the new session, and
+`FAILED`/`EXPIRED` sessions are excluded from routing.
+
+## Why not proxy-router failover=true
+
+The c-node's failover closes/reopens sessions underneath the client and the
+new sessionID diverges from `routed_sessions` (it only signals the change via
+SSE control chunks, which also corrupt non-streaming JSON responses). The flag
+is additionally non-functional in the current proxy-router build. The gateway
+therefore always opens sessions with `failover: false`.
+
+## Manual acceptance test
+
+Setup: a model with bids from two providers (provider1, provider2); local
+proxy-router as consumer node; gateway pointed at it via `PROXY_ROUTER_URL`.
+
+Provider failover:
+1. Send a prompt → verify it succeeds; note `session_id` S1 in
+   `routed_sessions` (state OPEN) and which provider serves it.
+2. Kill provider1's node (`docker kill` / stop the process).
+3. Send the next prompt with the same API key:
+   - it must succeed transparently (one retry, served by provider2),
+   - `routed_sessions` shows S1 `state=FAILED` with `error_reason` starting
+     with "recovery:", and a new row S2 `state=OPEN`,
+   - logs show `failover_triggered` → `failover_new_session` →
+     `recovery_retry_success` (or `stream_failover_retry_start` for
+     streaming),
+   - billing ledger has exactly one entry for the request (no double charge,
+     status posted, tokens from the successful attempt).
+4. Kill provider2 as well, send a prompt → clean 5xx error (`retry_failed` or
+   original error), hold voided, no infinite retry.
+
+Expired-session renewal:
+5. Use a model with a SINGLE bid and a short session duration
+   (`SESSION_DEFAULT_DURATION_SECONDS`); open a session, wait past its
+   on-chain expiry, send a prompt:
+   - it must succeed transparently (renewal retry),
+   - old row `state=EXPIRED`, new row OPEN,
+   - logs show `session_expired_detected` → `session_retry_start` →
+     `recovery_retry_success`.
+
+Kill switch:
+6. Set `CHAT_FAILOVER_ENABLED=false`, kill provider1, send a prompt → error
+   surfaces immediately with no failover retry (expired-session renewal
+   still works).

--- a/models/prod_model_price.json
+++ b/models/prod_model_price.json
@@ -78,6 +78,20 @@
 
     "venice-uncensored": { "input": "0.20", "output": "0.90" },
 
+    "claude-fable-5": { "input": "12.00", "output": "60.00" },
+    "claude-fable-5:web": { "input": "12.00", "output": "60.00" },
+    "claude-opus-4.8": { "input": "6.00", "output": "30.00" },
+    "claude-opus-4.8:web": { "input": "6.00", "output": "30.00" },
+    "clause-opus-4.8:web": { "input": "6.00", "output": "30.00" },
+    "gemini-3.1-pro-preview": { "input": "2.50", "output": "15.00" },
+    "gemini-3.1-pro-preview:web": { "input": "2.50", "output": "15.00" },
+    "gpt-5.5-pro": { "input": "38.00", "output": "250.00" },
+    "gpt-5.5-pro:web": { "input": "38.00", "output": "250.00" },
+    "gpt-5.5": { "input": "6.50", "output": "38.00" },
+    "gpt-5.5:web": { "input": "6.50", "output": "38.00" },
+    "grok-4.20": { "input": "1.40", "output": "2.80" },
+    "grok-4.20:web": { "input": "1.40", "output": "2.80" },
+
     "text-embedding-bge-m3": { "input": "0.10", "output": "0.50" }
   }
 }

--- a/models/test_model_price.json
+++ b/models/test_model_price.json
@@ -31,6 +31,20 @@
 
     "venice-uncensored": { "input": "0.20", "output": "0.90" },
 
+    "claude-fable-5": { "input": "12.00", "output": "60.00" },
+    "claude-fable-5:web": { "input": "12.00", "output": "60.00" },
+    "claude-opus-4.8": { "input": "6.00", "output": "30.00" },
+    "claude-opus-4.8:web": { "input": "6.00", "output": "30.00" },
+    "clause-opus-4.8:web": { "input": "6.00", "output": "30.00" },
+    "gemini-3.1-pro-preview": { "input": "2.50", "output": "15.00" },
+    "gemini-3.1-pro-preview:web": { "input": "2.50", "output": "15.00" },
+    "gpt-5.5-pro": { "input": "38.00", "output": "250.00" },
+    "gpt-5.5-pro:web": { "input": "38.00", "output": "250.00" },
+    "gpt-5.5": { "input": "6.50", "output": "38.00" },
+    "gpt-5.5:web": { "input": "6.50", "output": "38.00" },
+    "grok-4.20": { "input": "1.40", "output": "2.80" },
+    "grok-4.20:web": { "input": "1.40", "output": "2.80" },
+
     "text-embedding-bge-m3": { "input": "0.10", "output": "0.50" }
   }
 }

--- a/src/api/v1/chat/chat_failover.py
+++ b/src/api/v1/chat/chat_failover.py
@@ -1,0 +1,79 @@
+"""
+Gateway-owned provider failover.
+
+Failover = open a new session with a DIFFERENT provider. It applies ONLY
+when the provider becomes unavailable during a session (conn refused /
+timeouts / 5xx / provider death). On such a failure the gateway marks the
+dead RoutedSession FAILED, opens a fresh session for the same model (the
+proxy-router's per-bid handshake skips the dead provider), and the caller
+retries the prompt exactly once.
+
+Session expiry ("session expired") is a SEPARATE mechanism — the renewal
+flow in the chat handlers — and is explicitly EXCLUDED here.
+
+Proxy-side failover must stay OFF (openSession failover=False): if the
+c-node closed/reopened sessions itself, its sessionID would diverge from
+our routed_sessions DB.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from ....core.config import settings
+from ....db.database import get_db
+from ....services import proxy_router_service
+from ....services.session_routing_service import session_routing_service
+
+# Failures that must NEVER trigger failover:
+# - session-state errors: handled by the separate renewal mechanism
+# - TEE failures (NON_RETRIABLE_ERROR_PATTERNS): permanent
+# - queue cancellation: the client went away
+NON_FAILOVER_ERROR_PATTERNS = [
+    "session expired",
+    "session not found",
+    *proxy_router_service.NON_RETRIABLE_ERROR_PATTERNS,
+    "request cancelled while waiting in queue",
+]
+
+# Provider-unavailability signatures from the proxy-router (see
+# proxy-router/internal/proxyapi/proxy_sender.go sentinel errors).
+# Used when no status code is available on the exception.
+PROVIDER_FAILURE_PATTERNS = [
+    "failed to connect to provider",
+    "failed to write to provider",
+    "provider request failed",
+    "provider closed connection",
+    "provider not found",
+    "read timed out",
+    # chatCompletionsStream wraps transport errors with status=None and
+    # error_type="unknown" (proxy_router_service.py:786-792). Mid-stream
+    # wraps match too, but those are excluded by the chunk_count==0 gate.
+    "failed to create chat completions stream",
+]
+
+
+def is_failover_eligible(exc: proxy_router_service.ProxyRouterServiceError) -> bool:
+    """Decide whether a proxy error means the provider is unavailable.
+
+    Eligible: provider unreachable / 5xx / timeouts / transport failures.
+    Not eligible: session expired/not found (separate renewal mechanism),
+    user/4xx errors, TEE failures, client-cancelled requests.
+    """
+    if not settings.CHAT_FAILOVER_ENABLED:
+        return False
+
+    message = str(exc).lower()
+    if any(p in message for p in NON_FAILOVER_ERROR_PATTERNS):
+        return False
+
+    status = exc.status_code
+    if status is not None and 400 <= status < 500:
+        return False
+    if status is not None and status >= 500:
+        return True
+    # No status: gateway<->proxy transport failure, or wrapped errors.
+    if exc.error_type == "network_error":
+        return True
+    return any(p in message for p in PROVIDER_FAILURE_PATTERNS)

--- a/src/api/v1/chat/chat_failover.py
+++ b/src/api/v1/chat/chat_failover.py
@@ -79,6 +79,18 @@ def is_failover_eligible(exc: proxy_router_service.ProxyRouterServiceError) -> b
     return any(p in message for p in PROVIDER_FAILURE_PATTERNS)
 
 
+async def _release_new_session_quiet(session_id: str, logger) -> None:
+    """Release a just-assigned session's request slot, logging failures."""
+    try:
+        async with get_db() as db:
+            await session_routing_service.release_session(db, session_id)
+    except Exception as release_err:
+        logger.warning("Failed to release abandoned failover session",
+                       session_id=session_id,
+                       error=str(release_err),
+                       event_type="session_release_error")
+
+
 async def _has_alternate_bids(model_id: str, logger) -> bool:
     """True if the model has more than one rated bid.
 
@@ -188,11 +200,11 @@ async def attempt_failover(
         await asyncio.sleep(1.0)
     except asyncio.CancelledError:
         # Client disconnected before the retry took ownership — release the
-        # just-assigned session so its request slot doesn't leak.
+        # just-assigned session so its request slot doesn't leak. Shielded
+        # so a second cancellation can't abandon the release mid-flight.
         try:
-            async with get_db() as db:
-                await session_routing_service.release_session(db, new_session_id)
-        except Exception:
+            await asyncio.shield(_release_new_session_quiet(new_session_id, failover_logger))
+        except asyncio.CancelledError:
             pass
         raise
     return new_session_id

--- a/src/api/v1/chat/chat_failover.py
+++ b/src/api/v1/chat/chat_failover.py
@@ -142,10 +142,16 @@ async def attempt_failover(
 
     # 1. Unpin the dead session so no request routes to it again.
     #    Do this even if we end up unable to retry.
-    async with get_db() as db:
-        await session_routing_service.invalidate_session(
-            db, original_session_id, failure_reason[:300]
-        )
+    try:
+        async with get_db() as db:
+            await session_routing_service.invalidate_session(
+                db, original_session_id, failure_reason[:300]
+            )
+    except Exception as e:
+        failover_logger.error("Failover invalidation failed",
+                              error=str(e),
+                              event_type="failover_invalidate_failed")
+        return None
 
     # 2. Only retry when the model has >1 bid (spec guardrail).
     if model_id and not await _has_alternate_bids(model_id, failover_logger):

--- a/src/api/v1/chat/chat_failover.py
+++ b/src/api/v1/chat/chat_failover.py
@@ -184,5 +184,15 @@ async def attempt_failover(
                          event_type="failover_new_session")
     # Brief delay so the freshly opened session is registered everywhere
     # (same as the renewal path).
-    await asyncio.sleep(1.0)
+    try:
+        await asyncio.sleep(1.0)
+    except asyncio.CancelledError:
+        # Client disconnected before the retry took ownership — release the
+        # just-assigned session so its request slot doesn't leak.
+        try:
+            async with get_db() as db:
+                await session_routing_service.release_session(db, new_session_id)
+        except Exception:
+            pass
+        raise
     return new_session_id

--- a/src/api/v1/chat/chat_failover.py
+++ b/src/api/v1/chat/chat_failover.py
@@ -77,3 +77,106 @@ def is_failover_eligible(exc: proxy_router_service.ProxyRouterServiceError) -> b
     if exc.error_type == "network_error":
         return True
     return any(p in message for p in PROVIDER_FAILURE_PATTERNS)
+
+
+async def _has_alternate_bids(model_id: str, logger) -> bool:
+    """True if the model has more than one rated bid.
+
+    On lookup failure we proceed optimistically: route_request will fail
+    with a clean error anyway if no healthy bid exists.
+    """
+    try:
+        response = await proxy_router_service.getRatedBids(model_id)
+        result = response.json()
+        if isinstance(result, list):
+            count = len(result)
+        elif isinstance(result, dict):
+            count = len(result.get("bids", []))
+        else:
+            count = 0
+        logger.info("Failover bid availability check",
+                    model_id=model_id,
+                    bid_count=count,
+                    event_type="failover_bid_check")
+        return count > 1
+    except Exception as e:
+        logger.warning("Failover bid check failed, proceeding with retry",
+                       model_id=model_id,
+                       error=str(e),
+                       event_type="failover_bid_check_error")
+        return True
+
+
+async def attempt_failover(
+    *,
+    original_session_id: str,
+    model_id: Optional[str],
+    requested_model: Optional[str],
+    user,
+    logger,
+    request_id: Optional[str] = None,
+    failure_reason: str = "",
+) -> Optional[str]:
+    """
+    Gateway-owned provider failover: mark the dead session FAILED (with a
+    background on-chain close), verify the model has an alternate bid,
+    and route to a fresh session for the same model — the proxy-router's
+    per-bid handshake lands it on a surviving provider.
+
+    Returns the new session id (already assigned to this request), or None
+    when failover is not possible (caller surfaces the original error).
+
+    Session-accounting contract: this function does NOT release or assign
+    the ORIGINAL session (its release stays with index.py's finally); the
+    NEW session is assigned by route_request and must be released by the
+    code that performs the retry.
+    """
+    failover_logger = logger.bind(
+        original_session_id=original_session_id,
+        model_id=model_id,
+        request_id=request_id,
+    )
+    failover_logger.warning("Attempting gateway failover to a new provider",
+                            failure_reason=failure_reason[:300],
+                            event_type="failover_triggered")
+
+    # 1. Unpin the dead session so no request routes to it again.
+    #    Do this even if we end up unable to retry.
+    async with get_db() as db:
+        await session_routing_service.invalidate_session(
+            db, original_session_id, failure_reason[:300]
+        )
+
+    # 2. Only retry when the model has >1 bid (spec guardrail).
+    if model_id and not await _has_alternate_bids(model_id, failover_logger):
+        failover_logger.warning("No alternate bid available, not retrying",
+                                event_type="failover_no_alternate_bids")
+        return None
+
+    # 3. Open/route a fresh session by model. The proxy-router tries bids
+    #    best-first with a provider handshake per bid, so the dead
+    #    provider is skipped automatically.
+    try:
+        async with get_db() as db:
+            new_session_id = await session_routing_service.route_request(
+                db=db,
+                user_id=user.id,
+                requested_model=requested_model,
+                model_type="LLM",
+            )
+    except Exception as e:
+        failover_logger.error("Failover rerouting failed",
+                              error=str(e),
+                              event_type="failover_route_failed")
+        return None
+
+    if not new_session_id:
+        return None
+
+    failover_logger.info("Failover routed to new session",
+                         new_session_id=new_session_id,
+                         event_type="failover_new_session")
+    # Brief delay so the freshly opened session is registered everywhere
+    # (same as the renewal path).
+    await asyncio.sleep(1.0)
+    return new_session_id

--- a/src/api/v1/chat/chat_non_streaming.py
+++ b/src/api/v1/chat/chat_non_streaming.py
@@ -2,7 +2,10 @@
 Non-streaming chat completion handler.
 
 This module provides non-streaming response handling with:
-- Session expiry detection and automatic retry
+- Expired-session renewal: "session expired" errors reopen a session for the
+  same model and retry once
+- Provider failover: provider-unavailability errors fail over to a different
+  provider (chat_failover) and retry once
 - Proper error propagation using custom exceptions
 """
 
@@ -73,6 +76,20 @@ def _make_error_response(status_code: int, message: str, error_type: str = "prox
     )
 
 
+async def _release_session_quiet(session_id: str, logger) -> None:
+    """Release a session's request slot, logging (not raising) failures."""
+    try:
+        async with get_db() as db:
+            await session_routing_service.release_session(db, session_id)
+    except Exception as release_err:
+        logger.warning(
+            "Failed to release retry session",
+            session_id=session_id,
+            error=str(release_err),
+            event_type="session_release_error",
+        )
+
+
 async def _make_proxy_request(session_id: str, messages: list, chat_params: dict, request_id: str = None) -> httpx.Response:
     """Make a chat completion request to the proxy router."""
     return await proxy_router_service.chatCompletions(
@@ -108,12 +125,18 @@ async def _create_new_session(
             # background. The original's active_requests release stays
             # owned by index.py's finally.
             if original_session_id:
-                await session_routing_service.invalidate_session(
+                invalidated = await session_routing_service.invalidate_session(
                     db,
                     original_session_id,
                     "session expired on proxy",
                     state=SessionState.EXPIRED,
                 )
+                if not invalidated:
+                    logger.warning(
+                        "Expired session was not transitioned (already non-OPEN or DB error)",
+                        session_id=original_session_id,
+                        event_type="session_invalidate_skipped",
+                    )
 
             # Route to a new session
             new_session_id = await session_routing_service.route_request(
@@ -136,7 +159,16 @@ async def _create_new_session(
                 event_type="new_session_created",
             )
             
-            await asyncio.sleep(1.0)  # Brief delay to ensure session is registered
+            try:
+                await asyncio.sleep(1.0)  # Brief delay to ensure session is registered
+            except asyncio.CancelledError:
+                # Client disconnected before the retry could take ownership —
+                # release the just-assigned session so it doesn't leak.
+                try:
+                    await asyncio.shield(_release_session_quiet(new_session_id, logger))
+                except asyncio.CancelledError:
+                    pass
+                raise
             return new_session_id
             
     except Exception as e:
@@ -316,14 +348,9 @@ async def _retry_with_new_session(
 
     finally:
         # The retry owns the new session's assignment; index.py's finally
-        # only releases the ORIGINAL session.
+        # only releases the ORIGINAL session. Shielded so a client
+        # disconnect can't leak the slot.
         try:
-            async with get_db() as db:
-                await session_routing_service.release_session(db, new_session_id)
-        except Exception as release_err:
-            logger.warning(
-                "Failed to release retry session",
-                session_id=new_session_id,
-                error=str(release_err),
-                event_type="session_release_error",
-            )
+            await asyncio.shield(_release_session_quiet(new_session_id, logger))
+        except asyncio.CancelledError:
+            pass

--- a/src/api/v1/chat/chat_non_streaming.py
+++ b/src/api/v1/chat/chat_non_streaming.py
@@ -18,7 +18,9 @@ from fastapi.responses import JSONResponse
 from ....services import proxy_router_service
 from ....services import session_routing_service
 from ....db.database import get_db
+from ....db.models import SessionState
 from ....utils.error_sanitizer import sanitize_error_message
+from . import chat_failover
 from .chat_exceptions import (
     RequestParseError,
     SessionExpiredError,
@@ -100,10 +102,19 @@ async def _create_new_session(
     
     try:
         async with get_db() as db:
-            # Release the old session first if provided
+            # Mark the expired session EXPIRED (not just released): its DB
+            # expires_at may still be in the future, and route_request only
+            # skips non-OPEN rows. Also closes it on the proxy in the
+            # background. The original's active_requests release stays
+            # owned by index.py's finally.
             if original_session_id:
-                await session_routing_service.release_session(db, original_session_id)
-            
+                await session_routing_service.invalidate_session(
+                    db,
+                    original_session_id,
+                    "session expired on proxy",
+                    state=SessionState.EXPIRED,
+                )
+
             # Route to a new session
             new_session_id = await session_routing_service.route_request(
                 db=db,
@@ -145,6 +156,7 @@ async def handle_non_streaming_request(
     db_api_key,
     user,
     requested_model: Optional[str],
+    model_id: Optional[str] = None,
     session_id: str,
 ) -> JSONResponse:
     """
@@ -167,9 +179,50 @@ async def handle_non_streaming_request(
             "Proxy router error on initial request",
             error=str(e),
             error_type=e.error_type,
+            status_code=e.status_code,
             session_id=session_id,
             event_type="proxy_router_error",
         )
+        if db_api_key and user and _is_session_expired(str(e)):
+            # Separate mechanism: expired-session renewal. The provider is
+            # healthy; reopen a session for the same model and retry once.
+            logger.warning(
+                "Detected session expired error, will create new session and retry",
+                session_id=session_id,
+                event_type="session_expired_detected",
+            )
+            new_session_id = await _create_new_session(
+                db_api_key, user, requested_model, logger, request_id, session_id
+            )
+            if new_session_id:
+                return await _retry_with_new_session(
+                    new_session_id=new_session_id,
+                    original_session_id=session_id,
+                    messages=messages,
+                    chat_params=chat_params,
+                    logger=logger,
+                    request_id=request_id,
+                )
+        elif db_api_key and user and chat_failover.is_failover_eligible(e):
+            # Provider became unavailable: fail over to a different provider.
+            new_session_id = await chat_failover.attempt_failover(
+                original_session_id=session_id,
+                model_id=model_id,
+                requested_model=requested_model,
+                user=user,
+                logger=logger,
+                request_id=request_id,
+                failure_reason=str(e),
+            )
+            if new_session_id:
+                return await _retry_with_new_session(
+                    new_session_id=new_session_id,
+                    original_session_id=session_id,
+                    messages=messages,
+                    chat_params=chat_params,
+                    logger=logger,
+                    request_id=request_id,
+                )
         return _make_error_response(e.get_http_status_code(), sanitize_error_message(str(e)), e.error_type)
 
     # Handle success
@@ -192,25 +245,6 @@ async def handle_non_streaming_request(
         session_id=session_id,
         event_type="proxy_error_response",
     )
-
-    # Check for session expired - attempt retry
-    if _is_session_expired(error_content) and db_api_key and user:
-        logger.warning(
-            "Detected session expired error, will create new session and retry",
-            session_id=session_id,
-            event_type="session_expired_detected",
-        )
-        
-        new_session_id = await _create_new_session(db_api_key, user, requested_model, logger, request_id, session_id)
-        if new_session_id:
-            return await _retry_with_new_session(
-                new_session_id=new_session_id,
-                original_session_id=session_id,
-                messages=messages,
-                chat_params=chat_params,
-                logger=logger,
-                request_id=request_id,
-            )
 
     # Return original error
     try:
@@ -236,7 +270,7 @@ async def _retry_with_new_session(
     logger,
     request_id: str = None,
 ) -> JSONResponse:
-    """Retry the request with a new session."""
+    """Retry the request once with a new session. Releases the new session."""
     logger.info(
         "Retrying request with new session",
         new_session_id=new_session_id,
@@ -245,29 +279,51 @@ async def _retry_with_new_session(
     )
 
     try:
-        response = await _make_proxy_request(new_session_id, messages, chat_params, request_id=request_id)
-    except proxy_router_service.ProxyRouterServiceError as e:
-        logger.error(
-            "Retry request failed",
-            new_session_id=new_session_id,
-            error=str(e),
-            error_type=e.error_type,
-            event_type="session_retry_failed",
-        )
-        return _make_error_response(
-            e.get_http_status_code(),
-            f"Retry after session refresh failed: {e}",
-            "retry_failed",
-        )
+        try:
+            response = await _make_proxy_request(new_session_id, messages, chat_params, request_id=request_id)
+        except proxy_router_service.ProxyRouterServiceError as e:
+            logger.error(
+                "Retry request failed",
+                new_session_id=new_session_id,
+                error=str(e),
+                error_type=e.error_type,
+                event_type="session_retry_failed",
+            )
+            return _make_error_response(
+                e.get_http_status_code(),
+                f"Retry after session recovery failed: {sanitize_error_message(str(e))}",
+                "retry_failed",
+            )
 
-    content, error = _parse_response(response, logger, request_id)
-    if content:
-        logger.info(
-            "Non-streaming chat completion successful after retry",
-            session_id=new_session_id,
-            original_session_id=original_session_id,
-            event_type="chat_completion_success",
-        )
-        return JSONResponse(content=content, status_code=200)
-    
-    return _make_error_response(500, error, "unexpected_response_format", session_id=new_session_id)
+        if response.status_code != 200:
+            return _make_error_response(
+                response.status_code,
+                sanitize_error_message(response.text),
+                "proxy_error",
+            )
+
+        content, error = _parse_response(response, logger, request_id)
+        if content:
+            logger.info(
+                "Non-streaming chat completion successful after retry",
+                session_id=new_session_id,
+                original_session_id=original_session_id,
+                event_type="recovery_retry_success",
+            )
+            return JSONResponse(content=content, status_code=200)
+
+        return _make_error_response(500, error, "unexpected_response_format", session_id=new_session_id)
+
+    finally:
+        # The retry owns the new session's assignment; index.py's finally
+        # only releases the ORIGINAL session.
+        try:
+            async with get_db() as db:
+                await session_routing_service.release_session(db, new_session_id)
+        except Exception as release_err:
+            logger.warning(
+                "Failed to release retry session",
+                session_id=new_session_id,
+                error=str(release_err),
+                event_type="session_release_error",
+            )

--- a/src/api/v1/chat/chat_streaming.py
+++ b/src/api/v1/chat/chat_streaming.py
@@ -109,6 +109,20 @@ def _format_sse_error(error_type: str, message: str, **extra) -> bytes:
     return f"data: {json.dumps(error_msg)}\n\n".encode("utf-8")
 
 
+async def _release_session_quiet(session_id: str, logger) -> None:
+    """Release a session's request slot, logging (not raising) failures."""
+    try:
+        async with get_db() as db:
+            await session_routing_service.release_session(db, session_id)
+    except Exception as release_err:
+        logger.warning(
+            "Failed to release retry session",
+            session_id=session_id,
+            error=str(release_err),
+            event_type="session_release_error",
+        )
+
+
 async def _finalize_streaming_billing(
     user_id: int,
     ledger_entry_id: uuid.UUID,
@@ -691,18 +705,12 @@ async def _handle_session_retry(
         )
         yield StreamResult(success=False, error=str(e))
     finally:
-        # Release the new session after retry completes
+        # Shielded so a client disconnect can't leak the new session's slot.
         if new_session_id:
             try:
-                async with get_db() as db:
-                    await session_routing_service.release_session(db, new_session_id)
-            except Exception as release_err:
-                logger.warning(
-                    "Failed to release retry session",
-                    session_id=new_session_id,
-                    error=str(release_err),
-                    event_type="session_release_error",
-                )
+                await asyncio.shield(_release_session_quiet(new_session_id, logger))
+            except asyncio.CancelledError:
+                pass
 
 
 async def _handle_failover_retry(
@@ -777,20 +785,19 @@ async def _handle_failover_retry(
             error=str(e),
             event_type="stream_failover_error",
         )
-        yield _format_sse_error("retry_failed", sanitize_error_message(str(e)))
+        yield _format_sse_error(
+            "retry_failed",
+            sanitize_error_message(str(e)),
+            session_id=new_session_id or original_session_id,
+        )
         yield StreamResult(success=False, error=str(e))
     finally:
+        # Shielded so a client disconnect can't leak the new session's slot.
         if new_session_id:
             try:
-                async with get_db() as db:
-                    await session_routing_service.release_session(db, new_session_id)
-            except Exception as release_err:
-                logger.warning(
-                    "Failed to release failover retry session",
-                    session_id=new_session_id,
-                    error=str(release_err),
-                    event_type="session_release_error",
-                )
+                await asyncio.shield(_release_session_quiet(new_session_id, logger))
+            except asyncio.CancelledError:
+                pass
 
 
 __all__ = [

--- a/src/api/v1/chat/chat_streaming.py
+++ b/src/api/v1/chat/chat_streaming.py
@@ -22,6 +22,8 @@ from ....services.rate_limiting import rate_limit_service
 from ....schemas.billing import UsageFinalizeRequest, UsageVoidRequest
 from ....db.database import get_db
 from ....utils.error_sanitizer import sanitize_error_message
+from ....db.models import SessionState
+from . import chat_failover
 
 if TYPE_CHECKING:
     from structlog.stdlib import BoundLogger
@@ -30,7 +32,7 @@ if TYPE_CHECKING:
 @dataclass
 class StreamingBillingParams:
     """Parameters for streaming billing integration."""
-    
+
     user_id: int
     api_key_id: int
     model_name: Optional[str]
@@ -41,17 +43,17 @@ class StreamingBillingParams:
     request_id: Optional[str] = None
 
 
-@dataclass 
+@dataclass
 class StreamingUsageAccumulator:
     """Accumulates usage data during streaming for finalization."""
-    
+
     tokens_input: int = 0
     tokens_output: int = 0
     tokens_total: int = 0
     model_name: Optional[str] = None
     model_id: Optional[str] = None
     endpoint: str = "/v1/chat/completions"
-    
+
     def update_from_usage(self, usage: dict) -> None:
         """Update accumulated tokens from provider usage dict."""
         self.tokens_input = usage.get("prompt_tokens", self.tokens_input)
@@ -62,41 +64,42 @@ class StreamingUsageAccumulator:
 @dataclass
 class StreamResult:
     """Result metadata from stream processing (not yielded to client)."""
-    
+
     success: bool
     chunk_count: int = 0
     error: Optional[str] = None
-    needs_retry: bool = False
+    needs_retry: bool = False      # expired-session renewal mechanism
+    needs_failover: bool = False   # provider became unavailable pre-first-token
 
 
 def parse_sse_usage(chunk_bytes: bytes) -> Optional[Dict[str, Any]]:
     """
     Parse SSE chunk to extract usage_from_provider data.
-    
+
     Provider typically sends usage in the final chunk with format:
         data: {"usage_from_provider": {"prompt_tokens": X, "completion_tokens": Y, "total_tokens": Z}}
-    
+
     Returns the usage dict if found, None otherwise.
     """
     try:
         chunk_text = chunk_bytes.decode("utf-8", errors="replace")
-        
+
         for line in chunk_text.split("\n"):
             line = line.strip()
             if not line.startswith("data:"):
                 continue
-            
+
             json_str = line[5:].strip()
             if not json_str or json_str == "[DONE]":
                 continue
-            
+
             data = json.loads(json_str)
             if "usage_from_provider" in data:
                 return data["usage_from_provider"]
-                
+
     except (json.JSONDecodeError, UnicodeDecodeError):
         pass
-    
+
     return None
 
 
@@ -127,7 +130,7 @@ async def _finalize_streaming_billing(
                 endpoint=accumulator.endpoint,
             )
             response = await billing_service.finalize_usage(db, user_id, finalize_request)
-            
+
             logger.info(
                 "Streaming billing finalized",
                 tokens_input=accumulator.tokens_input,
@@ -135,7 +138,7 @@ async def _finalize_streaming_billing(
                 amount_total=str(response.amount_total),
                 event_type="streaming_billing_finalized",
             )
-        
+
         # Record actual token usage for rate limiting
         if rate_limit_user_id and accumulator.tokens_total > 0:
             await rate_limit_service.record_token_usage(
@@ -152,7 +155,7 @@ async def _finalize_streaming_billing(
                 tokens_total=accumulator.tokens_total,
                 event_type="rate_limit_streaming_tokens_recorded",
             )
-            
+
     except Exception as e:
         logger.error(
             "Failed to finalize streaming billing",
@@ -178,7 +181,7 @@ async def _void_streaming_billing(
                 failure_reason=failure_reason,
             )
             await billing_service.void_usage(db, user_id, void_request)
-            
+
             logger.info(
                 "Streaming billing hold voided",
                 failure_code=failure_code,
@@ -253,6 +256,7 @@ def build_stream_generator(
     session_id: str,
     body: bytes,
     requested_model: Optional[str],
+    model_id: Optional[str] = None,
     db_api_key,
     user,
     ledger_entry_id: Optional[uuid.UUID] = None,
@@ -266,11 +270,12 @@ def build_stream_generator(
         session_id: Session ID for the proxy request
         body: Request body bytes
         requested_model: Model name requested
+        model_id: Model ID for failover routing
         db_api_key: API key object
         user: User object
         ledger_entry_id: If provided, billing is enabled for this stream
         billing_params: Billing parameters (required if ledger_entry_id is set)
-    
+
     Note: Uses short-lived DB connections for session creation to avoid
     holding connections during long-running streaming operations.
     """
@@ -283,18 +288,18 @@ def build_stream_generator(
             session_id=session_id,
             billing_enabled=billing_enabled,
         )
-        
+
         stream_logger.info(
             "Starting stream generator",
             user_id=user.id if user else None,
             requested_model=requested_model,
             event_type="stream_generator_start",
         )
-        
+
         chunk_count = 0
         stream_completed_successfully = False
         stream_error: Optional[str] = None
-        
+
         accumulator = StreamingUsageAccumulator(
             model_name=requested_model,
             model_id=billing_params.model_id if billing_params else None,
@@ -315,25 +320,49 @@ def build_stream_generator(
                     chunk_count = chunk_data.chunk_count
                     stream_completed_successfully = chunk_data.success
                     stream_error = chunk_data.error
-                    
-                    if chunk_data.needs_retry and db_api_key and user:
-                        async for retry_chunk in _handle_session_retry(
-                            original_session_id=session_id,
-                            messages=messages,
-                            chat_params=chat_params,
-                            db_api_key=db_api_key,
-                            user=user,
-                            requested_model=requested_model,
-                            logger=stream_logger,
-                            accumulator=accumulator,
-                            request_id=billing_params.request_id if billing_params else None,
-                        ):
+
+                    if (chunk_data.needs_retry or chunk_data.needs_failover) and db_api_key and user:
+                        if chunk_data.needs_retry:
+                            # Expired-session renewal (existing mechanism).
+                            retry_gen = _handle_session_retry(
+                                original_session_id=session_id,
+                                messages=messages,
+                                chat_params=chat_params,
+                                db_api_key=db_api_key,
+                                user=user,
+                                requested_model=requested_model,
+                                logger=stream_logger,
+                                accumulator=accumulator,
+                                request_id=billing_params.request_id if billing_params else None,
+                            )
+                        else:
+                            # Provider failover (different provider).
+                            retry_gen = _handle_failover_retry(
+                                original_session_id=session_id,
+                                messages=messages,
+                                chat_params=chat_params,
+                                user=user,
+                                requested_model=requested_model,
+                                model_id=model_id,
+                                failure_reason=chunk_data.error or "",
+                                logger=stream_logger,
+                                accumulator=accumulator,
+                                request_id=billing_params.request_id if billing_params else None,
+                            )
+                        async for retry_chunk in retry_gen:
                             if isinstance(retry_chunk, StreamResult):
                                 chunk_count = retry_chunk.chunk_count
                                 stream_completed_successfully = retry_chunk.success
                                 stream_error = retry_chunk.error
                             else:
                                 yield retry_chunk
+                    elif chunk_data.needs_retry or chunk_data.needs_failover:
+                        # No auth context to reroute with — surface the error.
+                        yield _format_sse_error(
+                            "proxy_error",
+                            sanitize_error_message(chunk_data.error or "provider failure"),
+                            session_id=session_id,
+                        )
                 else:
                     yield chunk_data
 
@@ -355,7 +384,7 @@ def build_stream_generator(
                 exc_info=True,
             )
             yield _format_sse_error("gateway_error", f"Error in API gateway streaming: {e}", session_id=session_id)
-        
+
         finally:
             # Shield cleanup from task cancellation so that billing
             # void/finalize and session release always run to completion,
@@ -392,10 +421,10 @@ def _parse_request_body(body: bytes, logger: "BoundLogger") -> tuple[list, dict]
             k: v for k, v in req_body_json.items()
             if k not in ["messages", "stream", "session_id"]
         }
-        
+
         has_tool_msg = any(msg.get("role") == "tool" for msg in messages if isinstance(msg, dict))
         has_tool_calls = any("tool_calls" in msg for msg in messages if isinstance(msg, dict))
-        
+
         if has_tool_msg or has_tool_calls:
             logger.info(
                 "Request contains tool content",
@@ -404,9 +433,9 @@ def _parse_request_body(body: bytes, logger: "BoundLogger") -> tuple[list, dict]
                 message_count=len(messages),
                 event_type="tool_content_detected",
             )
-        
+
         return messages, chat_params
-        
+
     except Exception as parse_err:
         logger.error(
             "Failed to parse request body",
@@ -426,14 +455,14 @@ async def _process_stream_request(
 ) -> AsyncIterator[bytes | StreamResult]:
     """
     Process a single streaming request attempt.
-    
+
     Yields:
         - bytes: Chunk data to send to client
         - StreamResult: Final result metadata (not sent to client)
     """
     logger.info("Making streaming request", session_id=session_id, event_type="stream_request_start")
     chunk_count = 0
-    
+
     try:
         async with proxy_router_service.chatCompletionsStream(
             session_id=session_id,
@@ -447,7 +476,7 @@ async def _process_stream_request(
                 response_headers=dict(response.headers.items()),
                 event_type="stream_proxy_response",
             )
-            
+
             if response.status_code != 200:
                 result = await _handle_error_response(response, session_id, logger)
                 if result.needs_retry:
@@ -457,10 +486,10 @@ async def _process_stream_request(
                     yield _format_sse_error("proxy_error", f"Proxy router error: {sanitize_error_message(result.error)}", status=response.status_code)
                 yield result
                 return
-            
+
             async for chunk_bytes in response.aiter_bytes():
                 chunk_count += 1
-                
+
                 if accumulator and b"usage_from_provider" in chunk_bytes:
                     usage = parse_sse_usage(chunk_bytes)
                     if usage:
@@ -471,7 +500,7 @@ async def _process_stream_request(
                             tokens_output=accumulator.tokens_output,
                             event_type="stream_usage_extracted",
                         )
-                
+
                 if chunk_count <= 2:
                     try:
                         preview = chunk_bytes[:150].decode("utf-8", errors="replace")
@@ -487,9 +516,9 @@ async def _process_stream_request(
                             chunk_number=chunk_count,
                             chunk_size=len(chunk_bytes),
                         )
-                
+
                 yield chunk_bytes
-            
+
             logger.info(
                 "Stream finished from proxy",
                 total_chunks=chunk_count,
@@ -497,15 +526,27 @@ async def _process_stream_request(
                 event_type="stream_completed",
             )
             yield StreamResult(success=True, chunk_count=chunk_count)
-            
+
     except proxy_router_service.ProxyRouterServiceError as e:
         logger.error(
             "Proxy router error during streaming",
             error=str(e),
             error_type=e.error_type,
             status_code=e.status_code,
+            chunk_count=chunk_count,
             event_type="stream_proxy_router_error",
         )
+        if chunk_count == 0 and "session expired" in str(e).lower():
+            # Separate mechanism: expired-session renewal (trigger was
+            # previously unreachable here — real errors raise, they don't
+            # return non-200 responses).
+            yield StreamResult(success=False, chunk_count=0, error=str(e), needs_retry=True)
+            return
+        if chunk_count == 0 and chat_failover.is_failover_eligible(e):
+            # Provider unavailable and nothing reached the client yet — a
+            # transparent failover retry is possible.
+            yield StreamResult(success=False, chunk_count=0, error=str(e), needs_failover=True)
+            return
         yield _format_sse_error(e.error_type, sanitize_error_message(str(e)), status=e.status_code)
         yield StreamResult(success=False, chunk_count=chunk_count, error=str(e))
 
@@ -518,18 +559,18 @@ async def _handle_error_response(response, session_id: str, logger: "BoundLogger
         session_id=session_id,
         event_type="stream_proxy_error",
     )
-    
+
     try:
         error_body = await response.aread()
         error_text = error_body.decode("utf-8", errors="replace")
-        
+
         logger.error(
             "Error body received from proxy",
             error_text=error_text,
             status_code=response.status_code,
             event_type="stream_proxy_error_body",
         )
-        
+
         if "session expired" in error_text.lower():
             logger.warning(
                 "Detected session expired error, will create new session and retry",
@@ -537,9 +578,9 @@ async def _handle_error_response(response, session_id: str, logger: "BoundLogger
                 event_type="stream_session_expired_detected",
             )
             return StreamResult(success=False, error=error_text, needs_retry=True)
-        
+
         return StreamResult(success=False, error=error_text)
-        
+
     except Exception as read_err:
         logger.error(
             "Error reading error response",
@@ -568,13 +609,21 @@ async def _handle_session_retry(
         requested_model=requested_model,
         event_type="stream_new_session_creation_start",
     )
-    
+
     new_session_id = None
     try:
         async with get_db() as db:
-            # Release the old session first
-            await session_routing_service.release_session(db, original_session_id)
-            
+            # Mark the expired session EXPIRED (not just released): its DB
+            # expires_at may still be in the future, and route_request only
+            # skips non-OPEN rows. The original's active_requests release
+            # is owned by _stream_cleanup.
+            await session_routing_service.invalidate_session(
+                db,
+                original_session_id,
+                "session expired on proxy",
+                state=SessionState.EXPIRED,
+            )
+
             # Route to a new session
             new_session_id = await session_routing_service.route_request(
                 db=db,
@@ -582,30 +631,35 @@ async def _handle_session_retry(
                 requested_model=requested_model,
                 model_type="LLM",
             )
-        
+
         if not new_session_id:
             logger.error(
                 "Failed to route to new session",
                 event_type="stream_new_session_creation_failed",
             )
+            yield _format_sse_error(
+                "retry_failed",
+                "Failed to create new session after session expiry",
+                session_id=original_session_id,
+            )
             yield StreamResult(success=False, error="Failed to create new session")
             return
-        
+
         logger.info(
             "Routed to new session for stream retry",
             new_session_id=new_session_id,
             event_type="stream_new_session_created",
         )
-        
+
         await asyncio.sleep(1.0)
-        
+
         logger.info(
             "Retrying stream request with new session",
             new_session_id=new_session_id,
             original_session_id=original_session_id,
             event_type="stream_retry_start",
         )
-        
+
         async for chunk in _process_stream_request(
             session_id=new_session_id,
             messages=messages,
@@ -614,13 +668,26 @@ async def _handle_session_retry(
             accumulator=accumulator,
             request_id=request_id,
         ):
-            yield chunk
-            
+            if isinstance(chunk, StreamResult) and (chunk.needs_retry or chunk.needs_failover):
+                yield _format_sse_error(
+                    "retry_failed",
+                    sanitize_error_message(chunk.error or "retry failed"),
+                    session_id=new_session_id,
+                )
+                yield StreamResult(success=False, chunk_count=chunk.chunk_count, error=chunk.error)
+            else:
+                yield chunk
+
     except Exception as e:
         logger.error(
             "Failed to route to new session",
             error=str(e),
             event_type="stream_new_session_creation_failed",
+        )
+        yield _format_sse_error(
+            "retry_failed",
+            sanitize_error_message(str(e)),
+            session_id=original_session_id,
         )
         yield StreamResult(success=False, error=str(e))
     finally:
@@ -632,6 +699,94 @@ async def _handle_session_retry(
             except Exception as release_err:
                 logger.warning(
                     "Failed to release retry session",
+                    session_id=new_session_id,
+                    error=str(release_err),
+                    event_type="session_release_error",
+                )
+
+
+async def _handle_failover_retry(
+    original_session_id: str,
+    messages: list,
+    chat_params: dict,
+    user,
+    requested_model: Optional[str],
+    model_id: Optional[str],
+    failure_reason: str,
+    logger: "BoundLogger",
+    accumulator: Optional[StreamingUsageAccumulator] = None,
+    request_id: Optional[str] = None,
+) -> AsyncIterator[bytes | StreamResult]:
+    """Provider failover for streams: reroute to a different provider and
+    retry the stream once (pre-first-token only)."""
+    new_session_id = None
+    try:
+        new_session_id = await chat_failover.attempt_failover(
+            original_session_id=original_session_id,
+            model_id=model_id,
+            requested_model=requested_model,
+            user=user,
+            logger=logger,
+            request_id=request_id,
+            failure_reason=failure_reason,
+        )
+
+        if not new_session_id:
+            logger.error(
+                "Failover not possible for stream",
+                event_type="stream_failover_unavailable",
+            )
+            yield _format_sse_error(
+                "proxy_error",
+                sanitize_error_message(failure_reason or "provider failure, no alternate session"),
+                session_id=original_session_id,
+            )
+            yield StreamResult(success=False, error=failure_reason or "failover unavailable")
+            return
+
+        logger.info(
+            "Retrying stream request with new session after failover",
+            new_session_id=new_session_id,
+            original_session_id=original_session_id,
+            event_type="stream_failover_retry_start",
+        )
+
+        async for chunk in _process_stream_request(
+            session_id=new_session_id,
+            messages=messages,
+            chat_params=chat_params,
+            logger=logger.bind(retry_session_id=new_session_id),
+            accumulator=accumulator,
+            request_id=request_id,
+        ):
+            if isinstance(chunk, StreamResult) and (chunk.needs_retry or chunk.needs_failover):
+                # Single retry only: a second recoverable failure becomes a
+                # terminal client-visible error.
+                yield _format_sse_error(
+                    "retry_failed",
+                    sanitize_error_message(chunk.error or "retry failed"),
+                    session_id=new_session_id,
+                )
+                yield StreamResult(success=False, chunk_count=chunk.chunk_count, error=chunk.error)
+            else:
+                yield chunk
+
+    except Exception as e:
+        logger.error(
+            "Stream failover retry failed",
+            error=str(e),
+            event_type="stream_failover_error",
+        )
+        yield _format_sse_error("retry_failed", sanitize_error_message(str(e)))
+        yield StreamResult(success=False, error=str(e))
+    finally:
+        if new_session_id:
+            try:
+                async with get_db() as db:
+                    await session_routing_service.release_session(db, new_session_id)
+            except Exception as release_err:
+                logger.warning(
+                    "Failed to release failover retry session",
                     session_id=new_session_id,
                     error=str(release_err),
                     event_type="session_release_error",

--- a/src/api/v1/chat/index.py
+++ b/src/api/v1/chat/index.py
@@ -462,6 +462,7 @@ def _handle_streaming_request(
         session_id=session_id,
         body=body,
         requested_model=requested_model,
+        model_id=model_id,
         db_api_key=db_api_key,
         user=user,
         ledger_entry_id=ledger_entry_id,

--- a/src/api/v1/chat/index.py
+++ b/src/api/v1/chat/index.py
@@ -520,6 +520,7 @@ async def _handle_non_streaming_request(
             db_api_key=db_api_key,
             user=user,
             requested_model=requested_model,
+            model_id=model_id,
             session_id=session_id,
         )
         

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -163,6 +163,7 @@ class Settings(BaseSettings):
     PROXY_ROUTER_PASSWORD: str = Field(default=os.getenv("PROXY_ROUTER_PASSWORD", ""))
     PROXY_ROUTER_CHAT_TIMEOUT: float = Field(default=float(os.getenv("PROXY_ROUTER_CHAT_TIMEOUT", "300.0")))
     PROXY_ROUTER_STREAM_TIMEOUT: float = Field(default=float(os.getenv("PROXY_ROUTER_STREAM_TIMEOUT", "300.0")))
+    CHAT_FAILOVER_ENABLED: bool = Field(default=os.getenv("CHAT_FAILOVER_ENABLED", "true").lower() == "true")
 
     # AWS settings (credentials come from ECS task role; no explicit keys needed)
     AWS_REGION: str = os.getenv("AWS_REGION", "us-east-2")

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -68,6 +68,10 @@ class SessionRoutingService:
         # Automation loop control
         self._automation_task: Optional[asyncio.Task] = None
         self._shutdown_event = asyncio.Event()
+
+        # Strong refs to fire-and-forget close tasks (event loop keeps only
+        # weak refs; an unreferenced task can be GC'd before it runs).
+        self._background_close_tasks: set = set()
         
         logger.info("SessionRoutingService initialized",
                    event_type="session_routing_service_init")
@@ -252,7 +256,7 @@ class SessionRoutingService:
             await db.rollback()
             return False
 
-        transitioned = bool(getattr(result, "rowcount", 0))
+        transitioned = (getattr(result, "rowcount", 0) or 0) > 0
         if transitioned:
             invalidate_logger.warning("Session invalidated after prompt failure",
                                       reason=reason,
@@ -261,7 +265,9 @@ class SessionRoutingService:
             # failing) provider-report RPC plus a blockchain tx — too slow
             # to block the user's retry on. closeSession tolerates
             # already-closed sessions.
-            asyncio.create_task(self._close_invalidated_session(session_id))
+            task = asyncio.create_task(self._close_invalidated_session(session_id))
+            self._background_close_tasks.add(task)
+            task.add_done_callback(self._background_close_tasks.discard)
         return transitioned
 
     async def _close_invalidated_session(self, session_id: str) -> None:

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -205,6 +205,80 @@ class SessionRoutingService:
                                exc_info=True)
             await db.rollback()
     
+    async def invalidate_session(
+        self,
+        db: AsyncSession,
+        session_id: str,
+        reason: str,
+        state: SessionState = SessionState.FAILED,
+    ) -> bool:
+        """
+        Mark a session FAILED (provider failover) or EXPIRED (session
+        renewal) so it is never routed to again, and close it on the proxy
+        router in the background (best-effort).
+
+        Marking matters in both cases: the row's DB expires_at can lie in
+        the future (on-chain endsAt may pass earlier), so a released-only
+        row would keep being re-picked by route_request.
+
+        Unlike _close_session this works while the session is still
+        utilized (the failing request itself holds an assignment) and never
+        blocks the caller on the on-chain close transaction.
+
+        Returns True if this call transitioned the session out of OPEN.
+        """
+        invalidate_logger = logger.bind(session_id=session_id, target_state=state.value)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        try:
+            result = await db.execute(
+                update(RoutedSession)
+                .where(
+                    RoutedSession.id == session_id,
+                    RoutedSession.state == SessionState.OPEN.value,
+                )
+                .values(
+                    state=state.value,
+                    error_reason=f"recovery: {reason}"[:500],
+                    updated_at=now,
+                )
+            )
+            await db.commit()
+        except Exception as e:
+            invalidate_logger.error("Error invalidating session",
+                                    error=str(e),
+                                    event_type="session_invalidate_error",
+                                    exc_info=True)
+            await db.rollback()
+            return False
+
+        transitioned = bool(getattr(result, "rowcount", 0))
+        if transitioned:
+            invalidate_logger.warning("Session invalidated after prompt failure",
+                                      reason=reason,
+                                      event_type="session_invalidated")
+            # Close on-chain in the background: close needs a (possibly
+            # failing) provider-report RPC plus a blockchain tx — too slow
+            # to block the user's retry on. closeSession tolerates
+            # already-closed sessions.
+            asyncio.create_task(self._close_invalidated_session(session_id))
+        return transitioned
+
+    async def _close_invalidated_session(self, session_id: str) -> None:
+        """Best-effort proxy-router close for an invalidated session."""
+        try:
+            await proxy_router_service.closeSession(session_id)
+            logger.info("Invalidated session closed on proxy router",
+                        session_id=session_id,
+                        event_type="invalidated_session_closed")
+        except Exception as e:
+            # The proxy-router's SessionExpiryHandler will close it after
+            # EndsAt anyway; losing this close only delays stake recovery.
+            logger.warning("Best-effort close of invalidated session failed",
+                           session_id=session_id,
+                           error=str(e),
+                           event_type="invalidated_session_close_error")
+
     @asynccontextmanager
     async def session_context(
         self,

--- a/tests/unit/test_chat_failover.py
+++ b/tests/unit/test_chat_failover.py
@@ -50,3 +50,77 @@ class TestIsFailoverEligible:
         exc = _err('HTTP 500: {"error":"provider request failed"}', 500, "server_error")
         with patch.object(chat_failover.settings, "CHAT_FAILOVER_ENABLED", False):
             assert chat_failover.is_failover_eligible(exc) is False
+
+
+def _rated_bids_response(n):
+    resp = MagicMock()
+    resp.json.return_value = [{"bid": {"provider": f"0xp{i}"}} for i in range(n)]
+    return resp
+
+
+@pytest.fixture
+def mock_user():
+    user = MagicMock()
+    user.id = 42
+    return user
+
+
+@pytest.fixture
+def failover_mocks(mock_user):
+    """Patch DB, routing service and bids lookup used by attempt_failover."""
+    db = AsyncMock()
+
+    class FakeGetDb:
+        async def __aenter__(self):
+            return db
+        async def __aexit__(self, *args):
+            return False
+
+    with patch.object(chat_failover, "get_db", lambda: FakeGetDb()), \
+         patch.object(chat_failover.session_routing_service, "invalidate_session",
+                      new_callable=AsyncMock, return_value=True) as invalidate, \
+         patch.object(chat_failover.session_routing_service, "route_request",
+                      new_callable=AsyncMock, return_value="0xnew") as route, \
+         patch.object(chat_failover.proxy_router_service, "getRatedBids",
+                      new_callable=AsyncMock, return_value=_rated_bids_response(2)) as bids, \
+         patch.object(chat_failover.asyncio, "sleep", new_callable=AsyncMock):
+        yield {"invalidate": invalidate, "route": route, "bids": bids, "user": mock_user}
+
+
+def _failover(mocks, **overrides):
+    kwargs = dict(
+        original_session_id="0xdead",
+        model_id="0xmodel",
+        requested_model="llama-3.3-70b",
+        user=mocks["user"],
+        logger=MagicMock(),
+        failure_reason="connection refused",
+    )
+    kwargs.update(overrides)
+    return chat_failover.attempt_failover(**kwargs)
+
+
+class TestAttemptFailover:
+    async def test_happy_path_returns_new_session(self, failover_mocks):
+        new_id = await _failover(failover_mocks)
+        assert new_id == "0xnew"
+        failover_mocks["invalidate"].assert_awaited_once()
+        failover_mocks["bids"].assert_awaited_once()
+        failover_mocks["route"].assert_awaited_once()
+
+    async def test_single_bid_blocks_retry_but_still_invalidates(self, failover_mocks):
+        failover_mocks["bids"].return_value = _rated_bids_response(1)
+        new_id = await _failover(failover_mocks)
+        assert new_id is None
+        failover_mocks["invalidate"].assert_awaited_once()
+        failover_mocks["route"].assert_not_awaited()
+
+    async def test_bids_lookup_failure_proceeds_optimistically(self, failover_mocks):
+        failover_mocks["bids"].side_effect = Exception("chain read failed")
+        new_id = await _failover(failover_mocks)
+        assert new_id == "0xnew"
+
+    async def test_route_failure_returns_none(self, failover_mocks):
+        failover_mocks["route"].side_effect = Exception("no bids left")
+        new_id = await _failover(failover_mocks)
+        assert new_id is None

--- a/tests/unit/test_chat_failover.py
+++ b/tests/unit/test_chat_failover.py
@@ -1,0 +1,52 @@
+"""Tests for gateway-owned provider failover policy."""
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.services.proxy_router_service import ProxyRouterServiceError
+from src.api.v1.chat import chat_failover
+
+
+def _err(message, status_code=None, error_type="unknown"):
+    return ProxyRouterServiceError(message, status_code=status_code, error_type=error_type)
+
+
+class TestIsFailoverEligible:
+    @pytest.mark.parametrize("exc", [
+        _err('HTTP 500: {"error":"provider request failed: failed to connect to provider: dial tcp 1.2.3.4:8083: connect: connection refused"}', 500, "server_error"),
+        _err('HTTP 500: {"error":"provider request failed: read timed out after 3 retries"}', 500, "server_error"),
+        _err('HTTP 500: {"error":"provider request failed: provider closed connection without sending any data"}', 500, "server_error"),
+        _err('HTTP 500: {"error":"provider not found"}', 500, "server_error"),
+        _err('HTTP 502: {"error":"bad gateway"}', 502, "server_error"),
+        _err("Request failed after 1 attempts: All connection attempts failed", None, "network_error"),
+        # Streaming transport failure: chatCompletionsStream's catch-all wrap
+        # (proxy_router_service.py:786-792) produces status=None, type="unknown".
+        _err("Failed to create chat completions stream: All connection attempts failed", None, "unknown"),
+    ])
+    def test_provider_unavailability_is_eligible(self, exc):
+        assert chat_failover.is_failover_eligible(exc) is True
+
+    @pytest.mark.parametrize("exc", [
+        # Session-state errors belong to the SEPARATE renewal mechanism —
+        # failover must NOT trigger even though they arrive as 500.
+        _err('HTTP 500: {"error":"session expired"}', 500, "server_error"),
+        _err('HTTP 500: {"error":"session not found"}', 500, "server_error"),
+        # User/4xx and known-permanent failures.
+        _err('HTTP 400: {"error":"invalid request"}', 400, "client_error"),
+        _err('HTTP 404: {"error":"not found"}', 404, "client_error"),
+        _err('HTTP 500: {"error":"p-node tee attestation failed: quote invalid"}', 500, "server_error"),
+        _err('HTTP 500: {"error":"llm tee verification failed"}', 500, "server_error"),
+        _err('HTTP 500: {"error":"request cancelled while waiting in queue: context canceled"}', 500, "server_error"),
+        _err("something odd with no status and no known pattern", None, "unknown"),
+    ])
+    def test_not_eligible(self, exc):
+        assert chat_failover.is_failover_eligible(exc) is False
+
+    def test_kill_switch_disables_failover(self):
+        exc = _err('HTTP 500: {"error":"provider request failed"}', 500, "server_error")
+        with patch.object(chat_failover.settings, "CHAT_FAILOVER_ENABLED", False):
+            assert chat_failover.is_failover_eligible(exc) is False

--- a/tests/unit/test_chat_failover.py
+++ b/tests/unit/test_chat_failover.py
@@ -124,3 +124,9 @@ class TestAttemptFailover:
         failover_mocks["route"].side_effect = Exception("no bids left")
         new_id = await _failover(failover_mocks)
         assert new_id is None
+
+    async def test_invalidate_failure_returns_none_without_routing(self, failover_mocks):
+        failover_mocks["invalidate"].side_effect = Exception("db teardown failed")
+        new_id = await _failover(failover_mocks)
+        assert new_id is None
+        failover_mocks["route"].assert_not_awaited()

--- a/tests/unit/test_chat_non_streaming_failover.py
+++ b/tests/unit/test_chat_non_streaming_failover.py
@@ -151,9 +151,43 @@ async def test_failed_retry_returns_real_status_not_200(mock_user):
          patch.object(chat_non_streaming.chat_failover, "attempt_failover",
                       new_callable=AsyncMock, return_value="0xnew"), \
          patch.object(chat_non_streaming.session_routing_service, "release_session",
-                      new_callable=AsyncMock), \
+                      new_callable=AsyncMock) as release, \
          patch.object(chat_non_streaming, "get_db", _fake_get_db()):
         response = await _call(mock_user)
 
     # Real failure status so index.py voids (not finalizes) the billing hold.
+    assert response.status_code == 500
+    release.assert_awaited_once()
+    assert release.await_args.args[1] == "0xnew"
+
+
+async def test_retry_returning_non_200_response_propagates_status(mock_user):
+    bad_response = httpx.Response(502, text="upstream exploded")
+    with patch.object(chat_non_streaming.proxy_router_service, "chatCompletions",
+                      new_callable=AsyncMock, side_effect=[PROVIDER_DOWN, bad_response]), \
+         patch.object(chat_non_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value="0xnew"), \
+         patch.object(chat_non_streaming.session_routing_service, "release_session",
+                      new_callable=AsyncMock) as release, \
+         patch.object(chat_non_streaming, "get_db", _fake_get_db()):
+        response = await _call(mock_user)
+
+    assert response.status_code == 502
+    release.assert_awaited_once()
+
+
+async def test_renewal_route_failure_surfaces_original_error(mock_user):
+    with patch.object(chat_non_streaming.proxy_router_service, "chatCompletions",
+                      new_callable=AsyncMock, side_effect=[SESSION_EXPIRED]), \
+         patch.object(chat_non_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock) as failover, \
+         patch.object(chat_non_streaming.session_routing_service, "invalidate_session",
+                      new_callable=AsyncMock, return_value=True), \
+         patch.object(chat_non_streaming.session_routing_service, "route_request",
+                      new_callable=AsyncMock, side_effect=Exception("no session")), \
+         patch.object(chat_non_streaming, "get_db", _fake_get_db()), \
+         patch("asyncio.sleep", new_callable=AsyncMock):
+        response = await _call(mock_user)
+
+    failover.assert_not_awaited()
     assert response.status_code == 500

--- a/tests/unit/test_chat_non_streaming_failover.py
+++ b/tests/unit/test_chat_non_streaming_failover.py
@@ -1,0 +1,159 @@
+"""Integration tests for non-streaming recovery: provider failover + expired-session renewal."""
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.api.v1.chat import chat_non_streaming
+from src.db.models import SessionState
+from src.services.proxy_router_service import ProxyRouterServiceError
+
+BODY = json.dumps({"messages": [{"role": "user", "content": "hi"}]}).encode()
+
+
+def _success_response():
+    return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+
+PROVIDER_DOWN = ProxyRouterServiceError(
+    'HTTP 500: {"error":"provider request failed: failed to connect to provider: connection refused"}',
+    status_code=500,
+    error_type="server_error",
+)
+SESSION_EXPIRED = ProxyRouterServiceError(
+    'HTTP 500: {"error":"session expired"}', status_code=500, error_type="server_error",
+)
+USER_ERROR = ProxyRouterServiceError(
+    'HTTP 400: {"error":"invalid request"}', status_code=400, error_type="client_error",
+)
+
+
+def _fake_get_db():
+    db = AsyncMock()
+
+    class FakeGetDb:
+        async def __aenter__(self):
+            return db
+        async def __aexit__(self, *args):
+            return False
+
+    return lambda: FakeGetDb()
+
+
+@pytest.fixture
+def mock_user():
+    user = MagicMock()
+    user.id = 42
+    return user
+
+
+def _call(mock_user, **overrides):
+    kwargs = dict(
+        logger=MagicMock(),
+        request_id="req-1",
+        body=BODY,
+        db_api_key=MagicMock(),
+        user=mock_user,
+        requested_model="llama-3.3-70b",
+        model_id="0xmodel",
+        session_id="0xdead",
+    )
+    kwargs.update(overrides)
+    return chat_non_streaming.handle_non_streaming_request(**kwargs)
+
+
+async def test_provider_down_triggers_single_failover_retry(mock_user):
+    with patch.object(chat_non_streaming.proxy_router_service, "chatCompletions",
+                      new_callable=AsyncMock, side_effect=[PROVIDER_DOWN, _success_response()]) as chat, \
+         patch.object(chat_non_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value="0xnew") as failover, \
+         patch.object(chat_non_streaming.session_routing_service, "release_session",
+                      new_callable=AsyncMock) as release, \
+         patch.object(chat_non_streaming, "get_db", _fake_get_db()):
+        response = await _call(mock_user)
+
+    assert response.status_code == 200
+    assert chat.await_count == 2
+    assert chat.await_args_list[1].kwargs["session_id"] == "0xnew"
+    failover.assert_awaited_once()
+    assert failover.await_args.kwargs["original_session_id"] == "0xdead"
+    # New session released exactly once; original is NOT released here
+    # (index.py's finally owns it).
+    release.assert_awaited_once()
+    assert release.await_args.args[1] == "0xnew"
+
+
+async def test_session_expired_triggers_renewal_not_failover(mock_user):
+    """Expired session -> existing renewal mechanism (now reachable), not failover."""
+    with patch.object(chat_non_streaming.proxy_router_service, "chatCompletions",
+                      new_callable=AsyncMock, side_effect=[SESSION_EXPIRED, _success_response()]) as chat, \
+         patch.object(chat_non_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock) as failover, \
+         patch.object(chat_non_streaming.session_routing_service, "invalidate_session",
+                      new_callable=AsyncMock, return_value=True) as invalidate, \
+         patch.object(chat_non_streaming.session_routing_service, "route_request",
+                      new_callable=AsyncMock, return_value="0xrenewed") as route, \
+         patch.object(chat_non_streaming.session_routing_service, "release_session",
+                      new_callable=AsyncMock) as release, \
+         patch.object(chat_non_streaming, "get_db", _fake_get_db()), \
+         patch("asyncio.sleep", new_callable=AsyncMock):
+        response = await _call(mock_user)
+
+    assert response.status_code == 200
+    failover.assert_not_awaited()
+    assert chat.await_count == 2
+    assert chat.await_args_list[1].kwargs["session_id"] == "0xrenewed"
+    # Old row marked EXPIRED (not just released) so route_request can't re-pick it.
+    invalidate.assert_awaited_once()
+    assert invalidate.await_args.kwargs["state"] is SessionState.EXPIRED
+    route.assert_awaited_once()
+    # Renewal session released exactly once; original NOT released here.
+    release.assert_awaited_once()
+    assert release.await_args.args[1] == "0xrenewed"
+
+
+async def test_user_error_is_not_retried(mock_user):
+    with patch.object(chat_non_streaming.proxy_router_service, "chatCompletions",
+                      new_callable=AsyncMock, side_effect=[USER_ERROR]) as chat, \
+         patch.object(chat_non_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock) as failover:
+        response = await _call(mock_user)
+
+    assert response.status_code == 400
+    assert chat.await_count == 1
+    failover.assert_not_awaited()
+
+
+async def test_no_alternate_session_surfaces_original_error(mock_user):
+    with patch.object(chat_non_streaming.proxy_router_service, "chatCompletions",
+                      new_callable=AsyncMock, side_effect=[PROVIDER_DOWN]), \
+         patch.object(chat_non_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value=None):
+        response = await _call(mock_user)
+
+    assert response.status_code == 500
+    payload = json.loads(response.body)
+    assert payload["error"]["type"] == "server_error"
+
+
+async def test_failed_retry_returns_real_status_not_200(mock_user):
+    retry_error = ProxyRouterServiceError(
+        'HTTP 500: {"error":"provider request failed"}', status_code=500,
+        error_type="server_error",
+    )
+    with patch.object(chat_non_streaming.proxy_router_service, "chatCompletions",
+                      new_callable=AsyncMock, side_effect=[PROVIDER_DOWN, retry_error]), \
+         patch.object(chat_non_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value="0xnew"), \
+         patch.object(chat_non_streaming.session_routing_service, "release_session",
+                      new_callable=AsyncMock), \
+         patch.object(chat_non_streaming, "get_db", _fake_get_db()):
+        response = await _call(mock_user)
+
+    # Real failure status so index.py voids (not finalizes) the billing hold.
+    assert response.status_code == 500

--- a/tests/unit/test_chat_streaming_failover.py
+++ b/tests/unit/test_chat_streaming_failover.py
@@ -202,3 +202,49 @@ async def test_failover_retry_failure_emits_error_chunk(mock_user):
     assert any(b"error" in c for c in chunks)
     # New session released exactly once by the failover retry path.
     release.assert_awaited_once()
+
+
+async def test_failover_retry_releases_new_session_on_disconnect(mock_user):
+    """Client disconnect mid-retry must still release the new session
+    (shielded finally)."""
+    import asyncio
+
+    hang = asyncio.Event()
+
+    async def hanging_stream(**kwargs):
+        await hang.wait()
+        yield b"never"
+
+    with patch.object(chat_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value="0xnew"), \
+         patch.object(chat_streaming, "_process_stream_request", hanging_stream), \
+         patch.object(chat_streaming.session_routing_service, "release_session",
+                      new_callable=AsyncMock) as release, \
+         patch.object(chat_streaming, "get_db", _fake_get_db()):
+
+        async def consume():
+            gen = chat_streaming._handle_failover_retry(
+                original_session_id="0xdead",
+                messages=[],
+                chat_params={},
+                user=mock_user,
+                requested_model="llama-3.3-70b",
+                model_id="0xmodel",
+                failure_reason="provider down",
+                logger=MagicMock(),
+            )
+            async for _ in gen:
+                pass
+
+        task = asyncio.create_task(consume())
+        for _ in range(10):
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # Let the shielded release task finish
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+    release.assert_awaited_once()
+    assert release.await_args.args[1] == "0xnew"

--- a/tests/unit/test_chat_streaming_failover.py
+++ b/tests/unit/test_chat_streaming_failover.py
@@ -1,0 +1,204 @@
+"""Tests for streaming recovery: provider failover + expired-session renewal."""
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.api.v1.chat import chat_streaming
+from src.db.models import SessionState
+from src.services.proxy_router_service import ProxyRouterServiceError
+
+BODY = json.dumps({"messages": [{"role": "user", "content": "hi"}], "stream": True}).encode()
+
+PROVIDER_DOWN = ProxyRouterServiceError(
+    'HTTP 500: {"error":"provider request failed: failed to connect to provider"}',
+    status_code=500,
+    error_type="server_error",
+)
+SESSION_EXPIRED = ProxyRouterServiceError(
+    'HTTP 500: {"error":"session expired"}', status_code=500, error_type="server_error",
+)
+
+
+class FakeStreamResponse:
+    """Mimics httpx streaming response."""
+
+    def __init__(self, chunks):
+        self.status_code = 200
+        self.headers = {}
+        self._chunks = chunks
+
+    async def aiter_bytes(self):
+        for c in self._chunks:
+            yield c
+
+
+class FakeStreamCM:
+    def __init__(self, outcome):
+        self._outcome = outcome
+
+    async def __aenter__(self):
+        if isinstance(self._outcome, Exception):
+            raise self._outcome
+        return self._outcome
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _stream_cm_factory(outcomes):
+    it = iter(outcomes)
+
+    def factory(**kwargs):
+        return FakeStreamCM(next(it))
+
+    return factory
+
+
+def _fake_get_db():
+    db = AsyncMock()
+
+    class FakeGetDb:
+        async def __aenter__(self):
+            return db
+        async def __aexit__(self, *args):
+            return False
+
+    return lambda: FakeGetDb()
+
+
+@pytest.fixture
+def mock_user():
+    user = MagicMock()
+    user.id = 42
+    return user
+
+
+async def _collect(gen):
+    return [c async for c in gen]
+
+
+def _generator(mock_user):
+    return chat_streaming.build_stream_generator(
+        logger=MagicMock(),
+        session_id="0xdead",
+        body=BODY,
+        requested_model="llama-3.3-70b",
+        model_id="0xmodel",
+        db_api_key=MagicMock(),
+        user=mock_user,
+    )()
+
+
+GOOD_CHUNKS = [b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n', b"data: [DONE]\n\n"]
+
+
+async def test_pre_first_token_provider_failure_fails_over_transparently(mock_user):
+    outcomes = [PROVIDER_DOWN, FakeStreamResponse(GOOD_CHUNKS)]
+    with patch.object(chat_streaming.proxy_router_service, "chatCompletionsStream",
+                      side_effect=_stream_cm_factory(outcomes)), \
+         patch.object(chat_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value="0xnew") as failover, \
+         patch.object(chat_streaming.session_routing_service, "release_session",
+                      new_callable=AsyncMock), \
+         patch.object(chat_streaming, "get_db", _fake_get_db()), \
+         patch.object(chat_streaming, "_stream_cleanup", new_callable=AsyncMock):
+        chunks = await _collect(_generator(mock_user))
+
+    failover.assert_awaited_once()
+    # Client must see ONLY the successful stream — no error chunk.
+    assert chunks == GOOD_CHUNKS
+
+
+async def test_pre_first_token_session_expiry_renews_not_fails_over(mock_user):
+    """Expired session -> renewal mechanism (now reachable), not failover."""
+    outcomes = [SESSION_EXPIRED, FakeStreamResponse(GOOD_CHUNKS)]
+    with patch.object(chat_streaming.proxy_router_service, "chatCompletionsStream",
+                      side_effect=_stream_cm_factory(outcomes)), \
+         patch.object(chat_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock) as failover, \
+         patch.object(chat_streaming.session_routing_service, "invalidate_session",
+                      new_callable=AsyncMock, return_value=True) as invalidate, \
+         patch.object(chat_streaming.session_routing_service, "route_request",
+                      new_callable=AsyncMock, return_value="0xrenewed"), \
+         patch.object(chat_streaming.session_routing_service, "release_session",
+                      new_callable=AsyncMock) as release, \
+         patch.object(chat_streaming, "get_db", _fake_get_db()), \
+         patch.object(chat_streaming, "_stream_cleanup", new_callable=AsyncMock), \
+         patch("asyncio.sleep", new_callable=AsyncMock):
+        chunks = await _collect(_generator(mock_user))
+
+    failover.assert_not_awaited()
+    invalidate.assert_awaited_once()
+    assert invalidate.await_args.kwargs["state"] is SessionState.EXPIRED
+    assert chunks == GOOD_CHUNKS
+    # Renewal session released exactly once (by _handle_session_retry's finally).
+    release.assert_awaited_once()
+    assert release.await_args.args[1] == "0xrenewed"
+
+
+async def test_mid_stream_failure_is_not_retried(mock_user):
+    class ExplodingResponse(FakeStreamResponse):
+        async def aiter_bytes(self):
+            yield GOOD_CHUNKS[0]
+            raise PROVIDER_DOWN
+
+    with patch.object(chat_streaming.proxy_router_service, "chatCompletionsStream",
+                      side_effect=_stream_cm_factory([ExplodingResponse([])])), \
+         patch.object(chat_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock) as failover, \
+         patch.object(chat_streaming, "_stream_cleanup", new_callable=AsyncMock):
+        chunks = await _collect(_generator(mock_user))
+
+    failover.assert_not_awaited()
+    assert chunks[0] == GOOD_CHUNKS[0]
+    assert b"error" in chunks[-1]
+
+
+async def test_failover_impossible_emits_error_chunk(mock_user):
+    with patch.object(chat_streaming.proxy_router_service, "chatCompletionsStream",
+                      side_effect=_stream_cm_factory([PROVIDER_DOWN])), \
+         patch.object(chat_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value=None), \
+         patch.object(chat_streaming, "_stream_cleanup", new_callable=AsyncMock):
+        chunks = await _collect(_generator(mock_user))
+
+    assert len(chunks) == 1
+    assert b"error" in chunks[0]
+
+
+async def test_renewal_route_failure_emits_error_chunk(mock_user):
+    """When renewal can't route a new session, the client must still get an
+    error chunk (previously the stream would just end empty)."""
+    with patch.object(chat_streaming.proxy_router_service, "chatCompletionsStream",
+                      side_effect=_stream_cm_factory([SESSION_EXPIRED])), \
+         patch.object(chat_streaming.session_routing_service, "invalidate_session",
+                      new_callable=AsyncMock, return_value=True), \
+         patch.object(chat_streaming.session_routing_service, "route_request",
+                      new_callable=AsyncMock, side_effect=Exception("no session")), \
+         patch.object(chat_streaming, "get_db", _fake_get_db()), \
+         patch.object(chat_streaming, "_stream_cleanup", new_callable=AsyncMock), \
+         patch("asyncio.sleep", new_callable=AsyncMock):
+        chunks = await _collect(_generator(mock_user))
+
+    assert any(b"error" in c for c in chunks)
+
+
+async def test_failover_retry_failure_emits_error_chunk(mock_user):
+    with patch.object(chat_streaming.proxy_router_service, "chatCompletionsStream",
+                      side_effect=_stream_cm_factory([PROVIDER_DOWN, PROVIDER_DOWN])), \
+         patch.object(chat_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value="0xnew"), \
+         patch.object(chat_streaming.session_routing_service, "release_session",
+                      new_callable=AsyncMock) as release, \
+         patch.object(chat_streaming, "get_db", _fake_get_db()), \
+         patch.object(chat_streaming, "_stream_cleanup", new_callable=AsyncMock):
+        chunks = await _collect(_generator(mock_user))
+
+    assert any(b"error" in c for c in chunks)
+    # New session released exactly once by the failover retry path.
+    release.assert_awaited_once()

--- a/tests/unit/test_session_invalidation.py
+++ b/tests/unit/test_session_invalidation.py
@@ -50,6 +50,7 @@ async def test_invalidate_marks_failed_and_schedules_close(service, mock_db):
     update_stmt = mock_db.execute.await_args.args[0]
     compiled = str(update_stmt.compile(compile_kwargs={"literal_binds": True}))
     assert "FAILED" in compiled
+    assert "state = 'OPEN'" in compiled
 
 
 async def test_invalidate_with_expired_state_for_renewal(service, mock_db):
@@ -95,6 +96,23 @@ async def test_invalidate_survives_close_failure(service, mock_db):
         side_effect=Exception("proxy down"),
     ):
         # Must not raise even though the background close fails
-        await service.invalidate_session(mock_db, "0xdead", "reason")
+        ok = await service.invalidate_session(mock_db, "0xdead", "reason")
         await asyncio.sleep(0)
         await asyncio.sleep(0)
+
+    assert ok is True
+
+
+async def test_invalidate_db_error_rolls_back_and_skips_close(service, mock_db):
+    mock_db.execute.side_effect = Exception("db down")
+
+    with patch(
+        "src.services.session_routing_service.proxy_router_service.closeSession",
+        new_callable=AsyncMock,
+    ) as mock_close:
+        ok = await service.invalidate_session(mock_db, "0xdead", "reason")
+        await asyncio.sleep(0)
+
+    assert ok is False
+    mock_db.rollback.assert_awaited_once()
+    mock_close.assert_not_awaited()

--- a/tests/unit/test_session_invalidation.py
+++ b/tests/unit/test_session_invalidation.py
@@ -1,0 +1,100 @@
+"""Tests for SessionRoutingService.invalidate_session."""
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.db.models import SessionState
+from src.services.session_routing_service import SessionRoutingService
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def service():
+    return SessionRoutingService()
+
+
+def _ok_result():
+    result = MagicMock()
+    result.rowcount = 1
+    return result
+
+
+async def test_invalidate_marks_failed_and_schedules_close(service, mock_db):
+    mock_db.execute.return_value = _ok_result()
+
+    with patch(
+        "src.services.session_routing_service.proxy_router_service.closeSession",
+        new_callable=AsyncMock,
+    ) as mock_close:
+        ok = await service.invalidate_session(mock_db, "0xdead", "provider unreachable")
+        # Let the fire-and-forget close task run
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert ok is True
+    mock_db.execute.assert_awaited_once()
+    mock_db.commit.assert_awaited_once()
+    mock_close.assert_awaited_once_with("0xdead")
+    update_stmt = mock_db.execute.await_args.args[0]
+    compiled = str(update_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "FAILED" in compiled
+
+
+async def test_invalidate_with_expired_state_for_renewal(service, mock_db):
+    mock_db.execute.return_value = _ok_result()
+
+    with patch(
+        "src.services.session_routing_service.proxy_router_service.closeSession",
+        new_callable=AsyncMock,
+    ):
+        await service.invalidate_session(
+            mock_db, "0xdead", "session expired on proxy", state=SessionState.EXPIRED
+        )
+        await asyncio.sleep(0)
+
+    update_stmt = mock_db.execute.await_args.args[0]
+    compiled = str(update_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "EXPIRED" in compiled
+
+
+async def test_invalidate_noop_when_already_not_open(service, mock_db):
+    result = MagicMock()
+    result.rowcount = 0  # row was not OPEN (already FAILED/CLOSED/EXPIRED)
+    mock_db.execute.return_value = result
+
+    with patch(
+        "src.services.session_routing_service.proxy_router_service.closeSession",
+        new_callable=AsyncMock,
+    ) as mock_close:
+        ok = await service.invalidate_session(mock_db, "0xdead", "again")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert ok is False
+    mock_close.assert_not_awaited()
+
+
+async def test_invalidate_survives_close_failure(service, mock_db):
+    mock_db.execute.return_value = _ok_result()
+
+    with patch(
+        "src.services.session_routing_service.proxy_router_service.closeSession",
+        new_callable=AsyncMock,
+        side_effect=Exception("proxy down"),
+    ):
+        # Must not raise even though the background close fails
+        await service.invalidate_session(mock_db, "0xdead", "reason")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
Promotes the current `test` branch to `main`. `main` has no commits absent from `test`; this is a clean fast-forward of accumulated changes.

### API Gateway / provider failover
- feat(chat): add failover eligibility classifier for provider-unavailability errors
- feat(sessions): add `invalidate_session` (FAILED/EXPIRED) with background close
- feat(chat): add `attempt_failover` orchestration (invalidate, bid gate, reroute)
- feat(chat): wire provider failover and fix expired-session retry trigger (streaming + non-streaming)
- fix(chat): cancellation-safe session release in recovery paths
- fix(chat): shield streaming/failover session release against client disconnect
- fix(sessions): hold refs to background close tasks; harden invalidate tests

### Docs
- docs: gateway session recovery (provider failover + expired-session renewal)

### Pricing
- feat(pricing): add pricing for anonymized proprietary models (claude-fable-5, claude-opus-4.8, gemini-3.1-pro-preview, gpt-5.5-pro, gpt-5.5, grok-4.20, plus `:web` variants)

## Test plan
- [ ] Verify gateway failover reroutes on provider-unavailability errors
- [ ] Verify expired-session retry/renewal in streaming and non-streaming paths
- [ ] Verify session release is cancellation/disconnect safe (no leaked open sessions)
- [ ] Verify new model pricing resolves correctly in prod config

Made with [Cursor](https://cursor.com)