### PR TITLE
fix(stripe): stop sync Subscription.retrieve from blocking the event …

### DIFF
--- a/src/services/stripe_webhook_service.py
+++ b/src/services/stripe_webhook_service.py
@@ -6,6 +6,7 @@ Handles:
 - invoice.paid: Subscription invoice payments
 - invoice.payment_failed: Failed payment attempts
 """
+import asyncio
 from typing import Optional, Tuple, Dict, Any
 from decimal import Decimal
 import stripe
@@ -345,7 +346,28 @@ class StripeWebhookService:
         )
         
         return True, "Credits added successfully"
-    
+
+    @staticmethod
+    def _subscription_ref(invoice: "stripe.Invoice") -> Tuple[Dict[str, Any], Optional[str]]:
+        """
+        Extract (subscription_metadata_snapshot, subscription_id) from an invoice.
+
+        Handles both invoice schemas: the legacy top-level fields and the
+        2025-03-31+ schema where they moved under ``invoice.parent``.
+        ``subscription_details.metadata`` is an immutable snapshot of the
+        subscription metadata captured at invoice finalization, so reading it
+        avoids a Stripe API round trip in the common case.
+        """
+        sub_details = invoice.get("subscription_details")
+        subscription_id = invoice.get("subscription")
+        if not sub_details:
+            parent = invoice.get("parent") or {}
+            sub_details = parent.get("subscription_details")
+        sub_details = sub_details or {}
+        if not subscription_id:
+            subscription_id = sub_details.get("subscription")
+        return (sub_details.get("metadata") or {}), subscription_id
+
     async def handle_invoice_paid(
         self,
         db: AsyncSession,
@@ -373,17 +395,29 @@ class StripeWebhookService:
         metadata = invoice.metadata or {}
         fallback_metadata = None
         
-        if not metadata.get("user_id") and invoice.get("subscription"):
-            try:
-                subscription = stripe.Subscription.retrieve(invoice.subscription)
-                fallback_metadata = subscription.metadata or {}
-            except stripe.error.StripeError as e:
-                logger.warning(
-                    "Failed to retrieve subscription metadata",
-                    stripe_subscription_id=invoice.subscription,
-                    error=str(e),
-                    **log_context,
-                )
+        if not metadata.get("user_id"):
+            # Prefer the subscription-metadata snapshot carried on the invoice
+            # (immutable, taken at finalization): no HTTP call in the common case.
+            snapshot_metadata, subscription_id = self._subscription_ref(invoice)
+            fallback_metadata = snapshot_metadata or None
+
+            # Only call the Stripe API if the snapshot lacked user_id, and run the
+            # synchronous SDK call OFF the event loop so the open webhook
+            # transaction and other in-flight requests (incl. streaming chat) are
+            # not frozen for up to the Stripe read timeout.
+            if not (fallback_metadata or {}).get("user_id") and subscription_id:
+                try:
+                    subscription = await asyncio.to_thread(
+                        stripe.Subscription.retrieve, subscription_id
+                    )
+                    fallback_metadata = subscription.metadata or {}
+                except stripe.error.StripeError as e:
+                    logger.warning(
+                        "Failed to retrieve subscription metadata",
+                        stripe_subscription_id=subscription_id,
+                        error=str(e),
+                        **log_context,
+                    )
         
         user, error = await self._get_user_from_metadata(
             db, metadata, fallback_metadata, log_context
@@ -448,16 +482,24 @@ class StripeWebhookService:
         metadata = invoice.metadata or {}
         user_id_str = metadata.get("user_id")
         
-        if not user_id_str and invoice.subscription:
-            try:
-                subscription = stripe.Subscription.retrieve(invoice.subscription)
-                user_id_str = (subscription.metadata or {}).get("user_id")
-            except stripe.error.StripeError as e:
-                logger.warning(
-                    "Failed to retrieve subscription metadata for failed payment",
-                    stripe_invoice_id=invoice_id,
-                    error=str(e),
-                )
+        if not user_id_str:
+            # Prefer the snapshot carried on the invoice (no HTTP); fall back to
+            # the Stripe API off the event loop so the sync SDK call cannot freeze
+            # the loop while the webhook transaction is open. Handles both schemas.
+            snapshot_metadata, subscription_id = self._subscription_ref(invoice)
+            user_id_str = (snapshot_metadata or {}).get("user_id")
+            if not user_id_str and subscription_id:
+                try:
+                    subscription = await asyncio.to_thread(
+                        stripe.Subscription.retrieve, subscription_id
+                    )
+                    user_id_str = (subscription.metadata or {}).get("user_id")
+                except stripe.error.StripeError as e:
+                    logger.warning(
+                        "Failed to retrieve subscription metadata for failed payment",
+                        stripe_invoice_id=invoice_id,
+                        error=str(e),
+                    )
         
         logger.warning(
             "Stripe webhook event failed",

--- a/tests/unit/test_stripe_subscription_ref.py
+++ b/tests/unit/test_stripe_subscription_ref.py
@@ -1,0 +1,52 @@
+"""Unit tests for StripeWebhookService._subscription_ref (H8).
+
+Verifies the metadata-snapshot/subscription-id extraction works on BOTH invoice
+schemas — the legacy top-level fields and the 2025-03-31+ schema where they live
+under invoice.parent.subscription_details — so the webhook avoids a blocking
+Stripe API call whenever the snapshot carries the user_id. The invoice object is
+dict-like, so plain dicts stand in for stripe.Invoice here.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.services.stripe_webhook_service import StripeWebhookService
+
+ref = StripeWebhookService._subscription_ref
+
+
+def test_legacy_top_level_schema():
+    inv = {"subscription": "sub_1", "subscription_details": {"metadata": {"user_id": "7"}}}
+    metadata, sub_id = ref(inv)
+    assert metadata == {"user_id": "7"}
+    assert sub_id == "sub_1"
+
+
+def test_parent_schema_2025():
+    inv = {"parent": {"subscription_details": {"subscription": "sub_2", "metadata": {"user_id": "9"}}}}
+    metadata, sub_id = ref(inv)
+    assert metadata == {"user_id": "9"}
+    assert sub_id == "sub_2"
+
+
+def test_no_subscription_returns_empty():
+    inv = {"metadata": {"user_id": "1"}}
+    metadata, sub_id = ref(inv)
+    assert metadata == {}
+    assert sub_id is None
+
+
+def test_subscription_without_metadata_snapshot():
+    # subscription present but snapshot empty -> caller will fall back to the API
+    inv = {"subscription": "sub_3", "subscription_details": {}}
+    metadata, sub_id = ref(inv)
+    assert metadata == {}
+    assert sub_id == "sub_3"
+
+
+def test_parent_present_but_empty_is_safe():
+    inv = {"parent": {}}
+    metadata, sub_id = ref(inv)
+    assert metadata == {}
+    assert sub_id is None


### PR DESCRIPTION
…loop

The invoice.paid / invoice.payment_failed webhook handlers called stripe.Subscription.retrieve(...) — a synchronous HTTPS call (stripe 11.x, no usable async variant) — on the event loop while the webhook DB transaction was open. With one uvicorn worker per container that froze EVERY in-flight request (including streaming chat) for up to the Stripe read timeout, on essentially every subscription renewal.

- Read the subscription-metadata snapshot Stripe carries on the invoice first (immutable snapshot taken at finalization) — no HTTP call in the common case.
- Only when that snapshot lacks user_id, call Stripe via asyncio.to_thread(stripe.Subscription.retrieve, ...) so the blocking SDK call runs off the event loop. (Chose to_thread over retrieve_async because the async HTTP client it needs only ships in stripe v13.0.1+; we're on 11.6.0.)
- Idempotency check stays first (no extra Stripe RTT on duplicate deliveries).

The new _subscription_ref() helper reads both invoice schemas: the legacy top-level fields and the 2025-03-31+ schema where subscription_details/ subscription moved under invoice.parent, so the snapshot path works regardless of the account's API version.