### PR TITLE
Fix/db loops leader election

### DIFF
--- a/src/db/database.py
+++ b/src/db/database.py
@@ -1,5 +1,6 @@
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy import text
 from typing import AsyncGenerator
 from contextlib import asynccontextmanager
 from src.core.config import settings
@@ -53,6 +54,46 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
             raise
         finally:
             await session.close()
+
+# Cluster-wide leader election for in-process background loops
+@asynccontextmanager
+async def advisory_xact_lock(lock_name: str) -> AsyncGenerator[bool, None]:
+    """
+    Try to acquire a cluster-wide PostgreSQL advisory lock for the duration of
+    the context, so only one replica runs a given background job at a time.
+
+    Usage:
+        async with advisory_xact_lock("staking_sync") as is_leader:
+            if not is_leader:
+                return  # another replica owns this run
+            ...  # do the work
+
+    Yields True if this process acquired the lock, False otherwise.
+
+    Implementation notes:
+    - Uses a transaction-scoped advisory lock
+      (``pg_try_advisory_xact_lock(hashtext(:name))``) held on a dedicated
+      connection for the duration of the context.
+    - Transaction scope is required on a pooled asyncpg engine: a session-scoped
+      advisory lock (``pg_advisory_lock``) can outlive the work and be released
+      on — or leak across — a different pooled connection. The xact lock is
+      always released when this transaction ends (commit, rollback, or
+      connection drop), so a crashed leader never wedges the rest of the fleet.
+    - The lock is held on its own connection; the actual job should run on
+      separate ``get_db()`` / ``AsyncSessionLocal()`` connections so its own
+      commits do not release the lock.
+    """
+    async with AsyncSessionLocal() as session:
+        try:
+            result = await session.execute(
+                text("SELECT pg_try_advisory_xact_lock(hashtext(:name))"),
+                {"name": lock_name},
+            )
+            yield bool(result.scalar())
+        finally:
+            # Rollback ends the transaction, releasing the xact-scoped lock.
+            await session.rollback()
+
 
 # FastAPI dependency version (for use with Depends())
 async def get_db_session() -> AsyncGenerator[AsyncSession, None]:

--- a/src/main.py
+++ b/src/main.py
@@ -42,6 +42,10 @@ APP_START_TIME = None
 CONTAINER_ID = str(uuid.uuid4())
 APP_VERSION = get_version()
 
+# Handles to long-lived background tasks so they can be cancelled on shutdown
+_staking_sync_task = None
+_hold_reconciliation_task = None
+
 # Using our production-ready fixed route class
 app = FastAPI(
     title="Morpheus API Gateway",
@@ -397,7 +401,8 @@ async def startup_event():
     # Start the background tasks
     # Start the daily staking sync task
     try:
-        asyncio.create_task(daily_staking_sync())
+        global _staking_sync_task
+        _staking_sync_task = asyncio.create_task(daily_staking_sync())
         logger.info("Started background task for daily staking sync",
                    event_type="staking_sync_task_start")
     except Exception as e:
@@ -420,7 +425,8 @@ async def startup_event():
     
     # Start hold reconciliation loop (auto-void stale pending holds)
     try:
-        asyncio.create_task(hold_reconciliation_loop())
+        global _hold_reconciliation_task
+        _hold_reconciliation_task = asyncio.create_task(hold_reconciliation_loop())
         logger.info("Started background task for hold reconciliation",
                    interval_seconds=settings.HOLD_RECONCILIATION_INTERVAL_SECONDS,
                    max_pending_seconds=settings.HOLD_MAX_PENDING_SECONDS,
@@ -484,6 +490,26 @@ async def shutdown_event():
     except Exception as e:
         logger.warning("Error stopping session routing automation", error=str(e), event_type="session_routing_automation_stop_error")
     
+    # Cancel the fire-and-forget background loops
+    for task_name, task in (
+        ("staking_sync", _staking_sync_task),
+        ("hold_reconciliation", _hold_reconciliation_task),
+    ):
+        if task is None:
+            continue
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.warning("Error stopping background task",
+                          task=task_name, error=str(e),
+                          event_type="background_task_stop_error")
+        else:
+            logger.info("Background task stopped", task=task_name,
+                       event_type="background_task_stopped")
+    
     # Close rate limiting service
     try:
         await rate_limit_service.close()
@@ -512,6 +538,14 @@ async def shutdown_event():
         logger.info("Staking service HTTP client closed successfully", event_type="staking_service_shutdown")
     except Exception as e:
         logger.warning("Error closing staking service HTTP client", error=str(e), event_type="staking_service_shutdown_error")
+    
+    # Dispose the SQLAlchemy engine last, after all DB users are stopped, so the
+    # connection pool is closed cleanly on the way out.
+    try:
+        await engine.dispose()
+        logger.info("Database engine disposed", event_type="db_engine_disposed")
+    except Exception as e:
+        logger.warning("Error disposing database engine", error=str(e), event_type="db_engine_dispose_error")
     
     logger.info("Application shutdown complete", event_type="shutdown_complete")
 

--- a/src/main.py
+++ b/src/main.py
@@ -204,7 +204,7 @@ async def daily_staking_sync():
     Background task to sync staking data and update user balances daily.
     Runs at 0:05 UTC every day.
     """
-    from src.db.database import AsyncSessionLocal
+    from src.db.database import AsyncSessionLocal, advisory_xact_lock
     from datetime import datetime, timezone, timedelta
     import traceback
     
@@ -234,14 +234,26 @@ async def daily_staking_sync():
             
             staking_sync_logger.info("Starting daily staking sync", event_type="staking_sync_start")
             
-            # Run the sync
-            async with AsyncSessionLocal() as db:
-                summary = await staking_service.run_daily_sync(db)
-                staking_sync_logger.info(
-                    "Daily staking sync completed",
-                    **summary,
-                    event_type="staking_sync_complete"
-                )
+            # Leader election: every replica wakes at 00:05 UTC, but only the one
+            # that wins this advisory lock runs the sync. Without it, R replicas
+            # each run the full Builders-API pagination + per-user FOR UPDATE pass
+            # at the same second, creating a lock convoy on credit_account_balances
+            # shared with live billing (audit M24).
+            async with advisory_xact_lock("staking_sync") as is_leader:
+                if not is_leader:
+                    staking_sync_logger.info(
+                        "Skipping daily staking sync - another replica holds the leader lock",
+                        event_type="staking_sync_skipped_not_leader"
+                    )
+                else:
+                    # Run the sync
+                    async with AsyncSessionLocal() as db:
+                        summary = await staking_service.run_daily_sync(db)
+                        staking_sync_logger.info(
+                            "Daily staking sync completed",
+                            **summary,
+                            event_type="staking_sync_complete"
+                        )
                 
         except Exception as e:
             staking_sync_logger.error(
@@ -262,7 +274,7 @@ async def hold_reconciliation_loop():
     HOLD_MAX_PENDING_SECONDS is auto-voided and the affected users'
     balance caches are reconciled against the ledger.
     """
-    from src.db.database import AsyncSessionLocal
+    from src.db.database import AsyncSessionLocal, advisory_xact_lock
     from src.services.billing_service import billing_service
     import traceback
 
@@ -280,8 +292,17 @@ async def hold_reconciliation_loop():
     while True:
         await asyncio.sleep(interval)
         try:
-            async with AsyncSessionLocal() as db:
-                summary = await billing_service.reconcile_stale_holds(db, max_age)
+            # Leader election: only one replica reconciles stale holds per tick,
+            # so replicas don't redundantly scan/void the same holds (audit M24).
+            async with advisory_xact_lock("hold_reconciliation") as is_leader:
+                if not is_leader:
+                    recon_logger.debug(
+                        "Skipping hold reconciliation - another replica holds the leader lock",
+                        event_type="hold_reconciliation_skipped_not_leader",
+                    )
+                    continue
+                async with AsyncSessionLocal() as db:
+                    summary = await billing_service.reconcile_stale_holds(db, max_age)
 
             if summary["voided_count"] > 0:
                 recon_logger.warning(

--- a/src/services/cache_service.py
+++ b/src/services/cache_service.py
@@ -20,7 +20,7 @@ database", so this is correctness-safe.
 
 import json
 import asyncio
-from typing import Optional, Any, Dict, Callable, TypeVar
+from typing import Optional, Any, Dict, TypeVar
 from contextlib import asynccontextmanager
 
 import redis.asyncio as aioredis
@@ -397,118 +397,6 @@ class CacheService:
                 event_type="cache_delete_error",
             )
             return False
-
-    async def get_or_fetch(
-        self,
-        entity_type: str,
-        identifier: str,
-        fetch_fn: Callable[[], Any],
-        serializer: Optional[Callable[[Any], Dict[str, Any]]] = None,
-        ttl_seconds: Optional[int] = None,
-    ) -> Optional[Any]:
-        """
-        Read-through cache pattern: Get from cache, or fetch and cache.
-
-        This is the main method to use for caching - it implements the full
-        read-through pattern with automatic cache population.
-
-        Args:
-            entity_type: Type of entity
-            identifier: Unique identifier
-            fetch_fn: Async function to fetch data on cache miss
-            serializer: Optional function to serialize fetched data for caching
-            ttl_seconds: Optional TTL override
-
-        Returns:
-            The entity (either from cache or freshly fetched)
-        """
-        # Try cache first
-        cached = await self.get(entity_type, identifier)
-        if cached is not None:
-            # Cache hit - return cached data
-            # Note: Data is already deserialized from JSON
-            return cached
-
-        # Cache miss - fetch from source
-        try:
-            fetched = await fetch_fn()
-
-            if fetched is None:
-                # Source returned None - don't cache
-                return None
-
-            # Serialize for caching if serializer provided
-            if serializer:
-                cache_data = serializer(fetched)
-            elif isinstance(fetched, dict):
-                # Already a dict - use as-is
-                cache_data = fetched
-            else:
-                # Can't cache this - return without caching
-                logger.warning(
-                    "Cannot cache non-dict data without serializer",
-                    entity_type=entity_type,
-                    event_type="cache_skip_no_serializer",
-                )
-                return fetched
-
-            # Cache the fetched data
-            await self.set(entity_type, identifier, cache_data, ttl_seconds)
-
-            return fetched
-
-        except Exception as e:
-            logger.error(
-                "Fetch function failed in read-through cache",
-                entity_type=entity_type,
-                error=str(e),
-                event_type="cache_fetch_error",
-            )
-            # Return None on fetch errors
-            return None
-
-    async def invalidate_pattern(self, pattern: str) -> int:
-        """
-        Invalidate all keys matching a pattern.
-
-        WARNING: Use sparingly - SCAN can be expensive on large datasets.
-
-        Args:
-            pattern: Redis key pattern (e.g., "cache:user:*")
-
-        Returns:
-            Number of keys deleted
-        """
-        try:
-            async with self._get_redis() as redis:
-                if redis is None:
-                    # Caching disabled or circuit open - nothing to invalidate
-                    return 0
-
-                deleted = 0
-
-                # Use SCAN to avoid blocking Redis
-                async for key in redis.scan_iter(match=pattern):
-                    await redis.delete(key)
-                    deleted += 1
-
-                logger.info(
-                    "Cache pattern invalidated",
-                    pattern=pattern,
-                    deleted_count=deleted,
-                    event_type="cache_pattern_invalidate",
-                )
-                return deleted
-
-        except Exception as e:
-            self._note_op_error(e)
-            logger.error(
-                "Cache pattern invalidation failed",
-                pattern=pattern,
-                error=str(e),
-                event_type="cache_pattern_invalidate_error",
-            )
-            return 0
 
     def get_stats(self) -> Dict[str, int]:
         """Get cache statistics."""

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -23,7 +23,7 @@ from sqlalchemy import select, update, func, and_, or_, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db.models import RoutedSession, SessionState
-from ..db.database import get_db, AsyncSessionLocal
+from ..db.database import get_db, advisory_xact_lock
 from ..core.config import settings
 from ..core.model_routing import model_router
 from ..core.logging_config import get_api_logger
@@ -704,8 +704,19 @@ class SessionRoutingService:
                 auto_logger.debug("Running automation cycle",
                                 event_type="automation_cycle_start")
                 
-                async with get_db() as db:
-                    await self._run_automation_cycle(db)
+                # Leader election: only one replica runs the scaling cycle per
+                # tick. Without this, every replica's loop wakes on the same
+                # shared state and can open/close duplicate paid blockchain
+                # sessions (see efficiency audit H15/H16).
+                async with advisory_xact_lock("session_automation") as is_leader:
+                    if not is_leader:
+                        auto_logger.debug(
+                            "Skipping automation cycle - another replica holds the leader lock",
+                            event_type="automation_cycle_skipped_not_leader")
+                        continue
+                    
+                    async with get_db() as db:
+                        await self._run_automation_cycle(db)
                 
             except asyncio.CancelledError:
                 break

--- a/src/services/staking_service.py
+++ b/src/services/staking_service.py
@@ -26,6 +26,7 @@ from ..core.config import settings
 from ..core.logging_config import get_api_logger
 from ..db.models import WalletLink, CreditAccountBalance, LedgerStatus, LedgerEntryType
 from ..crud import credits as credits_crud
+from .cache_service import cache_service
 from .mor_pricing_service import get_mor_pricing_service
 from .mor_emission_service import get_mor_emission_service
 
@@ -460,6 +461,12 @@ class StakingService:
                     # Commit ledger entry + balance update atomically
                     await db.commit()
                     
+                    # Invalidate the Redis balance cache so the freshly granted
+                    # staking_available is not served stale for up to the TTL.
+                    # The for_update read above bypasses the cache, so without this
+                    # the write-through is skipped (audit L16). delete() fails open.
+                    await cache_service.delete("balance", f"user_balance:{user_id}")
+                    
                     users_processed += 1
                     wallets_updated += user_wallets_updated
                     
@@ -495,6 +502,7 @@ class StakingService:
                 stale_result = await db.execute(stale_query)
                 stale_balances = list(stale_result.scalars().all())
                 
+                zeroed_user_ids: List[int] = []
                 for balance in stale_balances:
                     if balance.user_id not in linked_user_ids:
                         balance.staking_daily_amount = Decimal("0")
@@ -503,6 +511,7 @@ class StakingService:
                         balance.is_staker = False
                         balance.updated_at = datetime.utcnow()
                         users_zeroed += 1
+                        zeroed_user_ids.append(balance.user_id)
                         
                         sync_logger.info(
                             "Zeroed staking balance for unlinked user",
@@ -512,6 +521,12 @@ class StakingService:
                 
                 if users_zeroed > 0:
                     await db.commit()
+                    
+                    # Invalidate the Redis balance cache for every zeroed user so
+                    # the now-zero staking_available isn't served stale (audit L16).
+                    for zeroed_user_id in zeroed_user_ids:
+                        await cache_service.delete("balance", f"user_balance:{zeroed_user_id}")
+                    
                     sync_logger.info(
                         "Zeroed staking balances for unlinked users",
                         users_zeroed=users_zeroed,


### PR DESCRIPTION
## Motivation

Each replica runs its own background loops (session automation, daily staking sync, hold reconciliation) against shared state. With R replicas, they wake near-simultaneously and act on identical data — opening/closing duplicate **paid on-chain sessions**, running R simultaneous staking syncs (a lock convoy on `credit_account_balances` at 00:05 UTC), and redundantly scanning for stale holds. Separately, the nightly staking grant was served stale from Redis, and there was dead cache code and an unclean shutdown.

## Changes

### Leader election for background loops (H15, H16, M24)
- New shared helper `advisory_xact_lock(name)` in `src/db/database.py` using a **transaction-scoped** PostgreSQL advisory lock (`pg_try_advisory_xact_lock(hashtext(name))`) held on a dedicated connection.
- Applied to all three loops with distinct keys: `session_automation`, `staking_sync`, `hold_reconciliation`. Only the replica that wins the lock runs each cycle; the rest skip and retry next tick.
- Transaction scope is required on the pooled asyncpg engine (session-scoped locks can leak across pooled connections) and guarantees the lock auto-releases if a leader crashes — no fleet-wide deadlock.

### Clean shutdown (L2)
- Track the staking-sync and hold-reconciliation task handles and cancel them on shutdown.
- Call `await engine.dispose()` last, after all DB users are stopped, to close the connection pool cleanly.

### Staking cache invalidation (L16)
- The nightly sync reads balances with `for_update` (bypassing the cache) and never invalidated `user_balance:{user_id}`, so freshly granted/zeroed `staking_available` was served stale until TTL. Now deletes the balance cache entry after each per-user grant commit and after zeroing unlinked users.

### Dead code removal (L13)
- Deleted `cache_service.get_or_fetch` (no stampede protection, swallowed fetch errors as `None`) and `invalidate_pattern` (per-key `DELETE` in a `SCAN` loop). Both had zero callers.