### PR TITLE
Promote glm-5.2 & kimi-k2.7-code pricing to test

### DIFF
--- a/models/prod_model_price.json
+++ b/models/prod_model_price.json
@@ -2,6 +2,8 @@
   "default_input_price_per_million": "0.50",
   "default_output_price_per_million": "2.00",
   "models": {
+    "glm-5.2": { "input": "1.25", "output": "4.40" },
+    "glm-5.2:web": { "input": "1.25", "output": "4.40" },
     "glm-5.1": { "input": "1.50", "output": "5.00" },
     "glm-5.1:web": { "input": "1.50", "output": "5.00" },
     "GLM-5.1": { "input": "1.50", "output": "5.00" },
@@ -18,6 +20,8 @@
     "glm-4.7-flash": { "input": "0.10", "output": "0.50" },
     "glm-4.7-flash:web": { "input": "0.10", "output": "0.50" },
 
+    "kimi-k2.7-code": { "input": "0.75", "output": "4.00" },
+    "kimi-k2.7-code:web": { "input": "0.75", "output": "4.00" },
     "kimi-k2.6": { "input": "0.50", "output": "3.25" },
     "kimi-k2.6:web": { "input": "0.50", "output": "3.25" },
     "kimi-k2.5": { "input": "0.60", "output": "3.00" },

--- a/models/prod_rate_limit.json
+++ b/models/prod_rate_limit.json
@@ -50,6 +50,8 @@
       "rpm": 20,
       "tpm": 500000,
       "models": [
+        "glm-5.2",
+        "glm-5.2:web",
         "glm-5",
         "glm-5:web",
         "GLM-5",
@@ -64,6 +66,8 @@
         "glm-4.7-thinking:web",
         "glm-4.7-flash",
         "glm-4.7-flash:web",
+        "kimi-k2.7-code",
+        "kimi-k2.7-code:web",
         "kimi-k2.5",
         "kimi-k2.5:web",
         "Kimi-K2.5",


### PR DESCRIPTION
## Summary
Promotes the new model pricing and rate-limit tiers from `dev` to `test`.

Adds prod pricing and rate-limit entries for:
- **glm-5.2** (and `:web`) — input 1.25 / output 4.40 per million
- **kimi-k2.7-code** (and `:web`) — input 0.75 / output 4.00 per million

Both models added to the 20 rpm / 500k tpm rate-limit tier.

## Changes
- `models/prod_model_price.json`
- `models/prod_rate_limit.json`

(PR #249 / commit 0e2e2cb)

## Test plan
- [ ] Verify pricing config parses on `test` deploy
- [ ] Confirm glm-5.2 and kimi-k2.7-code resolve to expected per-million rates

Made with [Cursor](https://cursor.com)