### PR TITLE
feat(pricing): add prod pricing and rate limits for glm-5.2 and kimi-k2.7-code

### DIFF
--- a/models/prod_model_price.json
+++ b/models/prod_model_price.json
@@ -2,6 +2,8 @@
   "default_input_price_per_million": "0.50",
   "default_output_price_per_million": "2.00",
   "models": {
+    "glm-5.2": { "input": "1.25", "output": "4.40" },
+    "glm-5.2:web": { "input": "1.25", "output": "4.40" },
     "glm-5.1": { "input": "1.50", "output": "5.00" },
     "glm-5.1:web": { "input": "1.50", "output": "5.00" },
     "GLM-5.1": { "input": "1.50", "output": "5.00" },
@@ -18,6 +20,8 @@
     "glm-4.7-flash": { "input": "0.10", "output": "0.50" },
     "glm-4.7-flash:web": { "input": "0.10", "output": "0.50" },
 
+    "kimi-k2.7-code": { "input": "0.75", "output": "4.00" },
+    "kimi-k2.7-code:web": { "input": "0.75", "output": "4.00" },
     "kimi-k2.6": { "input": "0.50", "output": "3.25" },
     "kimi-k2.6:web": { "input": "0.50", "output": "3.25" },
     "kimi-k2.5": { "input": "0.60", "output": "3.00" },

--- a/models/prod_rate_limit.json
+++ b/models/prod_rate_limit.json
@@ -50,6 +50,8 @@
       "rpm": 20,
       "tpm": 500000,
       "models": [
+        "glm-5.2",
+        "glm-5.2:web",
         "glm-5",
         "glm-5:web",
         "GLM-5",
@@ -64,6 +66,8 @@
         "glm-4.7-thinking:web",
         "glm-4.7-flash",
         "glm-4.7-flash:web",
+        "kimi-k2.7-code",
+        "kimi-k2.7-code:web",
         "kimi-k2.5",
         "kimi-k2.5:web",
         "Kimi-K2.5",


### PR DESCRIPTION
## Summary

Adds prod pricing and rate limit entries for two new models recently added to the API:

- **glm-5.2** — $1.25 input / $4.40 output per 1M tokens
- **kimi-k2.7-code** — $0.75 input / $4.00 output per 1M tokens

Both models also get `:web` variants at the same price. All four entries are added to the Large (L) rate limit tier (20 RPM, 500K TPM).

## Changes

- `models/prod_model_price.json` — 4 new pricing entries
- `models/prod_rate_limit.json` — 4 new entries in the L tier model group

## Context

These models were added to the blockchain registry and documented in api-gateway-docs (commit MorpheusAIs/api-gateway-docs@cf10730). This PR wires up the prod pricing and rate limiting so the API can serve them without falling back to default pricing.

Test environment pricing/rate limits are intentionally excluded per request — test configs will be updated separately.