### PR TITLE
perf(billing): skip redundant update_balance reads on the chat hot path

### DIFF
--- a/src/crud/credits.py
+++ b/src/crud/credits.py
@@ -151,23 +151,35 @@ async def update_balance(
     staking_daily_amount: Optional[Decimal] = None,
     staking_refresh_date: Optional[date] = None,
     auto_commit: bool = True,
-) -> CreditAccountBalance:
+    ensure_exists: bool = True,
+    return_balance: bool = True,
+) -> Optional[CreditAccountBalance]:
     """
     Update account balance using SQL-level atomic arithmetic.
-    
+
     Uses ``UPDATE ... SET column = column + delta`` to prevent lost-update race
     conditions under concurrent access.  Python-level read-modify-write is NOT
     used for delta operations.
-    
+
     Deltas are added to existing values via server-side expressions.
     Optional values (staking_daily_amount, staking_refresh_date) replace if provided.
-    
+
     Args:
         auto_commit: If False, the UPDATE is executed but not committed.
                      Caller is responsible for committing the transaction.
+        ensure_exists: If True (default), ensure the balance row exists before
+                     updating. Hot-path callers that already fetched/locked the
+                     row in the same transaction pass False to skip the redundant
+                     read + cache work — and to avoid get_or_create_balance's
+                     mid-flight commit() inside an auto_commit=False transaction.
+        return_balance: If True (default), re-read and return the updated row.
+                     Callers that discard the result pass False to skip the extra
+                     SELECT, in which case this returns None.
     """
-    # Ensure the record exists (no-op for existing users)
-    await get_or_create_balance(db, user_id)
+    # Ensure the record exists (no-op for existing users). Skipped by hot-path
+    # callers that already hold the locked row in this transaction.
+    if ensure_exists:
+        await get_or_create_balance(db, user_id)
     
     # Build SQL UPDATE with server-side arithmetic for deltas.
     # This is atomic at the database level – concurrent transactions each see
@@ -202,10 +214,17 @@ async def update_balance(
         .values(**values)
     )
     await db.execute(stmt)
-    
+
     if auto_commit:
         await db.commit()
-    
+
+    # Invalidate balance cache since it changed
+    cache_key = f"user_balance:{user_id}"
+    await cache_service.delete("balance", cache_key)
+
+    if not return_balance:
+        return None
+
     # Expire any stale ORM-cached object and re-read the updated row
     # (the raw UPDATE bypasses ORM identity map, so cached objects are stale)
     result = await db.execute(
@@ -213,13 +232,7 @@ async def update_balance(
         .where(CreditAccountBalance.user_id == user_id)
         .execution_options(populate_existing=True)
     )
-    balance = result.scalar_one()
-    
-    # Invalidate balance cache since it changed
-    cache_key = f"user_balance:{user_id}"
-    await cache_service.delete("balance", cache_key)
-    
-    return balance
+    return result.scalar_one()
 
 
 async def set_staking_daily_amount(db: AsyncSession, user_id: int, amount: Decimal) -> CreditAccountBalance:

--- a/src/services/billing_service.py
+++ b/src/services/billing_service.py
@@ -351,6 +351,8 @@ class BillingService:
             paid_holds_delta=-paid_hold,  # Negative (reduces paid_available)
             staking_delta=-staking_hold,  # Negative (reduces staking_available)
             auto_commit=False,
+            ensure_exists=False,   # row already locked above (for_update)
+            return_balance=False,  # result is discarded
         )
         
         # Commit both ledger entry and balance update atomically
@@ -481,6 +483,8 @@ class BillingService:
             paid_posted_delta=-paid_charge,  # Apply paid charge (negative)
             staking_delta=-original_hold_staking - staking_charge,  # Release staking hold + apply staking charge
             auto_commit=False,
+            ensure_exists=False,   # row ensured above; UPDATE locks it
+            return_balance=False,  # result is discarded
         )
         
         # Commit both ledger update and balance update atomically
@@ -565,6 +569,8 @@ class BillingService:
             paid_holds_delta=-original_hold_paid,  # Release paid hold (add back the negative)
             staking_delta=-original_hold_staking,  # Release staking hold (add back the negative)
             auto_commit=False,
+            ensure_exists=False,   # hold creation already ensured/locked the row
+            return_balance=False,  # result is discarded
         )
         
         # Commit both ledger update and balance update atomically

--- a/tests/unit/test_credits_update_balance.py
+++ b/tests/unit/test_credits_update_balance.py
@@ -1,0 +1,84 @@
+"""Unit tests for H3: credits.update_balance ensure_exists / return_balance flags.
+
+Hot-path callers (hold/finalize/void) pass both flags False to skip the
+redundant ensure-exists read and the post-update re-SELECT; defaults preserve
+the previous behavior. The atomic server-side delta UPDATE is unchanged.
+"""
+import os
+import sys
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.crud import credits as credits_crud
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+    return db
+
+
+def _select_result(balance):
+    r = MagicMock()
+    r.scalar_one.return_value = balance
+    return r
+
+
+async def test_hotpath_skips_ensure_exists_and_reselect(mock_db):
+    with patch("src.crud.credits.get_or_create_balance", new_callable=AsyncMock) as goc, \
+         patch("src.crud.credits.cache_service.delete", new_callable=AsyncMock) as cdel:
+        out = await credits_crud.update_balance(
+            mock_db, user_id=1, paid_holds_delta=Decimal("-5"),
+            auto_commit=False, ensure_exists=False, return_balance=False,
+        )
+    assert out is None
+    goc.assert_not_awaited()                 # no ensure-exists read
+    mock_db.execute.assert_awaited_once()    # only the UPDATE, no re-SELECT
+    mock_db.commit.assert_not_awaited()      # auto_commit=False
+    cdel.assert_awaited_once()               # cache still invalidated
+
+
+async def test_default_path_ensures_and_returns(mock_db):
+    balance = MagicMock()
+    mock_db.execute.side_effect = [MagicMock(), _select_result(balance)]
+    with patch("src.crud.credits.get_or_create_balance", new_callable=AsyncMock) as goc, \
+         patch("src.crud.credits.cache_service.delete", new_callable=AsyncMock):
+        out = await credits_crud.update_balance(
+            mock_db, user_id=1, paid_posted_delta=Decimal("10"),
+        )
+    assert out is balance
+    goc.assert_awaited_once()                # ensure-exists ran
+    assert mock_db.execute.await_count == 2  # UPDATE + re-SELECT
+    mock_db.commit.assert_awaited_once()     # auto_commit default True
+
+
+async def test_return_balance_false_skips_reselect_even_when_ensuring(mock_db):
+    with patch("src.crud.credits.get_or_create_balance", new_callable=AsyncMock) as goc, \
+         patch("src.crud.credits.cache_service.delete", new_callable=AsyncMock):
+        out = await credits_crud.update_balance(
+            mock_db, user_id=1, paid_posted_delta=Decimal("3"),
+            auto_commit=False, return_balance=False,
+        )
+    assert out is None
+    goc.assert_awaited_once()                # ensure_exists default True -> ran
+    mock_db.execute.assert_awaited_once()    # UPDATE only, no re-SELECT
+
+
+async def test_update_uses_atomic_server_side_delta(mock_db):
+    with patch("src.crud.credits.get_or_create_balance", new_callable=AsyncMock), \
+         patch("src.crud.credits.cache_service.delete", new_callable=AsyncMock):
+        await credits_crud.update_balance(
+            mock_db, user_id=7, paid_holds_delta=Decimal("-5"),
+            auto_commit=False, ensure_exists=False, return_balance=False,
+        )
+    stmt = mock_db.execute.await_args_list[0].args[0]
+    sql = str(stmt.compile(compile_kwargs={"literal_binds": True})).lower()
+    assert sql.lstrip().startswith("update")
+    assert "coalesce(" in sql                # server-side, not Python read-modify-write
+    assert "paid_pending_holds" in sql


### PR DESCRIPTION
update_balance always did an ensure-exists get_or_create_balance (Redis GET/SELECT/SETEX of the pre-update value) and an unconditional populate_existing re-SELECT, even for callers that already hold the locked balance row and discard the result. On a chat completion this ran twice (hold + finalize) inside the row-locked billing transaction.

Add ensure_exists / return_balance flags (default True, so webhooks/admin/signup are unchanged) and pass both False from the hold/finalize/void call sites, where the row is already fetched/locked in the same transaction and the return value is discarded. Skipping ensure_exists also avoids get_or_create_balance's mid-flight commit() inside the auto_commit=False transaction. The cache invalidation and the atomic coalesce+delta UPDATE are unchanged.

Each hot-path update_balance drops from ~3 SQL statements to 1, shortening the per-user lock window that serializes same-user concurrency.