### PR TITLE
fix(redis): circuit breaker for cache + rate limiter (instant degrade)

### DIFF
--- a/src/core/circuit_breaker.py
+++ b/src/core/circuit_breaker.py
@@ -1,0 +1,74 @@
+"""Lightweight time-based circuit breaker for optional external dependencies.
+
+Wraps Redis (cache + rate limiting) so a *timeout-mode* outage (blackholed IP,
+hung failover) does not make every request pay repeated multi-second connect
+timeouts. On failure the breaker "opens" for an exponentially backed-off
+cooldown during which callers skip the dependency and degrade immediately
+(`is_open()` → True). A single background re-probe (`run_reprobe`) owns
+recovery, so connection attempts stay off the request path entirely.
+
+The breaker itself is pure and synchronous (trivially unit-testable); the async
+recovery loop is a free function so each service can supply its own probe.
+"""
+import asyncio
+import time
+from typing import Awaitable, Callable
+
+
+class CircuitBreaker:
+    """Pure open/closed state with exponential-backoff cooldown.
+
+    Closed (`is_open()` False): callers may use the dependency.
+    Open  (`is_open()` True):   callers must skip it and degrade.
+    `record_failure()` opens (and lengthens) the cooldown; `record_success()`
+    closes it and resets the backoff.
+    """
+
+    def __init__(self, name: str, initial_backoff: float = 1.0, max_backoff: float = 30.0):
+        self.name = name
+        self._initial = initial_backoff
+        self._max = max_backoff
+        self._failures = 0
+        self._open_until = 0.0  # monotonic deadline
+
+    def is_open(self) -> bool:
+        return time.monotonic() < self._open_until
+
+    @property
+    def cooldown_remaining(self) -> float:
+        return max(0.0, self._open_until - time.monotonic())
+
+    @property
+    def consecutive_failures(self) -> int:
+        return self._failures
+
+    def record_success(self) -> None:
+        self._failures = 0
+        self._open_until = 0.0
+
+    def record_failure(self) -> float:
+        """Open the breaker for the next backoff window. Returns the cooldown (s)."""
+        self._failures += 1
+        backoff = min(self._initial * (2 ** (self._failures - 1)), self._max)
+        self._open_until = time.monotonic() + backoff
+        return backoff
+
+
+async def run_reprobe(
+    breaker: CircuitBreaker,
+    probe: Callable[[], Awaitable[bool]],
+) -> None:
+    """Background recovery loop: wait out the cooldown, probe once, repeat until
+    the probe succeeds — keeping reconnection attempts off the request path.
+
+    `probe` must itself update the breaker (success closes it, failure re-opens
+    with a longer cooldown); this loop only paces the attempts. Designed to be
+    run as a task and cancelled on shutdown.
+    """
+    while breaker.is_open():
+        await asyncio.sleep(max(breaker.cooldown_remaining, 0.05))
+        if breaker.is_open():
+            # Re-opened (or not yet due) — keep waiting rather than probing early.
+            continue
+        if await probe():
+            return

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -261,6 +261,11 @@ class Settings(BaseSettings):
     REDIS_MAX_CONNECTIONS: int = Field(default=int(os.getenv("REDIS_MAX_CONNECTIONS", "20")))
     REDIS_SOCKET_TIMEOUT: float = Field(default=float(os.getenv("REDIS_SOCKET_TIMEOUT", "5.0")))
     REDIS_SOCKET_CONNECT_TIMEOUT: float = Field(default=float(os.getenv("REDIS_SOCKET_CONNECT_TIMEOUT", "5.0")))
+    # Rate-limit checks sit on the hot path and fail open, so they use much
+    # tighter Redis timeouts than the cache: a limiter call must never be allowed
+    # to block for seconds before degrading.
+    RATE_LIMIT_REDIS_SOCKET_TIMEOUT: float = Field(default=float(os.getenv("RATE_LIMIT_REDIS_SOCKET_TIMEOUT", "1.0")))
+    RATE_LIMIT_REDIS_SOCKET_CONNECT_TIMEOUT: float = Field(default=float(os.getenv("RATE_LIMIT_REDIS_SOCKET_CONNECT_TIMEOUT", "0.5")))
     
     # Cache Settings
     # Enable Redis caching for API keys, users, sessions, and JWKS

--- a/src/main.py
+++ b/src/main.py
@@ -427,7 +427,25 @@ async def startup_event():
             logger.warning("Continuing startup without rate limiting")
     else:
         logger.info("Rate limiting is disabled", event_type="rate_limit_disabled")
-    
+
+    # Initialize Redis cache service (eager, so the connection/circuit-breaker is
+    # established at startup instead of lazily on the first request). Safe to call
+    # when CACHE_ENABLED=false (it no-ops) and never blocks startup on a Redis
+    # outage — a failed connect just opens the circuit and degrades to the DB.
+    if settings.CACHE_ENABLED:
+        try:
+            cache_ok = await cache_service.initialize()
+            logger.info("Redis cache service initialization attempted",
+                       connected=cache_ok,
+                       event_type="cache_init_attempt")
+        except Exception as e:
+            logger.error("Failed to initialize Redis cache service",
+                        error=str(e),
+                        event_type="cache_init_error")
+            logger.warning("Continuing startup with cache degraded to DB")
+    else:
+        logger.info("Redis caching is disabled", event_type="cache_disabled")
+
     logger.info("Application startup complete", event_type="startup_complete")
 
 @app.on_event("shutdown")

--- a/src/services/cache_service.py
+++ b/src/services/cache_service.py
@@ -8,18 +8,27 @@ Provides read-through caching for frequently accessed database entities:
 - JWKS (for JWT validation)
 
 Uses the same Redis instance as rate limiting for efficient resource usage.
+
+Resilience: a circuit breaker guards every Redis access. During a timeout-mode
+Redis outage the breaker opens after the first failure and all cache operations
+degrade to a cache miss *immediately* (no per-request connect timeouts, no
+global init lock contention). A single background task re-probes Redis with
+exponential backoff and closes the breaker on recovery, so reconnection attempts
+never run on the request path. Callers already treat a miss/None as "go to the
+database", so this is correctness-safe.
 """
 
 import json
 import asyncio
 from typing import Optional, Any, Dict, Callable, TypeVar
 from contextlib import asynccontextmanager
-from datetime import timedelta
 
 import redis.asyncio as aioredis
 from redis.asyncio import ConnectionPool
+from redis.exceptions import RedisError
 
 from src.core.config import settings
+from src.core.circuit_breaker import CircuitBreaker, run_reprobe
 from src.core.logging_config import get_core_logger
 
 logger = get_core_logger()
@@ -30,15 +39,15 @@ T = TypeVar('T')
 class CacheService:
     """
     Redis-based caching service with read-through pattern support.
-    
+
     Features:
     - Automatic cache-aside (read-through) pattern
     - Configurable TTLs per entity type
-    - Graceful degradation on Redis failures
+    - Circuit-breaker graceful degradation on Redis failures
     - Shared connection pool with rate limiter
     - JSON serialization for complex objects
     """
-    
+
     # Default TTLs for different entity types (in seconds)
     DEFAULT_TTLS = {
         "api_key": 300,      # 5 minutes - frequently used, rarely changes
@@ -46,13 +55,17 @@ class CacheService:
         "session": 300,      # 5 minutes - matches session check frequency
         "jwks": 3600,        # 1 hour - JWKS keys rarely change
     }
-    
+
     def __init__(self):
         self._pool: Optional[ConnectionPool] = None
         self._redis: Optional[aioredis.Redis] = None
         self._initialized = False
         self._initialization_lock = asyncio.Lock()
-        
+
+        # Circuit breaker: open => skip Redis entirely and degrade to DB.
+        self._breaker = CircuitBreaker("cache", initial_backoff=1.0, max_backoff=30.0)
+        self._reprobe_task: Optional[asyncio.Task] = None
+
         # Track cache stats for monitoring
         self._stats = {
             "hits": 0,
@@ -60,95 +73,173 @@ class CacheService:
             "errors": 0,
             "sets": 0,
         }
-    
-    async def initialize(self) -> bool:
-        """
-        Initialize Redis connection pool.
-        
-        Returns:
-            True if initialization was successful
-        """
-        async with self._initialization_lock:
-            if self._initialized:
-                return True
-            
-            # Check if caching is enabled
-            if not settings.CACHE_ENABLED:
-                logger.info(
-                    "Redis caching is disabled (CACHE_ENABLED=false)",
-                    event_type="cache_disabled",
-                )
-                self._initialized = False
-                return False
-            
-            try:
-                # Reuse the same Redis URL and connection settings as rate limiter
+
+    # ------------------------------------------------------------------ #
+    # Connection lifecycle + circuit breaker
+    # ------------------------------------------------------------------ #
+
+    async def _connect_locked(self) -> bool:
+        """Build (once) or reuse the pool and verify the connection. Assumes the
+        init lock is held. Returns True on success. Does not touch the breaker."""
+        try:
+            if self._pool is None:
+                # Pool is built once and reused — redis-py reconnects on demand,
+                # so we must not rebuild it per attempt (that was pure churn).
                 self._pool = ConnectionPool.from_url(
                     settings.REDIS_URL,
                     max_connections=settings.REDIS_MAX_CONNECTIONS,
                     socket_timeout=settings.REDIS_SOCKET_TIMEOUT,
                     socket_connect_timeout=settings.REDIS_SOCKET_CONNECT_TIMEOUT,
-                    decode_responses=True,  # Automatically decode responses to strings
+                    decode_responses=True,
+                    health_check_interval=30,  # recycle stale sockets after a failover
+                    retry_on_timeout=True,
                 )
-                
-                self._redis = aioredis.Redis(connection_pool=self._pool)
-                
-                # Test connection
-                await self._redis.ping()
-                
-                self._initialized = True
-                logger.info(
-                    "Redis cache service initialized",
-                    redis_url=settings.REDIS_URL.split("@")[-1],  # Hide password
-                    event_type="cache_service_init",
-                )
+            self._redis = aioredis.Redis(connection_pool=self._pool)
+            await self._redis.ping()
+            self._initialized = True
+            return True
+        except Exception as e:
+            # Critical: drop the broken client so it is never yielded to callers
+            # (otherwise the op pays a second connect timeout before degrading).
+            self._redis = None
+            self._initialized = False
+            logger.error(
+                "Failed to connect Redis cache service",
+                error=str(e),
+                event_type="cache_service_init_error",
+            )
+            return False
+
+    async def _attempt_locked(self) -> bool:
+        """Connect (if needed) and update the breaker, under the init lock."""
+        if self._initialized and self._redis is not None:
+            return True
+        ok = await self._connect_locked()
+        if ok:
+            self._breaker.record_success()
+        else:
+            self._breaker.record_failure()
+        return ok
+
+    async def initialize(self) -> bool:
+        """
+        Initialize the Redis connection pool. Safe to call once at startup; also
+        used as the single-flight (re)connect on the request path.
+
+        Returns True if a usable connection is established.
+        """
+        if not settings.CACHE_ENABLED:
+            logger.info(
+                "Redis caching is disabled (CACHE_ENABLED=false)",
+                event_type="cache_disabled",
+            )
+            return False
+
+        async with self._initialization_lock:
+            if self._initialized:
                 return True
-                
-            except Exception as e:
-                logger.error(
-                    "Failed to initialize Redis cache service",
-                    error=str(e),
-                    event_type="cache_service_init_error",
-                )
-                self._initialized = False
+            # Breaker open: a recent attempt already failed — don't dial again here.
+            if self._breaker.is_open():
                 return False
-    
+            ok = await self._attempt_locked()
+
+        if ok:
+            logger.info(
+                "Redis cache service initialized",
+                redis_url=settings.REDIS_URL.split("@")[-1],  # Hide password
+                event_type="cache_service_init",
+            )
+        else:
+            self._ensure_reprobe()
+            logger.warning(
+                "Redis cache unavailable; circuit opened, degrading to DB",
+                retry_in=round(self._breaker.cooldown_remaining, 1),
+                event_type="cache_circuit_open",
+            )
+        return ok
+
+    async def _probe(self) -> bool:
+        """Background re-probe used by run_reprobe; updates the breaker."""
+        try:
+            async with self._initialization_lock:
+                return await self._attempt_locked()
+        except Exception:
+            return False
+
+    def _ensure_reprobe(self) -> None:
+        """Start the single background recovery loop if not already running."""
+        if self._reprobe_task is not None and not self._reprobe_task.done():
+            return
+        try:
+            self._reprobe_task = asyncio.create_task(run_reprobe(self._breaker, self._probe))
+        except RuntimeError:
+            # No running loop (e.g. called outside async context) — recovery will
+            # be retried on the next request-path initialize() instead.
+            self._reprobe_task = None
+
+    def _note_op_error(self, error: Exception) -> None:
+        """Trip the breaker on a connectivity error so subsequent ops short-circuit."""
+        if not isinstance(error, (RedisError, OSError, asyncio.TimeoutError)):
+            return  # not a connectivity failure (e.g. JSON) — leave Redis in place
+        if self._breaker.is_open():
+            return
+        self._redis = None
+        self._initialized = False
+        backoff = self._breaker.record_failure()
+        self._ensure_reprobe()
+        logger.warning(
+            "Redis cache circuit opened after operation failure",
+            retry_in=round(backoff, 1),
+            error=str(error),
+            event_type="cache_circuit_open",
+        )
+
+    async def _acquire_redis(self) -> Optional[aioredis.Redis]:
+        """Return a usable client, or None to signal 'degrade to DB' — never dials
+        while the breaker is open."""
+        if not settings.CACHE_ENABLED:
+            return None
+        if self._breaker.is_open():
+            return None
+        if self._initialized and self._redis is not None:
+            return self._redis
+        await self.initialize()
+        return self._redis if self._initialized else None
+
     async def close(self) -> None:
-        """Close Redis connections."""
+        """Close Redis connections and stop the recovery loop."""
+        if self._reprobe_task is not None and not self._reprobe_task.done():
+            self._reprobe_task.cancel()
+            try:
+                await self._reprobe_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._reprobe_task = None
         if self._redis:
             await self._redis.close()
         if self._pool:
             await self._pool.disconnect()
         self._initialized = False
         logger.info("Redis cache service closed", event_type="cache_service_close")
-    
+
     @asynccontextmanager
     async def _get_redis(self):
-        """Get Redis connection with lazy initialization."""
-        if not self._initialized:
-            await self.initialize()
-        
-        if not self._redis:
-            # Caching is disabled or initialization failed
-            # Return None to allow graceful degradation
-            yield None
-            return
-        
-        yield self._redis
-    
+        """Yield a usable Redis client, or None when caching is unavailable."""
+        yield await self._acquire_redis()
+
     def _make_key(self, entity_type: str, identifier: str) -> str:
         """
         Generate Redis key for caching.
-        
+
         Args:
             entity_type: Type of entity (api_key, user, session, etc.)
             identifier: Unique identifier for the entity
-            
+
         Returns:
             Redis key string
         """
         return f"cache:{entity_type}:{identifier}"
-    
+
     async def get(
         self,
         entity_type: str,
@@ -156,23 +247,23 @@ class CacheService:
     ) -> Optional[Dict[str, Any]]:
         """
         Get a cached entity.
-        
+
         Args:
             entity_type: Type of entity
             identifier: Unique identifier
-            
+
         Returns:
             Cached data as dict, or None if not found
         """
         try:
             async with self._get_redis() as redis:
                 if redis is None:
-                    # Caching disabled - return cache miss
+                    # Caching disabled or circuit open - return cache miss
                     return None
-                
+
                 key = self._make_key(entity_type, identifier)
                 data = await redis.get(key)
-                
+
                 if data:
                     self._stats["hits"] += 1
                     logger.debug(
@@ -191,9 +282,10 @@ class CacheService:
                         event_type="cache_miss",
                     )
                     return None
-                    
+
         except Exception as e:
             self._stats["errors"] += 1
+            self._note_op_error(e)
             logger.warning(
                 "Cache get failed, returning None",
                 entity_type=entity_type,
@@ -203,7 +295,7 @@ class CacheService:
             )
             # Fail gracefully - return None on errors
             return None
-    
+
     async def set(
         self,
         entity_type: str,
@@ -213,33 +305,33 @@ class CacheService:
     ) -> bool:
         """
         Set a cached entity.
-        
+
         Args:
             entity_type: Type of entity
             identifier: Unique identifier
             data: Data to cache (must be JSON-serializable)
             ttl_seconds: Optional TTL override (uses default if not provided)
-            
+
         Returns:
             True if successful
         """
         try:
             async with self._get_redis() as redis:
                 if redis is None:
-                    # Caching disabled - return success without caching
+                    # Caching disabled or circuit open - return success without caching
                     return True
-                
+
                 key = self._make_key(entity_type, identifier)
-                
+
                 # Use entity-specific TTL or provided override
                 ttl = ttl_seconds or self.DEFAULT_TTLS.get(entity_type, 300)
-                
+
                 # Serialize to JSON
                 serialized = json.dumps(data)
-                
+
                 # Set with TTL
                 await redis.setex(key, ttl, serialized)
-                
+
                 self._stats["sets"] += 1
                 logger.debug(
                     "Cache set",
@@ -249,9 +341,10 @@ class CacheService:
                     event_type="cache_set",
                 )
                 return True
-                
+
         except Exception as e:
             self._stats["errors"] += 1
+            self._note_op_error(e)
             logger.warning(
                 "Cache set failed",
                 entity_type=entity_type,
@@ -261,7 +354,7 @@ class CacheService:
             )
             # Fail gracefully - don't raise on cache errors
             return False
-    
+
     async def delete(
         self,
         entity_type: str,
@@ -269,23 +362,23 @@ class CacheService:
     ) -> bool:
         """
         Delete a cached entity (cache invalidation).
-        
+
         Args:
             entity_type: Type of entity
             identifier: Unique identifier
-            
+
         Returns:
             True if successful
         """
         try:
             async with self._get_redis() as redis:
                 if redis is None:
-                    # Caching disabled - return success
+                    # Caching disabled or circuit open - return success
                     return True
-                
+
                 key = self._make_key(entity_type, identifier)
                 await redis.delete(key)
-                
+
                 logger.debug(
                     "Cache deleted",
                     entity_type=entity_type,
@@ -293,8 +386,9 @@ class CacheService:
                     event_type="cache_delete",
                 )
                 return True
-                
+
         except Exception as e:
+            self._note_op_error(e)
             logger.warning(
                 "Cache delete failed",
                 entity_type=entity_type,
@@ -303,7 +397,7 @@ class CacheService:
                 event_type="cache_delete_error",
             )
             return False
-    
+
     async def get_or_fetch(
         self,
         entity_type: str,
@@ -314,17 +408,17 @@ class CacheService:
     ) -> Optional[Any]:
         """
         Read-through cache pattern: Get from cache, or fetch and cache.
-        
+
         This is the main method to use for caching - it implements the full
         read-through pattern with automatic cache population.
-        
+
         Args:
             entity_type: Type of entity
             identifier: Unique identifier
             fetch_fn: Async function to fetch data on cache miss
             serializer: Optional function to serialize fetched data for caching
             ttl_seconds: Optional TTL override
-            
+
         Returns:
             The entity (either from cache or freshly fetched)
         """
@@ -334,15 +428,15 @@ class CacheService:
             # Cache hit - return cached data
             # Note: Data is already deserialized from JSON
             return cached
-        
+
         # Cache miss - fetch from source
         try:
             fetched = await fetch_fn()
-            
+
             if fetched is None:
                 # Source returned None - don't cache
                 return None
-            
+
             # Serialize for caching if serializer provided
             if serializer:
                 cache_data = serializer(fetched)
@@ -357,12 +451,12 @@ class CacheService:
                     event_type="cache_skip_no_serializer",
                 )
                 return fetched
-            
+
             # Cache the fetched data
             await self.set(entity_type, identifier, cache_data, ttl_seconds)
-            
+
             return fetched
-            
+
         except Exception as e:
             logger.error(
                 "Fetch function failed in read-through cache",
@@ -372,28 +466,32 @@ class CacheService:
             )
             # Return None on fetch errors
             return None
-    
+
     async def invalidate_pattern(self, pattern: str) -> int:
         """
         Invalidate all keys matching a pattern.
-        
+
         WARNING: Use sparingly - SCAN can be expensive on large datasets.
-        
+
         Args:
             pattern: Redis key pattern (e.g., "cache:user:*")
-            
+
         Returns:
             Number of keys deleted
         """
         try:
             async with self._get_redis() as redis:
+                if redis is None:
+                    # Caching disabled or circuit open - nothing to invalidate
+                    return 0
+
                 deleted = 0
-                
+
                 # Use SCAN to avoid blocking Redis
                 async for key in redis.scan_iter(match=pattern):
                     await redis.delete(key)
                     deleted += 1
-                
+
                 logger.info(
                     "Cache pattern invalidated",
                     pattern=pattern,
@@ -401,8 +499,9 @@ class CacheService:
                     event_type="cache_pattern_invalidate",
                 )
                 return deleted
-                
+
         except Exception as e:
+            self._note_op_error(e)
             logger.error(
                 "Cache pattern invalidation failed",
                 pattern=pattern,
@@ -410,7 +509,7 @@ class CacheService:
                 event_type="cache_pattern_invalidate_error",
             )
             return 0
-    
+
     def get_stats(self) -> Dict[str, int]:
         """Get cache statistics."""
         total_requests = self._stats["hits"] + self._stats["misses"]
@@ -419,32 +518,50 @@ class CacheService:
             if total_requests > 0
             else 0
         )
-        
+
         return {
             **self._stats,
             "total_requests": total_requests,
             "hit_rate_percent": round(hit_rate, 2),
         }
-    
+
     async def health_check(self) -> Dict[str, Any]:
         """
-        Check Redis cache health.
-        
-        Returns:
-            Health status dictionary
+        Check Redis cache health. Returns fast (no dial) while the circuit is open
+        so /health probes never hang on a Redis outage.
         """
+        if not settings.CACHE_ENABLED:
+            return {"status": "disabled", "connected": False, "stats": self.get_stats()}
+
+        if self._breaker.is_open():
+            return {
+                "status": "degraded",
+                "connected": False,
+                "circuit": "open",
+                "retry_in_seconds": round(self._breaker.cooldown_remaining, 1),
+                "stats": self.get_stats(),
+            }
+
         try:
-            async with self._get_redis() as redis:
-                await redis.ping()
-                info = await redis.info("memory")
-                
+            redis = await self._acquire_redis()
+            if redis is None:
                 return {
-                    "status": "healthy",
-                    "connected": True,
-                    "used_memory": info.get("used_memory_human", "unknown"),
+                    "status": "degraded",
+                    "connected": False,
+                    "circuit": "open",
                     "stats": self.get_stats(),
                 }
+            await redis.ping()
+            info = await redis.info("memory")
+
+            return {
+                "status": "healthy",
+                "connected": True,
+                "used_memory": info.get("used_memory_human", "unknown"),
+                "stats": self.get_stats(),
+            }
         except Exception as e:
+            self._note_op_error(e)
             return {
                 "status": "unhealthy",
                 "connected": False,

--- a/src/services/rate_limiting/redis_limiter.py
+++ b/src/services/rate_limiting/redis_limiter.py
@@ -3,6 +3,15 @@ Redis Rate Limiter
 
 Implements sliding window rate limiting using Redis for distributed rate tracking.
 Supports both RPM (requests per minute) and TPM (tokens per minute) limits.
+
+Resilience: a circuit breaker guards every Redis access. The limiter already
+fails open by design, so during a timeout-mode Redis outage the breaker opens
+after the first failure and every check returns "allowed" *immediately* — no
+per-request connect timeouts, no global init lock contention on the hot path.
+A single background task re-probes Redis with exponential backoff and closes the
+breaker on recovery, so reconnection attempts never run on the request path.
+The limiter also uses much tighter socket timeouts than the cache (a rate-limit
+check must never be allowed to block for seconds).
 """
 
 import time
@@ -12,8 +21,10 @@ from contextlib import asynccontextmanager
 
 import redis.asyncio as aioredis
 from redis.asyncio import ConnectionPool
+from redis.exceptions import RedisError
 
 from src.core.config import settings
+from src.core.circuit_breaker import CircuitBreaker, run_reprobe
 from src.core.logging_config import get_core_logger
 
 from .types import RateLimitConfig
@@ -79,102 +90,182 @@ return {current + increment, 1, ttl}
 class RedisRateLimiter:
     """
     Redis-based rate limiter using sliding window algorithm.
-    
+
     Provides:
     - Atomic rate limit checks using Lua scripts
     - Support for both RPM and TPM limits
-    - Graceful degradation on Redis failures
+    - Circuit-breaker graceful degradation on Redis failures (fail open)
     - Connection pooling for efficiency
     """
-    
+
     def __init__(self):
         self._pool: Optional[ConnectionPool] = None
         self._redis: Optional[aioredis.Redis] = None
         self._script_sha: Optional[str] = None
         self._initialized = False
         self._initialization_lock = asyncio.Lock()
-    
+
+        # Circuit breaker: open => skip Redis and fail open immediately.
+        self._breaker = CircuitBreaker("rate_limiter", initial_backoff=0.5, max_backoff=10.0)
+        self._reprobe_task: Optional[asyncio.Task] = None
+
+    # ------------------------------------------------------------------ #
+    # Connection lifecycle + circuit breaker
+    # ------------------------------------------------------------------ #
+
+    async def _connect_locked(self) -> bool:
+        """Build (once) or reuse the pool, verify it, and load the Lua script.
+        Assumes the init lock is held. Returns True on success."""
+        try:
+            if self._pool is None:
+                # Pool is built once and reused — redis-py reconnects on demand,
+                # so we must not rebuild it per attempt.
+                self._pool = ConnectionPool.from_url(
+                    settings.REDIS_URL,
+                    max_connections=settings.REDIS_MAX_CONNECTIONS,
+                    socket_timeout=settings.RATE_LIMIT_REDIS_SOCKET_TIMEOUT,
+                    socket_connect_timeout=settings.RATE_LIMIT_REDIS_SOCKET_CONNECT_TIMEOUT,
+                    decode_responses=True,
+                    health_check_interval=30,
+                    retry_on_timeout=True,
+                )
+            self._redis = aioredis.Redis(connection_pool=self._pool)
+            await self._redis.ping()
+            self._script_sha = await self._redis.script_load(FIXED_WINDOW_SCRIPT)
+            self._initialized = True
+            return True
+        except Exception as e:
+            # Drop the broken client so it is never yielded to the request path.
+            self._redis = None
+            self._initialized = False
+            logger.error(
+                "Failed to connect Redis rate limiter",
+                error=str(e),
+                event_type="redis_limiter_init_error",
+            )
+            return False
+
+    async def _attempt_locked(self) -> bool:
+        """Connect (if needed) and update the breaker, under the init lock."""
+        if self._initialized and self._redis is not None:
+            return True
+        ok = await self._connect_locked()
+        if ok:
+            self._breaker.record_success()
+        else:
+            self._breaker.record_failure()
+        return ok
+
     async def initialize(self) -> bool:
         """
-        Initialize Redis connection pool.
-        
-        Returns:
-            True if initialization was successful
+        Initialize the Redis connection pool. Safe to call at startup; also used
+        as the single-flight (re)connect on the request path.
+
+        Returns True if a usable connection is established.
         """
         async with self._initialization_lock:
             if self._initialized:
                 return True
-            
-            try:
-                self._pool = ConnectionPool.from_url(
-                    settings.REDIS_URL,
-                    max_connections=settings.REDIS_MAX_CONNECTIONS,
-                    socket_timeout=settings.REDIS_SOCKET_TIMEOUT,
-                    socket_connect_timeout=settings.REDIS_SOCKET_CONNECT_TIMEOUT,
-                    decode_responses=True,
-                )
-                
-                self._redis = aioredis.Redis(connection_pool=self._pool)
-                
-                # Test connection
-                await self._redis.ping()
-                
-                # Load Lua script
-                self._script_sha = await self._redis.script_load(FIXED_WINDOW_SCRIPT)
-                
-                self._initialized = True
-                logger.info(
-                    "Redis rate limiter initialized",
-                    redis_url=settings.REDIS_URL.split("@")[-1],  # Hide password
-                    event_type="redis_limiter_init",
-                )
-                return True
-                
-            except Exception as e:
-                logger.error(
-                    "Failed to initialize Redis rate limiter",
-                    error=str(e),
-                    event_type="redis_limiter_init_error",
-                )
-                self._initialized = False
+            if self._breaker.is_open():
                 return False
-    
+            ok = await self._attempt_locked()
+
+        if ok:
+            logger.info(
+                "Redis rate limiter initialized",
+                redis_url=settings.REDIS_URL.split("@")[-1],  # Hide password
+                event_type="redis_limiter_init",
+            )
+        else:
+            self._ensure_reprobe()
+            logger.warning(
+                "Redis rate limiter unavailable; circuit opened, failing open",
+                retry_in=round(self._breaker.cooldown_remaining, 1),
+                event_type="redis_limiter_circuit_open",
+            )
+        return ok
+
+    async def _probe(self) -> bool:
+        """Background re-probe used by run_reprobe; updates the breaker."""
+        try:
+            async with self._initialization_lock:
+                return await self._attempt_locked()
+        except Exception:
+            return False
+
+    def _ensure_reprobe(self) -> None:
+        """Start the single background recovery loop if not already running."""
+        if self._reprobe_task is not None and not self._reprobe_task.done():
+            return
+        try:
+            self._reprobe_task = asyncio.create_task(run_reprobe(self._breaker, self._probe))
+        except RuntimeError:
+            self._reprobe_task = None
+
+    def _note_op_error(self, error: Exception) -> None:
+        """Trip the breaker on a connectivity error so subsequent checks fail open fast."""
+        if not isinstance(error, (RedisError, OSError, asyncio.TimeoutError)):
+            return
+        if self._breaker.is_open():
+            return
+        self._redis = None
+        self._initialized = False
+        backoff = self._breaker.record_failure()
+        self._ensure_reprobe()
+        logger.warning(
+            "Redis rate limiter circuit opened after operation failure",
+            retry_in=round(backoff, 1),
+            error=str(error),
+            event_type="redis_limiter_circuit_open",
+        )
+
+    async def _acquire_redis(self) -> Optional[aioredis.Redis]:
+        """Return a usable client, or None to signal 'fail open' — never dials
+        while the breaker is open."""
+        if self._breaker.is_open():
+            return None
+        if self._initialized and self._redis is not None:
+            return self._redis
+        await self.initialize()
+        return self._redis if self._initialized else None
+
     async def close(self) -> None:
-        """Close Redis connections."""
+        """Close Redis connections and stop the recovery loop."""
+        if self._reprobe_task is not None and not self._reprobe_task.done():
+            self._reprobe_task.cancel()
+            try:
+                await self._reprobe_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._reprobe_task = None
         if self._redis:
             await self._redis.close()
         if self._pool:
             await self._pool.disconnect()
         self._initialized = False
         logger.info("Redis rate limiter closed", event_type="redis_limiter_close")
-    
+
     @asynccontextmanager
     async def _get_redis(self):
-        """Get Redis connection with lazy initialization."""
-        if not self._initialized:
-            await self.initialize()
-        
-        if not self._redis:
-            raise RuntimeError("Redis not initialized")
-        
-        yield self._redis
-    
+        """Yield a usable Redis client, or None when the limiter is degraded."""
+        yield await self._acquire_redis()
+
     def _get_key(self, user_id: str, key_type: str, model_group: Optional[str] = None) -> str:
         """
         Generate Redis key for rate limiting.
-        
+
         Args:
             user_id: The user identifier
             key_type: Either 'rpm' or 'tpm'
             model_group: Optional model group name
-            
+
         Returns:
             Redis key string
         """
         if model_group:
             return f"ratelimit:{key_type}:{model_group}:{user_id}"
         return f"ratelimit:{key_type}:{user_id}"
-    
+
     async def check_and_increment_rpm(
         self,
         user_id: str,
@@ -184,31 +275,35 @@ class RedisRateLimiter:
     ) -> Tuple[int, int, bool]:
         """
         Check and increment the RPM counter.
-        
+
         Args:
             user_id: The user identifier
             config: Rate limit configuration
             model_group: Optional model group for separate limits
             request_id: Unique identifier for this request
-            
+
         Returns:
             Tuple of (current_count, limit, allowed)
         """
         try:
             async with self._get_redis() as redis:
+                if redis is None:
+                    # Degraded (circuit open) - fail open
+                    return 0, config.rpm, True
+
                 key = self._get_key(user_id, "rpm", model_group)
-                
+
                 # Use fixed window boundaries aligned to clock intervals
                 # This ensures the window resets at predictable times (e.g., start of each minute)
                 current_time_seconds = int(time.time())
                 window_start_seconds = (current_time_seconds // config.window_seconds) * config.window_seconds
-                
+
                 # Convert to milliseconds for Redis storage
                 current_time = int(time.time() * 1000)
                 window_start = window_start_seconds * 1000  # Window boundary in milliseconds
-                
+
                 entry_id = request_id or str(current_time)
-                
+
                 result = await redis.evalsha(
                     self._script_sha,
                     1,  # Number of keys
@@ -220,11 +315,12 @@ class RedisRateLimiter:
                     entry_id,
                     str(config.window_seconds + 10),  # TTL with buffer
                 )
-                
+
                 current_count, allowed, _ = result
                 return int(current_count), config.rpm, bool(allowed)
-                
+
         except Exception as e:
+            self._note_op_error(e)
             logger.warning(
                 "RPM check failed, allowing request",
                 error=str(e),
@@ -233,7 +329,7 @@ class RedisRateLimiter:
             )
             # Fail open - allow the request if Redis fails
             return 0, config.rpm, True
-    
+
     async def add_tokens(
         self,
         user_id: str,
@@ -244,34 +340,39 @@ class RedisRateLimiter:
     ) -> bool:
         """
         Add tokens to the TPM counter without checking limits.
-        
+
         Used to record actual token usage after a request completes.
-        
+
         Args:
             user_id: The user identifier
             token_count: Number of tokens to add
             config: Rate limit configuration
             model_group: Optional model group
             request_id: Unique identifier for this request
-            
+
         Returns:
             True if successful
         """
         try:
             async with self._get_redis() as redis:
+                if redis is None:
+                    # Degraded (circuit open) - skip recording
+                    return False
+
                 key = self._get_key(user_id, "tpm", model_group)
                 current_time = int(time.time() * 1000)
                 entry_id = f"{request_id or current_time}:actual"
-                
+
                 # Add tokens with timestamp as score, token count in member name
                 # Member format: "token_count:entry_id:timestamp"
                 member = f"{token_count}:{entry_id}:{current_time}"
                 await redis.zadd(key, {member: current_time})
                 await redis.expire(key, config.window_seconds + 10)
-                
+
                 return True
-                
+
         except Exception as e:
+            self._note_op_error(e)
             logger.warning(
                 "Failed to add tokens",
                 error=str(e),
@@ -280,7 +381,7 @@ class RedisRateLimiter:
                 event_type="add_tokens_error",
             )
             return False
-    
+
     async def get_current_usage(
         self,
         user_id: str,
@@ -289,40 +390,44 @@ class RedisRateLimiter:
     ) -> Tuple[int, int]:
         """
         Get current usage counts without incrementing.
-        
+
         Args:
             user_id: The user identifier
             config: Rate limit configuration
             model_group: Optional model group
-            
+
         Returns:
             Tuple of (rpm_current, tpm_current)
         """
         try:
             async with self._get_redis() as redis:
+                if redis is None:
+                    # Degraded (circuit open) - report no usage
+                    return 0, 0
+
                 # Use fixed window boundaries aligned to clock intervals
                 current_time_seconds = int(time.time())
                 window_start_seconds = (current_time_seconds // config.window_seconds) * config.window_seconds
                 window_start = window_start_seconds * 1000  # Convert to milliseconds
-                
+
                 rpm_key = self._get_key(user_id, "rpm", model_group)
                 tpm_key = self._get_key(user_id, "tpm", model_group)
-                
+
                 # Clean up old entries (before current window) and get members
                 pipe = redis.pipeline()
                 pipe.zremrangebyscore(rpm_key, 0, window_start - 1)  # Remove entries before window start
                 pipe.zremrangebyscore(tpm_key, 0, window_start - 1)
                 pipe.zrange(rpm_key, 0, -1)  # Get all RPM members
                 pipe.zrange(tpm_key, 0, -1)  # Get all TPM members
-                
+
                 results = await pipe.execute()
-                
+
                 rpm_members = results[2] or []
                 tpm_members = results[3] or []
-                
+
                 # For RPM, each entry represents 1 request
                 rpm_count = len(rpm_members)
-                
+
                 # For TPM, parse increment from member names (format: "increment:entry_id:timestamp")
                 tpm_count = 0
                 for member in tpm_members:
@@ -332,10 +437,11 @@ class RedisRateLimiter:
                     except (ValueError, IndexError):
                         # Fallback: count as 1 if parsing fails
                         tpm_count += 1
-                
+
                 return int(rpm_count), int(tpm_count)
-                
+
         except Exception as e:
+            self._note_op_error(e)
             logger.warning(
                 "Failed to get current usage",
                 error=str(e),
@@ -343,7 +449,7 @@ class RedisRateLimiter:
                 event_type="get_usage_error",
             )
             return 0, 0
-    
+
     async def reset_user_limits(
         self,
         user_id: str,
@@ -351,21 +457,24 @@ class RedisRateLimiter:
     ) -> bool:
         """
         Reset rate limits for a user.
-        
+
         Args:
             user_id: The user identifier
             model_group: Optional model group
-            
+
         Returns:
             True if successful
         """
         try:
             async with self._get_redis() as redis:
+                if redis is None:
+                    return False
+
                 rpm_key = self._get_key(user_id, "rpm", model_group)
                 tpm_key = self._get_key(user_id, "tpm", model_group)
-                
+
                 await redis.delete(rpm_key, tpm_key)
-                
+
                 logger.info(
                     "User rate limits reset",
                     user_id=user_id,
@@ -373,8 +482,9 @@ class RedisRateLimiter:
                     event_type="rate_limits_reset",
                 )
                 return True
-                
+
         except Exception as e:
+            self._note_op_error(e)
             logger.error(
                 "Failed to reset user limits",
                 error=str(e),
@@ -382,26 +492,35 @@ class RedisRateLimiter:
                 event_type="reset_limits_error",
             )
             return False
-    
+
     async def health_check(self) -> dict:
         """
-        Check Redis health status.
-        
-        Returns:
-            Health status dictionary
+        Check Redis health status. Returns fast (no dial) while the circuit is
+        open so /health probes never hang on a Redis outage.
         """
+        if self._breaker.is_open():
+            return {
+                "status": "degraded",
+                "connected": False,
+                "circuit": "open",
+                "retry_in_seconds": round(self._breaker.cooldown_remaining, 1),
+            }
+
         try:
-            async with self._get_redis() as redis:
-                await redis.ping()
-                info = await redis.info("memory")
-                
-                return {
-                    "status": "healthy",
-                    "connected": True,
-                    "used_memory": info.get("used_memory_human", "unknown"),
-                    "max_memory": info.get("maxmemory_human", "unknown"),
-                }
+            redis = await self._acquire_redis()
+            if redis is None:
+                return {"status": "degraded", "connected": False, "circuit": "open"}
+            await redis.ping()
+            info = await redis.info("memory")
+
+            return {
+                "status": "healthy",
+                "connected": True,
+                "used_memory": info.get("used_memory_human", "unknown"),
+                "max_memory": info.get("maxmemory_human", "unknown"),
+            }
         except Exception as e:
+            self._note_op_error(e)
             return {
                 "status": "unhealthy",
                 "connected": False,
@@ -411,4 +530,3 @@ class RedisRateLimiter:
 
 # Singleton instance
 redis_limiter = RedisRateLimiter()
-

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -1,0 +1,174 @@
+"""Tests for the Redis circuit breaker and the degraded-mode behavior it gives
+cache_service and redis_limiter (instant fail-open/degrade, no per-request dial).
+
+No real Redis is used: the breaker is pure, and the service tests assert that an
+open circuit short-circuits *before* any connection attempt, and that a
+connectivity error trips the breaker. Background re-probe is patched out so tests
+stay hermetic.
+"""
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.core.circuit_breaker import CircuitBreaker, run_reprobe
+from src.services.cache_service import CacheService
+from src.services.rate_limiting.redis_limiter import RedisRateLimiter
+from src.services.rate_limiting.types import RateLimitConfig
+
+
+# --------------------------------------------------------------------------- #
+# Pure CircuitBreaker
+# --------------------------------------------------------------------------- #
+
+
+def test_breaker_starts_closed():
+    cb = CircuitBreaker("t")
+    assert cb.is_open() is False
+    assert cb.cooldown_remaining == 0.0
+
+
+def test_failure_opens_with_backoff_then_success_closes():
+    cb = CircuitBreaker("t", initial_backoff=5.0, max_backoff=30.0)
+    backoff = cb.record_failure()
+    assert backoff == 5.0
+    assert cb.is_open() is True
+    assert cb.cooldown_remaining > 0
+    cb.record_success()
+    assert cb.is_open() is False
+    assert cb.consecutive_failures == 0
+
+
+def test_backoff_is_exponential_and_capped():
+    cb = CircuitBreaker("t", initial_backoff=1.0, max_backoff=8.0)
+    assert cb.record_failure() == 1.0   # 1 * 2^0
+    assert cb.record_failure() == 2.0   # 1 * 2^1
+    assert cb.record_failure() == 4.0   # 1 * 2^2
+    assert cb.record_failure() == 8.0   # 1 * 2^3
+    assert cb.record_failure() == 8.0   # capped
+
+
+async def test_run_reprobe_closes_breaker_on_successful_probe():
+    cb = CircuitBreaker("t", initial_backoff=0.01, max_backoff=0.02)
+    cb.record_failure()  # open it
+
+    async def probe():
+        cb.record_success()  # simulate a successful reconnect updating the breaker
+        return True
+
+    await run_reprobe(cb, probe)
+    assert cb.is_open() is False
+
+
+# --------------------------------------------------------------------------- #
+# CacheService degraded-mode
+# --------------------------------------------------------------------------- #
+
+
+async def test_cache_open_circuit_returns_miss_without_dialing():
+    svc = CacheService()
+    svc._connect_locked = AsyncMock()  # must NOT be called
+    svc._breaker.record_failure()      # open the circuit
+
+    with patch("src.services.cache_service.settings.CACHE_ENABLED", True):
+        result = await svc.get("api_key", "abc")
+
+    assert result is None
+    svc._connect_locked.assert_not_awaited()
+
+
+async def test_cache_disabled_returns_miss_without_dialing():
+    svc = CacheService()
+    svc._connect_locked = AsyncMock()
+    with patch("src.services.cache_service.settings.CACHE_ENABLED", False):
+        assert await svc.get("api_key", "abc") is None
+        assert await svc.set("api_key", "abc", {"x": 1}) is True
+    svc._connect_locked.assert_not_awaited()
+
+
+async def test_cache_connectivity_error_trips_breaker():
+    svc = CacheService()
+    svc._ensure_reprobe = MagicMock()  # don't spawn a real background task
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(side_effect=RedisConnectionError("redis down"))
+    svc._acquire_redis = AsyncMock(return_value=fake_redis)
+
+    with patch("src.services.cache_service.settings.CACHE_ENABLED", True):
+        result = await svc.get("api_key", "abc")
+
+    assert result is None                  # degrades gracefully
+    assert svc._breaker.is_open() is True  # circuit tripped for next ops
+    svc._ensure_reprobe.assert_called_once()
+
+
+async def test_cache_non_connectivity_error_does_not_trip_breaker():
+    svc = CacheService()
+    svc._ensure_reprobe = MagicMock()
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(side_effect=ValueError("not a redis error"))
+    svc._acquire_redis = AsyncMock(return_value=fake_redis)
+
+    with patch("src.services.cache_service.settings.CACHE_ENABLED", True):
+        result = await svc.get("api_key", "abc")
+
+    assert result is None
+    assert svc._breaker.is_open() is False
+    svc._ensure_reprobe.assert_not_called()
+
+
+async def test_cache_health_check_fast_when_circuit_open():
+    svc = CacheService()
+    svc._connect_locked = AsyncMock()  # must NOT dial
+    svc._breaker.record_failure()
+    with patch("src.services.cache_service.settings.CACHE_ENABLED", True):
+        health = await svc.health_check()
+    assert health["status"] == "degraded"
+    assert health["circuit"] == "open"
+    svc._connect_locked.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# RedisRateLimiter degraded-mode (fail open)
+# --------------------------------------------------------------------------- #
+
+
+def _cfg():
+    return RateLimitConfig(rpm=100, tpm=10000, window_seconds=60)
+
+
+async def test_limiter_open_circuit_fails_open_without_dialing():
+    lim = RedisRateLimiter()
+    lim._connect_locked = AsyncMock()  # must NOT be called
+    lim._breaker.record_failure()      # open the circuit
+
+    current, limit, allowed = await lim.check_and_increment_rpm("user1", _cfg())
+
+    assert allowed is True   # fail open
+    assert limit == 100
+    lim._connect_locked.assert_not_awaited()
+
+
+async def test_limiter_connectivity_error_trips_breaker_and_fails_open():
+    lim = RedisRateLimiter()
+    lim._ensure_reprobe = MagicMock()
+    fake_redis = MagicMock()
+    fake_redis.evalsha = AsyncMock(side_effect=RedisConnectionError("redis down"))
+    lim._acquire_redis = AsyncMock(return_value=fake_redis)
+
+    current, limit, allowed = await lim.check_and_increment_rpm("user1", _cfg())
+
+    assert allowed is True                 # fail open
+    assert lim._breaker.is_open() is True  # tripped for subsequent checks
+    lim._ensure_reprobe.assert_called_once()
+
+
+async def test_limiter_get_current_usage_degrades_to_zero():
+    lim = RedisRateLimiter()
+    lim._connect_locked = AsyncMock()
+    lim._breaker.record_failure()
+    assert await lim.get_current_usage("user1", _cfg()) == (0, 0)
+    lim._connect_locked.assert_not_awaited()


### PR DESCRIPTION
A timeout-mode Redis outage no longer stalls the API. A shared CircuitBreaker (src/core/circuit_breaker.py) opens on failure so cache ops degrade to the DB and rate-limit checks fail open immediately — no per-request 5s dials, no init lock contention. Pools are built once and reused, the broken client is dropped before it can be yielded, a background re-probe handles recovery off the request path, cache_service is initialized at startup, and health checks return fast when degraded.

Config (new optional env vars, sane defaults):
- RATE_LIMIT_REDIS_SOCKET_TIMEOUT (default 1.0)
- RATE_LIMIT_REDIS_SOCKET_CONNECT_TIMEOUT (default 0.5) Tight timeouts for the rate-limit hot path; the cache keeps the 5s defaults.