### PR TITLE
Fix/failover onchain serialization

### DIFF
--- a/src/api/v1/audio/index.py
+++ b/src/api/v1/audio/index.py
@@ -102,13 +102,11 @@ async def create_audio_transcription(
                     requested_model=requested_model,
                     event_type="session_routing_start"
                 )
-                async with get_db() as db:
-                    session_id = await session_routing_service.route_request(
-                        db=db,
-                        user_id=user.id,
-                        requested_model=requested_model,
-                        model_type='STT'
-                    )
+                session_id = await session_routing_service.route_request(
+                    user_id=user.id,
+                    requested_model=requested_model,
+                    model_type='STT'
+                )
                 
                 if session_id:
                     transcription_logger.info(
@@ -358,13 +356,11 @@ async def create_audio_speech(
                     requested_model=requested_model,
                     event_type="session_routing_start"
                 )
-                async with get_db() as db:
-                    session_id = await session_routing_service.route_request(
-                        db=db,
-                        user_id=user.id,
-                        requested_model=requested_model,
-                        model_type='TTS'
-                    )
+                session_id = await session_routing_service.route_request(
+                    user_id=user.id,
+                    requested_model=requested_model,
+                    model_type='TTS'
+                )
                 
                 if session_id:
                     speech_logger.info(

--- a/src/api/v1/chat/chat_failover.py
+++ b/src/api/v1/chat/chat_failover.py
@@ -175,13 +175,11 @@ async def attempt_failover(
     #    best-first with a provider handshake per bid, so the dead
     #    provider is skipped automatically.
     try:
-        async with get_db() as db:
-            new_session_id = await session_routing_service.route_request(
-                db=db,
-                user_id=user.id,
-                requested_model=requested_model,
-                model_type="LLM",
-            )
+        new_session_id = await session_routing_service.route_request(
+            user_id=user.id,
+            requested_model=requested_model,
+            model_type="LLM",
+        )
     except Exception as e:
         failover_logger.error("Failover rerouting failed",
                               error=str(e),

--- a/src/api/v1/chat/chat_non_streaming.py
+++ b/src/api/v1/chat/chat_non_streaming.py
@@ -138,14 +138,13 @@ async def _create_new_session(
                         event_type="session_invalidate_skipped",
                     )
 
-            # Route to a new session
+            # Route to a new session (route_request manages its own DB session)
             new_session_id = await session_routing_service.route_request(
-                db=db,
                 user_id=user.id,
                 requested_model=requested_model,
                 model_type="LLM",
             )
-            
+
             if not new_session_id:
                 logger.error(
                     "Failed to route to new session",

--- a/src/api/v1/chat/chat_streaming.py
+++ b/src/api/v1/chat/chat_streaming.py
@@ -638,9 +638,8 @@ async def _handle_session_retry(
                 state=SessionState.EXPIRED,
             )
 
-            # Route to a new session
+            # Route to a new session (route_request manages its own DB session)
             new_session_id = await session_routing_service.route_request(
-                db=db,
                 user_id=user.id,
                 requested_model=requested_model,
                 model_type="LLM",

--- a/src/api/v1/chat/index.py
+++ b/src/api/v1/chat/index.py
@@ -332,19 +332,17 @@ async def _resolve_session(
     )
     
     try:
-        async with get_db() as db:
-            routed_session_id = await session_routing_service.route_request(
-                db=db,
-                user_id=user.id,
-                requested_model=requested_model,
-                model_type="LLM"
-            )
-            chat_logger.info(
-                "Session routed successfully",
-                session_id=routed_session_id,
-                event_type="session_routing_success",
-            )
-            return routed_session_id
+        routed_session_id = await session_routing_service.route_request(
+            user_id=user.id,
+            requested_model=requested_model,
+            model_type="LLM"
+        )
+        chat_logger.info(
+            "Session routed successfully",
+            session_id=routed_session_id,
+            event_type="session_routing_success",
+        )
+        return routed_session_id
     except NoSessionAvailableError as e:
         raise SessionNotFoundError() from e
     except SessionOpenError as e:

--- a/src/api/v1/embeddings/index.py
+++ b/src/api/v1/embeddings/index.py
@@ -96,14 +96,12 @@ async def create_embeddings(
                        api_key_id=db_api_key.id,
                        requested_model=requested_model,
                        event_type="session_routing_start")
-            async with get_db() as db:
-                session_id = await session_routing_service.route_request(
-                    db=db,
-                    user_id=user.id,
-                    requested_model=requested_model,
-                    model_type='EMBEDDINGS'
-                )
-            
+            session_id = await session_routing_service.route_request(
+                user_id=user.id,
+                requested_model=requested_model,
+                model_type='EMBEDDINGS'
+            )
+
             embeddings_logger.info("Session routed successfully",
                         request_id=request_id,
                         session_id=session_id,

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -184,7 +184,12 @@ class Settings(BaseSettings):
     SESSION_DEFAULT_DURATION_SECONDS: int = Field(default=int(os.getenv("SESSION_DEFAULT_DURATION_SECONDS", "1800")))
     # Comma-separated list of preferred models (keep at least one idle session)
     SESSION_PREFERRED_MODELS: str = Field(default=os.getenv("SESSION_PREFERRED_MODELS", ""))
-    
+    # Adaptive on-chain wallet throttle: after a nonce conflict is observed on a
+    # session open/close, on-chain ops serialize on the wallet lock for this many
+    # seconds (sliding; each new conflict re-arms it). 0 disables the throttle
+    # (always concurrent). The happy path is never serialized.
+    SESSION_ONCHAIN_THROTTLE_COOLDOWN_SECONDS: float = Field(default=float(os.getenv("SESSION_ONCHAIN_THROTTLE_COOLDOWN_SECONDS", "20")))
+
     # Direct Model Fetching Settings (replaces model sync)
     ACTIVE_MODELS_URL: str = Field(default=os.getenv("ACTIVE_MODELS_URL", "https://active.dev.mor.org/active_models.json"))
     DEFAULT_FALLBACK_MODEL: str = Field(default=os.getenv("DEFAULT_FALLBACK_MODEL", "mistral-31-24b"))

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -184,7 +184,7 @@ class Settings(BaseSettings):
     SESSION_DEFAULT_DURATION_SECONDS: int = Field(default=int(os.getenv("SESSION_DEFAULT_DURATION_SECONDS", "1800")))
     # Comma-separated list of preferred models (keep at least one idle session)
     SESSION_PREFERRED_MODELS: str = Field(default=os.getenv("SESSION_PREFERRED_MODELS", ""))
-    
+
     # Direct Model Fetching Settings (replaces model sync)
     ACTIVE_MODELS_URL: str = Field(default=os.getenv("ACTIVE_MODELS_URL", "https://active.dev.mor.org/active_models.json"))
     DEFAULT_FALLBACK_MODEL: str = Field(default=os.getenv("DEFAULT_FALLBACK_MODEL", "mistral-31-24b"))

--- a/src/services/proxy_router_service.py
+++ b/src/services/proxy_router_service.py
@@ -117,6 +117,30 @@ def _is_non_retriable_error(response_text: str) -> bool:
     return any(pattern in text_lower for pattern in NON_RETRIABLE_ERROR_PATTERNS)
 
 
+# On-chain nonce-conflict signatures from the proxy-router signer. Mirror of the
+# proxy-router's internal/lib/nonce_manager.go IsNonceError patterns. A burst of
+# concurrent on-chain txs from the single consumer wallet collides on nonce; the
+# gateway reacts by throttling the wallet (see SessionRoutingService._run_onchain).
+NONCE_ERROR_PATTERNS = [
+    "nonce too low",
+    "nonce too high",
+    "replacement transaction underpriced",
+    "transaction underpriced",
+    "already known",
+    "invalid nonce",
+    "incorrect nonce",
+    "nonce error",
+]
+
+
+def is_nonce_error(message: str) -> bool:
+    """Return True if a proxy-router error indicates an on-chain nonce conflict."""
+    if not message:
+        return False
+    text_lower = message.lower()
+    return any(pattern in text_lower for pattern in NONCE_ERROR_PATTERNS)
+
+
 
 
 async def _execute_request(
@@ -234,7 +258,12 @@ async def _execute_request(
             elif status_code >= 400:
                 error_type = "client_error"
             
-            non_retriable = _is_non_retriable_error(response.text)
+            # Nonce conflicts are non-retriable HERE: re-sending the identical
+            # request never fixes a nonce race. Surfacing it immediately lets the
+            # gateway's adaptive wallet throttle engage and do a serialized retry
+            # (SessionRoutingService._run_onchain) instead of amplifying the
+            # storm with blind backoff retries of a colliding tx.
+            non_retriable = _is_non_retriable_error(response.text) or is_nonce_error(response.text)
             if non_retriable:
                 req_logger.error(
                     "Non-retriable error detected, skipping remaining retries",

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -15,9 +15,11 @@ Key concepts:
 """
 
 import asyncio
+import random
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
-from typing import Optional, Dict, Any, List, Tuple
+from typing import Awaitable, Callable, Optional, Dict, Any, List
 
 from sqlalchemy import select, update, func, and_, or_, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -56,15 +58,28 @@ class SessionRoutingService:
     Service for routing requests to sessions and managing session lifecycle.
     
     Thread-safety:
-    - Uses per-model locking to prevent race conditions
+    - On-chain session ops use an ADAPTIVE wallet throttle per replica: they run
+      concurrently on the happy path, and serialize on a single wallet lock only
+      after a nonce conflict is observed (see _run_onchain)
     - Database operations use row-level locking where needed
     """
-    
+
     def __init__(self):
-        # Per-model locks for request routing
-        self._model_locks: Dict[str, asyncio.Lock] = {}
-        self._locks_lock = asyncio.Lock()
-        
+        # Adaptive on-chain wallet throttle (per replica). The single consumer
+        # wallet has NO nonce lock in the C-Node (it fetches PendingNonceAt per
+        # tx), so a simultaneous BURST of txs (a failover storm: many open+close
+        # at once across models) collides on nonce ("replacement transaction
+        # underpriced") — while normal, time-staggered load sequences fine.
+        # So we do NOT serialize on the happy path; instead, when a nonce
+        # conflict is observed we open a short THROTTLED window during which all
+        # on-chain ops serialize on this lock (draining the burst in nonce
+        # order). See _run_onchain / _is_throttled.
+        self._wallet_lock = asyncio.Lock()
+        # Monotonic deadline; while time.monotonic() < this, the wallet is
+        # throttled (serialized). Each new nonce conflict slides it forward.
+        self._throttle_until = 0.0
+        self._throttle_cooldown = settings.SESSION_ONCHAIN_THROTTLE_COOLDOWN_SECONDS
+
         # Automation loop control
         self._automation_task: Optional[asyncio.Task] = None
         self._shutdown_event = asyncio.Event()
@@ -76,46 +91,95 @@ class SessionRoutingService:
         logger.info("SessionRoutingService initialized",
                    event_type="session_routing_service_init")
     
-    async def _get_model_lock(self, model_id: str) -> asyncio.Lock:
-        """Get or create a lock for a specific model."""
-        async with self._locks_lock:
-            if model_id not in self._model_locks:
-                self._model_locks[model_id] = asyncio.Lock()
-            return self._model_locks[model_id]
-    
     def _get_preferred_models(self) -> set:
         """Get the set of preferred model IDs from configuration."""
         if not settings.SESSION_PREFERRED_MODELS:
             return set()
         return set(m.strip() for m in settings.SESSION_PREFERRED_MODELS.split(",") if m.strip())
-    
+
+    # =========================================================================
+    # ADAPTIVE ON-CHAIN WALLET THROTTLE
+    # =========================================================================
+
+    def _is_throttled(self) -> bool:
+        """True while the wallet is in its post-nonce-conflict cooldown window."""
+        return time.monotonic() < self._throttle_until
+
+    def _engage_throttle(self) -> None:
+        """(Re)open the THROTTLED window; sustained conflicts keep sliding it."""
+        self._throttle_until = time.monotonic() + self._throttle_cooldown
+
+    async def _run_onchain(
+        self,
+        op_factory: Callable[[], Awaitable[Any]],
+        *,
+        op_name: str,
+        op_logger,
+    ) -> Any:
+        """
+        Run a single on-chain wallet op (open/close) with adaptive throttling.
+
+        The consumer wallet has no nonce lock in the C-Node, so a simultaneous
+        burst collides on nonce while normal/staggered load is fine. Therefore:
+
+        - Happy path (not throttled): run the op directly, fully concurrent.
+        - While throttled: acquire the wallet lock so the burst drains in nonce
+          order.
+        - On a nonce conflict (not yet throttled): open the THROTTLED window so
+          subsequent ops serialize, then retry THIS op once under the lock (a
+          serialized retry lands on a fresh, uncontended nonce).
+
+        op_factory must build a fresh awaitable on each call (it may be retried).
+        Only the on-chain call belongs inside op_factory — never a DB connection,
+        so a throttled queue can grow without pinning the DB pool.
+        """
+        if self._is_throttled():
+            async with self._wallet_lock:
+                return await op_factory()
+
+        try:
+            return await op_factory()
+        except proxy_router_service.ProxyRouterServiceError as e:
+            if not proxy_router_service.is_nonce_error(str(e)):
+                raise
+            # Burst detected: throttle subsequent ops and retry this one once,
+            # serialized, after a brief jittered settle so the prior tx registers.
+            self._engage_throttle()
+            op_logger.warning(
+                "On-chain nonce conflict; throttling wallet and retrying serialized",
+                op=op_name,
+                cooldown_s=self._throttle_cooldown,
+                event_type="onchain_nonce_throttle",
+            )
+            await asyncio.sleep(0.2 + random.random() * 0.3)
+            async with self._wallet_lock:
+                return await op_factory()
+
     # =========================================================================
     # REQUEST PATH: Route requests to sessions
     # =========================================================================
     
     async def route_request(
         self,
-        db: AsyncSession,
         user_id: int,
         requested_model: Optional[str] = None,
         model_type: str = "LLM"
     ) -> str:
         """
         Route an authorized request to an appropriate session.
-        
-        This is the main entry point for the request path.
-        Sessions are shared across users - user_id is only used for
-        private key lookup when opening new sessions.
-        
-        Args:
-            db: Database session
-            user_id: User ID for private key lookup when opening sessions
-            requested_model: Model name or blockchain ID requested
-            model_type: Type of model (LLM, EMBEDDINGS, TTS, STT)
-            
+
+        Main entry point for the request path. Sessions are shared across
+        users - user_id is only used for private key lookup when opening a new
+        session.
+
+        Manages its own short-lived DB connections and holds NO DB connection
+        while waiting on the wallet lock / the slow on-chain openSession call.
+        This means any number of concurrent requests can queue for an open
+        without pinning the DB pool (the wallet lock itself is the queue).
+
         Returns:
             str: Session ID to use for the request
-            
+
         Raises:
             NoSessionAvailableError: If no session could be acquired
             SessionOpenError: If session opening failed
@@ -125,54 +189,45 @@ class SessionRoutingService:
             requested_model=requested_model,
             model_type=model_type
         )
-        
+
         # Resolve model to blockchain ID
         model_id = await model_router.get_target_model(requested_model, type=model_type)
         route_logger = route_logger.bind(model_id=model_id)
-        
+
         route_logger.info("Routing request to session",
                          event_type="route_request_start")
-        
+
         # FAST PATH (lock-free): atomically claim an idle OPEN session for this
-        # model with a single UPDATE ... FOR UPDATE SKIP LOCKED. This replaces the
-        # old "take per-model asyncio.Lock -> SELECT all rows -> pick in Python ->
-        # separate UPDATE+COMMIT" sequence. The DB row lock (not an in-process
-        # lock) guarantees a session is handed to exactly one request, so it is
-        # correct across replicas, and it never holds a lock across the slow
-        # blockchain openSession() call.
-        claimed_id = await self._claim_idle_session(db, model_id)
+        # model with a single UPDATE ... FOR UPDATE SKIP LOCKED on its own
+        # short-lived connection. The DB row lock (not an in-process lock) hands
+        # a session to exactly one request, correct across replicas, and the
+        # connection is released immediately (never held across the open below).
+        async with get_db() as db:
+            claimed_id = await self._claim_idle_session(db, model_id)
         if claimed_id is not None:
             route_logger.info("Routed to idle session (atomic claim)",
                              session_id=claimed_id,
                              event_type="route_to_unutilized")
             return claimed_id
 
-        # OPEN PATH: no idle session is available -> open a new one. Opening is a
-        # paid on-chain transaction, so we serialize opens per model with the lock
-        # to avoid a thundering herd of duplicate opens. The fast path above no
-        # longer touches this lock, so a slow open only blocks other requests that
-        # *also* need a brand-new session for the same model (not every request).
-        # We re-claim once after acquiring the lock: while we waited, a concurrent
-        # opener may have created a session that has since been released.
-        # NOTE: if open latency under heavy scale-up becomes a problem, replace
-        # this lock with a bounded asyncio.Semaphore to cap (rather than serialize)
-        # concurrent on-chain opens per model.
-        model_lock = await self._get_model_lock(model_id)
-        async with model_lock:
-            claimed_id = await self._claim_idle_session(db, model_id)
-            if claimed_id is not None:
-                route_logger.info("Routed to idle session after lock wait (atomic claim)",
-                                 session_id=claimed_id,
-                                 event_type="route_to_unutilized_after_wait")
-                return claimed_id
+        # OPEN PATH: no idle session -> open a new paid on-chain session. The tx
+        # is serialized on the wallet lock inside _open_session_for_model (one
+        # consumer wallet -> one nonce sequence). NO DB connection is held while
+        # waiting on that lock, so any number of concurrent openers may queue
+        # without exhausting the DB pool. The session is created already assigned
+        # to this request (active_requests=1), so it is never momentarily visible
+        # as idle - and thus claimable by another request - between insert and
+        # use.
+        route_logger.info("No idle session for model, opening a new one",
+                         event_type="no_idle_session")
+        return await self._open_session_for_model(
+            model_id=model_id,
+            model_name=requested_model,
+            model_type=model_type,
+            user_id=user_id,
+            initial_active_requests=1,
+        )
 
-            route_logger.info("No idle session for model, opening a new one",
-                             event_type="no_idle_session")
-            session = await self._open_session_for_model(
-                db, model_id, requested_model, model_type, user_id
-            )
-            return await self._assign_request_to_session(db, session.id)
-    
     async def release_session(self, db: AsyncSession, session_id: str) -> None:
         """
         Release a session after request completion.
@@ -274,7 +329,13 @@ class SessionRoutingService:
     async def _close_invalidated_session(self, session_id: str) -> None:
         """Best-effort proxy-router close for an invalidated session."""
         try:
-            await proxy_router_service.closeSession(session_id)
+            # Same wallet/nonce sequence as opens -> route through the adaptive
+            # throttle so a storm's closes don't collide with its opens.
+            await self._run_onchain(
+                lambda: proxy_router_service.closeSession(session_id),
+                op_name="closeSession",
+                op_logger=logger,
+            )
             logger.info("Invalidated session closed on proxy router",
                         session_id=session_id,
                         event_type="invalidated_session_closed")
@@ -302,11 +363,10 @@ class SessionRoutingService:
                 ...
             # Session automatically released on exit
         """
-        async with get_db() as db:
-            session_id = await self.route_request(
-                db, user_id, requested_model, model_type
-            )
-        
+        session_id = await self.route_request(
+            user_id, requested_model, model_type
+        )
+
         try:
             yield session_id
         finally:
@@ -319,30 +379,39 @@ class SessionRoutingService:
     
     async def _open_session_for_model(
         self,
-        db: AsyncSession,
         model_id: str,
         model_name: Optional[str] = None,
         model_type: str = "LLM",
-        user_id: Optional[int] = None
-    ) -> RoutedSession:
+        user_id: Optional[int] = None,
+        initial_active_requests: int = 0,
+    ) -> str:
         """
-        Open a new session for a model.
-        
-        Sessions are shared across users. The user_id is only used for
-        private key lookup when calling the proxy router.
-        
-        Note: DB row is only created after successful session opening (no OPENING state).
-        
+        Open a new on-chain session for a model and persist its row.
+
+        Sessions are shared across users. The user_id is only used for private
+        key lookup when calling the proxy router.
+
+        Holds NO DB connection while it waits on the wallet lock / the slow
+        on-chain openSession call - the row insert uses its own short-lived
+        connection afterwards. This lets any number of concurrent openers queue
+        on the wallet lock without pinning the DB pool.
+
+        DB row is only created after a successful open (no OPENING state).
+
         Args:
-            db: Database session
             model_id: Blockchain model ID (hex string)
             model_name: Human-readable model name
             model_type: Type of model
             user_id: Optional user ID for private key lookup (uses fallback if not provided)
-            
+            initial_active_requests: active_requests to create the row with. The
+                request path passes 1 so the session is created already assigned
+                to its caller (never momentarily idle / claimable by another
+                request between insert and use); the automation path passes 0 to
+                create an idle, pre-warmed session.
+
         Returns:
-            RoutedSession: The newly opened session
-            
+            str: The blockchain session id of the newly opened session.
+
         Raises:
             SessionOpenError: If session opening fails
         """
@@ -350,35 +419,44 @@ class SessionRoutingService:
             model_id=model_id,
             model_name=model_name
         )
-        
+
         open_logger.info("Opening new session for model",
                         event_type="session_open_start")
-        
+
         session_duration = settings.SESSION_DEFAULT_DURATION_SECONDS
         expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=session_duration)
-        
+
         try:
             # Call proxy router to open session
             # Uses user's private key if provided, otherwise uses fallback key
             open_logger.info("Calling proxy router to open session",
                            user_id=user_id,
                            event_type="proxy_open_session_start")
-            
-            response = await proxy_router_service.openSession(
-                target_model=model_id,
-                session_duration=session_duration,
-                failover=False,
-                direct_payment=False
+
+            # Adaptive throttle: open concurrently on the happy path; serialize
+            # on the wallet lock only while throttled (after a nonce conflict).
+            # No DB connection is held across this call (the row insert below
+            # uses its own short-lived session), so a throttled queue can grow
+            # without exhausting the DB pool.
+            response = await self._run_onchain(
+                lambda: proxy_router_service.openSession(
+                    target_model=model_id,
+                    session_duration=session_duration,
+                    failover=False,
+                    direct_payment=False,
+                ),
+                op_name="openSession",
+                op_logger=open_logger,
             )
-            
+
             blockchain_session_id = response.get("sessionID")
-            
+
             if not blockchain_session_id:
                 raise SessionOpenError(
                     "No session ID returned from proxy router",
                     model_id=model_id
                 )
-            
+
             # Create session record only after successful open
             now = datetime.now(timezone.utc).replace(tzinfo=None)
             endpoint = "/v1/chat/completions"
@@ -386,44 +464,51 @@ class SessionRoutingService:
                 endpoint = "/v1/embeddings"
             elif model_type == "AUTOMATION":
                 endpoint = ""
-            session = RoutedSession(
-                id=blockchain_session_id,
-                model_id=model_id,
-                model_name=model_name,
-                state=SessionState.OPEN,
-                expires_at=expires_at,
-                active_requests=0,
-                created_at=now,
-                updated_at=now,
-                endpoint=endpoint
-            )
-            
-            db.add(session)
-            await db.commit()
-            await db.refresh(session)
-            
+
+            # Persist on a fresh short-lived connection. Create the row already
+            # assigned (active_requests=initial_active_requests) so a request-path
+            # session (1) is never visible as idle - and thus claimable by a
+            # concurrent request via _claim_idle_session - between insert and use.
+            async with get_db() as db:
+                session = RoutedSession(
+                    id=blockchain_session_id,
+                    model_id=model_id,
+                    model_name=model_name,
+                    state=SessionState.OPEN,
+                    expires_at=expires_at,
+                    active_requests=initial_active_requests,
+                    created_at=now,
+                    updated_at=now,
+                    endpoint=endpoint
+                )
+                db.add(session)
+                await db.commit()
+
             open_logger.info("Session opened successfully",
                            session_id=blockchain_session_id,
                            event_type="session_opened")
-            
-            return session
-            
+
+            return blockchain_session_id
+
+        except SessionOpenError:
+            # Already a clean domain error (e.g. no session id returned).
+            raise
         except proxy_router_service.ProxyRouterServiceError as e:
             open_logger.error("Proxy router error opening session",
                             error=str(e),
                             event_type="session_open_proxy_error")
-            
+
             raise SessionOpenError(
                 f"Failed to open session: {e.message}",
                 model_id=model_id
             ) from e
-            
+
         except Exception as e:
             open_logger.error("Error opening session",
                             error=str(e),
                             event_type="session_open_error",
                             exc_info=True)
-            
+
             raise SessionOpenError(
                 f"Failed to open session: {str(e)}",
                 model_id=model_id
@@ -462,9 +547,14 @@ class SessionRoutingService:
                          event_type="session_close_start")
         
         try:
-            # Call proxy router to close session
-            await proxy_router_service.closeSession(session.id)
-            
+            # Close on-chain via the adaptive throttle (shared wallet/nonce
+            # with every other on-chain session op on this replica).
+            await self._run_onchain(
+                lambda: proxy_router_service.closeSession(session.id),
+                op_name="closeSession",
+                op_logger=close_logger,
+            )
+
             # Mark as CLOSED
             session.state = SessionState.CLOSED
             session.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -499,41 +589,6 @@ class SessionRoutingService:
                              exc_info=True)
             return False
     
-    async def _assign_request_to_session(
-        self,
-        db: AsyncSession,
-        session_id: str
-    ) -> str:
-        """
-        Assign a request to a session (increment active_requests).
-        
-        Args:
-            db: Database session
-            session_id: Session ID to assign to
-            
-        Returns:
-            str: The session ID
-        """
-        now = datetime.now(timezone.utc).replace(tzinfo=None)
-        
-        # Atomic increment of active_requests and update last_used_at
-        await db.execute(
-            update(RoutedSession)
-            .where(RoutedSession.id == session_id)
-            .values(
-                active_requests=RoutedSession.active_requests + 1,
-                last_used_at=now,
-                updated_at=now
-            )
-        )
-        await db.commit()
-        
-        logger.debug("Request assigned to session",
-                    session_id=session_id,
-                    event_type="request_assigned")
-
-        return session_id
-
     async def _claim_idle_session(
         self,
         db: AsyncSession,
@@ -759,7 +814,6 @@ class SessionRoutingService:
                 
                 try:
                     await self._open_session_for_model(
-                        db=db,
                         model_id=model_id,
                         model_name=None,
                         model_type="AUTOMATION",
@@ -824,7 +878,6 @@ class SessionRoutingService:
                                   event_type="preferred_all_utilized")
                 try:
                     await self._open_session_for_model(
-                        db=db,
                         model_id=model_id,
                         model_name=None,
                         model_type="LLM",
@@ -884,10 +937,15 @@ class SessionRoutingService:
             session.state = SessionState.EXPIRED
             session.updated_at = now
             
-            # Still try to close on proxy router
+            # Still try to close on proxy router (via the adaptive throttle,
+            # shared wallet/nonce with all other on-chain ops).
             try:
-                await proxy_router_service.closeSession(session.id)
-                
+                await self._run_onchain(
+                    lambda: proxy_router_service.closeSession(session.id),
+                    op_name="closeSession",
+                    op_logger=logger,
+                )
+
             except Exception as e:
                 logger.warning("Error closing expired session on proxy",
                              session_id=session.id,

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -56,15 +56,19 @@ class SessionRoutingService:
     Service for routing requests to sessions and managing session lifecycle.
     
     Thread-safety:
-    - Uses per-model locking to prevent race conditions
+    - On-chain session ops are serialized per replica on a single wallet lock
+      (the consumer wallet's nonce is shared across all models)
     - Database operations use row-level locking where needed
     """
     
     def __init__(self):
-        # Per-model locks for request routing
-        self._model_locks: Dict[str, asyncio.Lock] = {}
-        self._locks_lock = asyncio.Lock()
-        
+        # On-chain wallet serialization (per replica). A single consumer wallet
+        # signs every open/closeSession, so concurrent on-chain txs collide on
+        # nonce ("replacement transaction underpriced"). This lock serializes
+        # ALL on-chain session ops on this replica (opens AND closes), across
+        # models — nonce is per-wallet, not per-model.
+        self._wallet_lock = asyncio.Lock()
+
         # Automation loop control
         self._automation_task: Optional[asyncio.Task] = None
         self._shutdown_event = asyncio.Event()
@@ -75,13 +79,6 @@ class SessionRoutingService:
         
         logger.info("SessionRoutingService initialized",
                    event_type="session_routing_service_init")
-    
-    async def _get_model_lock(self, model_id: str) -> asyncio.Lock:
-        """Get or create a lock for a specific model."""
-        async with self._locks_lock:
-            if model_id not in self._model_locks:
-                self._model_locks[model_id] = asyncio.Lock()
-            return self._model_locks[model_id]
     
     def _get_preferred_models(self) -> set:
         """Get the set of preferred model IDs from configuration."""
@@ -95,27 +92,25 @@ class SessionRoutingService:
     
     async def route_request(
         self,
-        db: AsyncSession,
         user_id: int,
         requested_model: Optional[str] = None,
         model_type: str = "LLM"
     ) -> str:
         """
         Route an authorized request to an appropriate session.
-        
-        This is the main entry point for the request path.
-        Sessions are shared across users - user_id is only used for
-        private key lookup when opening new sessions.
-        
-        Args:
-            db: Database session
-            user_id: User ID for private key lookup when opening sessions
-            requested_model: Model name or blockchain ID requested
-            model_type: Type of model (LLM, EMBEDDINGS, TTS, STT)
-            
+
+        Main entry point for the request path. Sessions are shared across
+        users - user_id is only used for private key lookup when opening a new
+        session.
+
+        Manages its own short-lived DB connections and holds NO DB connection
+        while waiting on the wallet lock / the slow on-chain openSession call.
+        This means any number of concurrent requests can queue for an open
+        without pinning the DB pool (the wallet lock itself is the queue).
+
         Returns:
             str: Session ID to use for the request
-            
+
         Raises:
             NoSessionAvailableError: If no session could be acquired
             SessionOpenError: If session opening failed
@@ -125,54 +120,45 @@ class SessionRoutingService:
             requested_model=requested_model,
             model_type=model_type
         )
-        
+
         # Resolve model to blockchain ID
         model_id = await model_router.get_target_model(requested_model, type=model_type)
         route_logger = route_logger.bind(model_id=model_id)
-        
+
         route_logger.info("Routing request to session",
                          event_type="route_request_start")
-        
+
         # FAST PATH (lock-free): atomically claim an idle OPEN session for this
-        # model with a single UPDATE ... FOR UPDATE SKIP LOCKED. This replaces the
-        # old "take per-model asyncio.Lock -> SELECT all rows -> pick in Python ->
-        # separate UPDATE+COMMIT" sequence. The DB row lock (not an in-process
-        # lock) guarantees a session is handed to exactly one request, so it is
-        # correct across replicas, and it never holds a lock across the slow
-        # blockchain openSession() call.
-        claimed_id = await self._claim_idle_session(db, model_id)
+        # model with a single UPDATE ... FOR UPDATE SKIP LOCKED on its own
+        # short-lived connection. The DB row lock (not an in-process lock) hands
+        # a session to exactly one request, correct across replicas, and the
+        # connection is released immediately (never held across the open below).
+        async with get_db() as db:
+            claimed_id = await self._claim_idle_session(db, model_id)
         if claimed_id is not None:
             route_logger.info("Routed to idle session (atomic claim)",
                              session_id=claimed_id,
                              event_type="route_to_unutilized")
             return claimed_id
 
-        # OPEN PATH: no idle session is available -> open a new one. Opening is a
-        # paid on-chain transaction, so we serialize opens per model with the lock
-        # to avoid a thundering herd of duplicate opens. The fast path above no
-        # longer touches this lock, so a slow open only blocks other requests that
-        # *also* need a brand-new session for the same model (not every request).
-        # We re-claim once after acquiring the lock: while we waited, a concurrent
-        # opener may have created a session that has since been released.
-        # NOTE: if open latency under heavy scale-up becomes a problem, replace
-        # this lock with a bounded asyncio.Semaphore to cap (rather than serialize)
-        # concurrent on-chain opens per model.
-        model_lock = await self._get_model_lock(model_id)
-        async with model_lock:
-            claimed_id = await self._claim_idle_session(db, model_id)
-            if claimed_id is not None:
-                route_logger.info("Routed to idle session after lock wait (atomic claim)",
-                                 session_id=claimed_id,
-                                 event_type="route_to_unutilized_after_wait")
-                return claimed_id
+        # OPEN PATH: no idle session -> open a new paid on-chain session. The tx
+        # is serialized on the wallet lock inside _open_session_for_model (one
+        # consumer wallet -> one nonce sequence). NO DB connection is held while
+        # waiting on that lock, so any number of concurrent openers may queue
+        # without exhausting the DB pool. The session is created already assigned
+        # to this request (active_requests=1), so it is never momentarily visible
+        # as idle - and thus claimable by another request - between insert and
+        # use.
+        route_logger.info("No idle session for model, opening a new one",
+                         event_type="no_idle_session")
+        return await self._open_session_for_model(
+            model_id=model_id,
+            model_name=requested_model,
+            model_type=model_type,
+            user_id=user_id,
+            initial_active_requests=1,
+        )
 
-            route_logger.info("No idle session for model, opening a new one",
-                             event_type="no_idle_session")
-            session = await self._open_session_for_model(
-                db, model_id, requested_model, model_type, user_id
-            )
-            return await self._assign_request_to_session(db, session.id)
-    
     async def release_session(self, db: AsyncSession, session_id: str) -> None:
         """
         Release a session after request completion.
@@ -274,7 +260,11 @@ class SessionRoutingService:
     async def _close_invalidated_session(self, session_id: str) -> None:
         """Best-effort proxy-router close for an invalidated session."""
         try:
-            await proxy_router_service.closeSession(session_id)
+            # Same wallet, same nonce sequence as opens -> serialize on the
+            # wallet lock so a failover storm's closes don't collide with its
+            # opens (or each other).
+            async with self._wallet_lock:
+                await proxy_router_service.closeSession(session_id)
             logger.info("Invalidated session closed on proxy router",
                         session_id=session_id,
                         event_type="invalidated_session_closed")
@@ -302,11 +292,10 @@ class SessionRoutingService:
                 ...
             # Session automatically released on exit
         """
-        async with get_db() as db:
-            session_id = await self.route_request(
-                db, user_id, requested_model, model_type
-            )
-        
+        session_id = await self.route_request(
+            user_id, requested_model, model_type
+        )
+
         try:
             yield session_id
         finally:
@@ -319,30 +308,39 @@ class SessionRoutingService:
     
     async def _open_session_for_model(
         self,
-        db: AsyncSession,
         model_id: str,
         model_name: Optional[str] = None,
         model_type: str = "LLM",
-        user_id: Optional[int] = None
-    ) -> RoutedSession:
+        user_id: Optional[int] = None,
+        initial_active_requests: int = 0,
+    ) -> str:
         """
-        Open a new session for a model.
-        
-        Sessions are shared across users. The user_id is only used for
-        private key lookup when calling the proxy router.
-        
-        Note: DB row is only created after successful session opening (no OPENING state).
-        
+        Open a new on-chain session for a model and persist its row.
+
+        Sessions are shared across users. The user_id is only used for private
+        key lookup when calling the proxy router.
+
+        Holds NO DB connection while it waits on the wallet lock / the slow
+        on-chain openSession call - the row insert uses its own short-lived
+        connection afterwards. This lets any number of concurrent openers queue
+        on the wallet lock without pinning the DB pool.
+
+        DB row is only created after a successful open (no OPENING state).
+
         Args:
-            db: Database session
             model_id: Blockchain model ID (hex string)
             model_name: Human-readable model name
             model_type: Type of model
             user_id: Optional user ID for private key lookup (uses fallback if not provided)
-            
+            initial_active_requests: active_requests to create the row with. The
+                request path passes 1 so the session is created already assigned
+                to its caller (never momentarily idle / claimable by another
+                request between insert and use); the automation path passes 0 to
+                create an idle, pre-warmed session.
+
         Returns:
-            RoutedSession: The newly opened session
-            
+            str: The blockchain session id of the newly opened session.
+
         Raises:
             SessionOpenError: If session opening fails
         """
@@ -350,35 +348,41 @@ class SessionRoutingService:
             model_id=model_id,
             model_name=model_name
         )
-        
+
         open_logger.info("Opening new session for model",
                         event_type="session_open_start")
-        
+
         session_duration = settings.SESSION_DEFAULT_DURATION_SECONDS
         expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=session_duration)
-        
+
         try:
             # Call proxy router to open session
             # Uses user's private key if provided, otherwise uses fallback key
             open_logger.info("Calling proxy router to open session",
                            user_id=user_id,
                            event_type="proxy_open_session_start")
-            
-            response = await proxy_router_service.openSession(
-                target_model=model_id,
-                session_duration=session_duration,
-                failover=False,
-                direct_payment=False
-            )
-            
+
+            # Serialize the on-chain tx on the wallet lock: one consumer wallet
+            # signs every session tx, so concurrent opens collide on nonce. No DB
+            # connection is held across this wait/call (the row insert below uses
+            # its own short-lived session), so unbounded concurrent openers can
+            # queue here without exhausting the DB pool.
+            async with self._wallet_lock:
+                response = await proxy_router_service.openSession(
+                    target_model=model_id,
+                    session_duration=session_duration,
+                    failover=False,
+                    direct_payment=False
+                )
+
             blockchain_session_id = response.get("sessionID")
-            
+
             if not blockchain_session_id:
                 raise SessionOpenError(
                     "No session ID returned from proxy router",
                     model_id=model_id
                 )
-            
+
             # Create session record only after successful open
             now = datetime.now(timezone.utc).replace(tzinfo=None)
             endpoint = "/v1/chat/completions"
@@ -386,44 +390,51 @@ class SessionRoutingService:
                 endpoint = "/v1/embeddings"
             elif model_type == "AUTOMATION":
                 endpoint = ""
-            session = RoutedSession(
-                id=blockchain_session_id,
-                model_id=model_id,
-                model_name=model_name,
-                state=SessionState.OPEN,
-                expires_at=expires_at,
-                active_requests=0,
-                created_at=now,
-                updated_at=now,
-                endpoint=endpoint
-            )
-            
-            db.add(session)
-            await db.commit()
-            await db.refresh(session)
-            
+
+            # Persist on a fresh short-lived connection. Create the row already
+            # assigned (active_requests=initial_active_requests) so a request-path
+            # session (1) is never visible as idle - and thus claimable by a
+            # concurrent request via _claim_idle_session - between insert and use.
+            async with get_db() as db:
+                session = RoutedSession(
+                    id=blockchain_session_id,
+                    model_id=model_id,
+                    model_name=model_name,
+                    state=SessionState.OPEN,
+                    expires_at=expires_at,
+                    active_requests=initial_active_requests,
+                    created_at=now,
+                    updated_at=now,
+                    endpoint=endpoint
+                )
+                db.add(session)
+                await db.commit()
+
             open_logger.info("Session opened successfully",
                            session_id=blockchain_session_id,
                            event_type="session_opened")
-            
-            return session
-            
+
+            return blockchain_session_id
+
+        except SessionOpenError:
+            # Already a clean domain error (e.g. no session id returned).
+            raise
         except proxy_router_service.ProxyRouterServiceError as e:
             open_logger.error("Proxy router error opening session",
                             error=str(e),
                             event_type="session_open_proxy_error")
-            
+
             raise SessionOpenError(
                 f"Failed to open session: {e.message}",
                 model_id=model_id
             ) from e
-            
+
         except Exception as e:
             open_logger.error("Error opening session",
                             error=str(e),
                             event_type="session_open_error",
                             exc_info=True)
-            
+
             raise SessionOpenError(
                 f"Failed to open session: {str(e)}",
                 model_id=model_id
@@ -462,9 +473,12 @@ class SessionRoutingService:
                          event_type="session_close_start")
         
         try:
-            # Call proxy router to close session
-            await proxy_router_service.closeSession(session.id)
-            
+            # Call proxy router to close session. Serialize on the wallet lock:
+            # the consumer wallet's nonce is shared with every other on-chain
+            # session op on this replica.
+            async with self._wallet_lock:
+                await proxy_router_service.closeSession(session.id)
+
             # Mark as CLOSED
             session.state = SessionState.CLOSED
             session.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -499,41 +513,6 @@ class SessionRoutingService:
                              exc_info=True)
             return False
     
-    async def _assign_request_to_session(
-        self,
-        db: AsyncSession,
-        session_id: str
-    ) -> str:
-        """
-        Assign a request to a session (increment active_requests).
-        
-        Args:
-            db: Database session
-            session_id: Session ID to assign to
-            
-        Returns:
-            str: The session ID
-        """
-        now = datetime.now(timezone.utc).replace(tzinfo=None)
-        
-        # Atomic increment of active_requests and update last_used_at
-        await db.execute(
-            update(RoutedSession)
-            .where(RoutedSession.id == session_id)
-            .values(
-                active_requests=RoutedSession.active_requests + 1,
-                last_used_at=now,
-                updated_at=now
-            )
-        )
-        await db.commit()
-        
-        logger.debug("Request assigned to session",
-                    session_id=session_id,
-                    event_type="request_assigned")
-
-        return session_id
-
     async def _claim_idle_session(
         self,
         db: AsyncSession,
@@ -759,7 +738,6 @@ class SessionRoutingService:
                 
                 try:
                     await self._open_session_for_model(
-                        db=db,
                         model_id=model_id,
                         model_name=None,
                         model_type="AUTOMATION",
@@ -824,7 +802,6 @@ class SessionRoutingService:
                                   event_type="preferred_all_utilized")
                 try:
                     await self._open_session_for_model(
-                        db=db,
                         model_id=model_id,
                         model_name=None,
                         model_type="LLM",
@@ -884,10 +861,12 @@ class SessionRoutingService:
             session.state = SessionState.EXPIRED
             session.updated_at = now
             
-            # Still try to close on proxy router
+            # Still try to close on proxy router (serialized on the wallet lock
+            # with all other on-chain session ops to avoid nonce collisions).
             try:
-                await proxy_router_service.closeSession(session.id)
-                
+                async with self._wallet_lock:
+                    await proxy_router_service.closeSession(session.id)
+
             except Exception as e:
                 logger.warning("Error closing expired session on proxy",
                              session_id=session.id,

--- a/tests/unit/test_proxy_nonce_retry.py
+++ b/tests/unit/test_proxy_nonce_retry.py
@@ -1,0 +1,42 @@
+"""Nonce errors must be non-retriable in _execute_request.
+
+Re-sending the identical request never fixes a nonce race, and blind backoff
+retries amplify a failover storm. Surfacing the nonce error after one attempt
+lets the gateway's adaptive wallet throttle engage (see
+SessionRoutingService._run_onchain). Non-nonce 5xx errors must still be retried.
+"""
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.services import proxy_router_service as prs
+
+
+def _fake_client_returning(status: int, body: str):
+    req = httpx.Request("POST", "http://proxy/blockchain/models/0xabc/session")
+    resp = httpx.Response(status, text=body, request=req)  # .raise_for_status() raises on 5xx
+    client = MagicMock()
+    client.request = AsyncMock(return_value=resp)
+    return client
+
+
+async def test_nonce_error_is_not_retried():
+    client = _fake_client_returning(500, '{"error":"failed to send transaction: replacement transaction underpriced"}')
+    with patch.object(prs, "get_http_client", new_callable=AsyncMock, return_value=client):
+        with pytest.raises(prs.ProxyRouterServiceError):
+            await prs.openSession(target_model="0xabc", session_duration=60)
+    assert client.request.await_count == 1, "nonce errors must surface after one attempt"
+
+
+async def test_non_nonce_5xx_is_still_retried():
+    client = _fake_client_returning(500, '{"error":"no provider accepting session"}')
+    with patch.object(prs, "get_http_client", new_callable=AsyncMock, return_value=client), \
+         patch.object(prs.asyncio, "sleep", new_callable=AsyncMock):
+        with pytest.raises(prs.ProxyRouterServiceError):
+            await prs.openSession(target_model="0xabc", session_duration=60)
+    assert client.request.await_count == 3, "non-nonce 5xx must still exhaust max_retries"

--- a/tests/unit/test_session_routing_claim.py
+++ b/tests/unit/test_session_routing_claim.py
@@ -10,6 +10,7 @@ at runtime/CI against the real database.
 """
 import os
 import sys
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -43,66 +44,55 @@ def _claim_result(value):
 
 # ---------------------------------------------------------------------------
 # route_request control flow
+#
+# route_request no longer takes a `db` param — it manages its own short-lived
+# connections (so it holds none while waiting on the wallet lock). It opens at
+# most one claim attempt, then opens a new session created already-assigned
+# (no separate _assign step, no re-claim).
 # ---------------------------------------------------------------------------
 
 
-async def test_fast_path_returns_claimed_session_without_lock_or_open(service, mock_db):
-    """An idle session is claimed lock-free; no open, single claim attempt."""
+def _patch_get_db(db):
+    @asynccontextmanager
+    async def _fake_get_db():
+        yield db
+    return patch("src.services.session_routing_service.get_db", _fake_get_db)
+
+
+async def test_fast_path_returns_claimed_session_without_open(service, mock_db):
+    """An idle session is claimed lock-free; no open."""
     service._claim_idle_session = AsyncMock(return_value="0xidle")
     service._open_session_for_model = AsyncMock()
-    service._assign_request_to_session = AsyncMock()
 
-    with patch(
+    with _patch_get_db(mock_db), patch(
         "src.services.session_routing_service.model_router.get_target_model",
         new_callable=AsyncMock,
         return_value="0xmodel",
     ):
-        session_id = await service.route_request(mock_db, user_id=1, requested_model="m")
+        session_id = await service.route_request(user_id=1, requested_model="m")
 
     assert session_id == "0xidle"
     service._claim_idle_session.assert_awaited_once_with(mock_db, "0xmodel")
     service._open_session_for_model.assert_not_awaited()
-    service._assign_request_to_session.assert_not_awaited()
 
 
-async def test_open_path_opens_new_session_when_none_idle(service, mock_db):
-    """Two misses (fast path + re-claim under lock) -> open + assign."""
-    service._claim_idle_session = AsyncMock(side_effect=[None, None])
-    new_session = MagicMock()
-    new_session.id = "0xnew"
-    service._open_session_for_model = AsyncMock(return_value=new_session)
-    service._assign_request_to_session = AsyncMock(return_value="0xnew")
+async def test_open_path_opens_assigned_session_when_none_idle(service, mock_db):
+    """Fast-path miss -> open a new session, created already assigned (active_requests=1)."""
+    service._claim_idle_session = AsyncMock(return_value=None)
+    service._open_session_for_model = AsyncMock(return_value="0xnew")
 
-    with patch(
+    with _patch_get_db(mock_db), patch(
         "src.services.session_routing_service.model_router.get_target_model",
         new_callable=AsyncMock,
         return_value="0xmodel",
     ):
-        session_id = await service.route_request(mock_db, user_id=1, requested_model="m")
+        session_id = await service.route_request(user_id=1, requested_model="m")
 
     assert session_id == "0xnew"
-    assert service._claim_idle_session.await_count == 2
+    service._claim_idle_session.assert_awaited_once()
     service._open_session_for_model.assert_awaited_once()
-    service._assign_request_to_session.assert_awaited_once_with(mock_db, "0xnew")
-
-
-async def test_reclaim_after_lock_wait_avoids_redundant_open(service, mock_db):
-    """Fast path misses, but a session freed up while waiting on the lock:
-    the re-claim succeeds and we must NOT open another session."""
-    service._claim_idle_session = AsyncMock(side_effect=[None, "0xfreed"])
-    service._open_session_for_model = AsyncMock()
-    service._assign_request_to_session = AsyncMock()
-
-    with patch(
-        "src.services.session_routing_service.model_router.get_target_model",
-        new_callable=AsyncMock,
-        return_value="0xmodel",
-    ):
-        session_id = await service.route_request(mock_db, user_id=1, requested_model="m")
-
-    assert session_id == "0xfreed"
-    assert service._claim_idle_session.await_count == 2
-    service._open_session_for_model.assert_not_awaited()
+    _, kwargs = service._open_session_for_model.call_args
+    assert kwargs.get("initial_active_requests") == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_session_routing_serialization.py
+++ b/tests/unit/test_session_routing_serialization.py
@@ -1,0 +1,230 @@
+"""Tests for the ADAPTIVE on-chain wallet throttle in SessionRoutingService.
+
+The single consumer wallet has no nonce lock in the C-Node, so a simultaneous
+BURST of txs (a failover storm) collides on nonce, while normal time-staggered
+load sequences fine. So on-chain ops run CONCURRENTLY on the happy path and
+serialize on the wallet lock only after a nonce conflict is observed, for a
+short cooldown window. New request-path sessions are still created already
+assigned (active_requests=1), and no DB connection is held across the on-chain
+call. These tests pin that behavior.
+"""
+import asyncio
+import os
+import sys
+import time
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.db.models import SessionState
+from src.services import proxy_router_service
+from src.services.proxy_router_service import ProxyRouterServiceError
+from src.services.session_routing_service import SessionRoutingService
+
+
+@pytest.fixture
+def service():
+    return SessionRoutingService()
+
+
+def _make_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.execute = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+def _patch_get_db(db):
+    @asynccontextmanager
+    async def _fake_get_db():
+        yield db
+    return patch("src.services.session_routing_service.get_db", _fake_get_db)
+
+
+def _overlap_tracker(state, return_value):
+    """Async stand-in for an on-chain call that records peak concurrency."""
+
+    async def _call(*args, **kwargs):
+        state["cur"] += 1
+        state["max"] = max(state["max"], state["cur"])
+        await asyncio.sleep(0.01)
+        state["cur"] -= 1
+        return return_value
+
+    return _call
+
+
+# ---------------------------------------------------------------------------
+# is_nonce_error detector
+# ---------------------------------------------------------------------------
+
+
+def test_is_nonce_error_matches_signatures():
+    assert proxy_router_service.is_nonce_error("HTTP 500: replacement transaction underpriced")
+    assert proxy_router_service.is_nonce_error("nonce too low")
+    assert proxy_router_service.is_nonce_error("Nonce error for 0xabc")
+    assert not proxy_router_service.is_nonce_error("no provider accepting session")
+    assert not proxy_router_service.is_nonce_error("insufficient balance")
+    assert not proxy_router_service.is_nonce_error("")
+
+
+# ---------------------------------------------------------------------------
+# Happy path: NOT serialized (the whole point of adaptive throttling).
+# ---------------------------------------------------------------------------
+
+
+async def test_normal_mode_opens_run_concurrently(service):
+    state = {"cur": 0, "max": 0}
+    with _patch_get_db(_make_db()), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(side_effect=_overlap_tracker(state, {"sessionID": "0xsid"})),
+    ):
+        await asyncio.gather(
+            *[service._open_session_for_model(model_id=f"0xmodel{i}") for i in range(6)]
+        )
+    assert not service._is_throttled()
+    assert state["max"] > 1, "happy-path opens must NOT be serialized"
+
+
+# ---------------------------------------------------------------------------
+# Nonce conflict -> engage throttle + serialized retry of the failing op.
+# ---------------------------------------------------------------------------
+
+
+async def test_nonce_conflict_engages_throttle_and_retries_serialized(service):
+    open_mock = AsyncMock(side_effect=[
+        ProxyRouterServiceError("HTTP 500: replacement transaction underpriced"),
+        {"sessionID": "0xrecovered"},
+    ])
+    with _patch_get_db(_make_db()), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession", new=open_mock
+    ), patch("src.services.session_routing_service.asyncio.sleep", new=AsyncMock()):
+        sid = await service._open_session_for_model(model_id="0xmodel", initial_active_requests=1)
+
+    assert sid == "0xrecovered", "the op must be rescued by the serialized retry"
+    assert open_mock.await_count == 2, "exactly one serialized retry"
+    assert service._is_throttled(), "a nonce conflict must arm the throttle window"
+
+
+async def test_non_nonce_error_does_not_throttle_or_retry(service):
+    open_mock = AsyncMock(side_effect=ProxyRouterServiceError("no provider accepting session"))
+    with _patch_get_db(_make_db()), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession", new=open_mock
+    ):
+        with pytest.raises(Exception):
+            await service._open_session_for_model(model_id="0xmodel")
+
+    assert open_mock.await_count == 1, "non-nonce errors must not be retried"
+    assert not service._is_throttled(), "non-nonce errors must not arm the throttle"
+
+
+# ---------------------------------------------------------------------------
+# While throttled: serialize (drain the burst in nonce order), opens AND closes.
+# ---------------------------------------------------------------------------
+
+
+async def test_throttled_mode_serializes_opens(service):
+    service._throttle_until = time.monotonic() + 100  # force THROTTLED
+    state = {"cur": 0, "max": 0}
+    with _patch_get_db(_make_db()), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(side_effect=_overlap_tracker(state, {"sessionID": "0xsid"})),
+    ):
+        await asyncio.gather(
+            *[service._open_session_for_model(model_id=f"0xmodel{i}") for i in range(6)]
+        )
+    assert state["max"] == 1, "throttled opens must serialize on the wallet lock"
+
+
+async def test_throttled_mode_open_and_close_share_lock(service):
+    service._throttle_until = time.monotonic() + 100
+    state = {"cur": 0, "max": 0}
+    with _patch_get_db(_make_db()), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(side_effect=_overlap_tracker(state, {"sessionID": "0xsid"})),
+    ), patch(
+        "src.services.session_routing_service.proxy_router_service.closeSession",
+        new=AsyncMock(side_effect=_overlap_tracker(state, {"success": True})),
+    ):
+        await asyncio.gather(
+            service._open_session_for_model(model_id="0xmodel"),
+            service._close_invalidated_session("0xdead"),
+        )
+    assert state["max"] == 1, "throttled open and close share the wallet lock"
+
+
+# ---------------------------------------------------------------------------
+# No DB connection is held across the on-chain open (so a throttled queue
+# cannot exhaust the pool).
+# ---------------------------------------------------------------------------
+
+
+async def test_no_db_connection_held_during_onchain_open(service):
+    db_entered_during_open = {"value": False}
+    open_in_flight = {"value": False}
+
+    async def _open(*args, **kwargs):
+        open_in_flight["value"] = True
+        await asyncio.sleep(0.01)
+        open_in_flight["value"] = False
+        return {"sessionID": "0xnew"}
+
+    @asynccontextmanager
+    async def _tracking_get_db():
+        if open_in_flight["value"]:
+            db_entered_during_open["value"] = True
+        yield _make_db()
+
+    with patch("src.services.session_routing_service.get_db", _tracking_get_db), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(side_effect=_open),
+    ):
+        await service._open_session_for_model(model_id="0xmodel")
+
+    assert db_entered_during_open["value"] is False, (
+        "a DB connection was checked out while the on-chain open was in flight"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create-assigned: request-path sessions are persisted with active_requests=1.
+# ---------------------------------------------------------------------------
+
+
+async def test_request_path_session_created_already_assigned(service):
+    db = _make_db()
+    added = []
+    db.add = MagicMock(side_effect=added.append)
+
+    with _patch_get_db(db), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(return_value={"sessionID": "0xnew"}),
+    ):
+        sid = await service._open_session_for_model(
+            model_id="0xmodel", initial_active_requests=1
+        )
+
+    assert sid == "0xnew"
+    assert len(added) == 1
+    assert added[0].active_requests == 1, "request-path session must be created already assigned"
+    assert added[0].state == SessionState.OPEN
+
+
+async def test_automation_path_session_created_idle(service):
+    db = _make_db()
+    added = []
+    db.add = MagicMock(side_effect=added.append)
+
+    with _patch_get_db(db), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(return_value={"sessionID": "0xidle"}),
+    ):
+        await service._open_session_for_model(model_id="0xmodel")  # default 0
+
+    assert added[0].active_requests == 0, "automation pre-warm session must be idle"

--- a/tests/unit/test_session_routing_serialization.py
+++ b/tests/unit/test_session_routing_serialization.py
@@ -1,0 +1,190 @@
+"""Tests for per-replica on-chain wallet serialization in SessionRoutingService.
+
+A single consumer wallet signs every on-chain open/closeSession, so concurrent
+txs collide on nonce ("replacement transaction underpriced"). The service
+serializes all on-chain session ops on a replica with one wallet lock, while
+holding NO DB connection during the wait — so any number of concurrent openers
+can queue on the lock without pinning the DB pool. New request-path sessions are
+created already assigned (active_requests=1) so they are never momentarily
+claimable by another request. These tests pin that behavior.
+"""
+import asyncio
+import os
+import sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.db.models import SessionState
+from src.services.session_routing_service import SessionRoutingService
+
+
+@pytest.fixture
+def service():
+    return SessionRoutingService()
+
+
+def _make_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.execute = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+def _patch_get_db(db):
+    """Patch the module-level get_db() so route paths use a mocked connection."""
+    @asynccontextmanager
+    async def _fake_get_db():
+        yield db
+    return patch("src.services.session_routing_service.get_db", _fake_get_db)
+
+
+def _overlap_tracker(state, return_value):
+    """An async stand-in for an on-chain call that records peak concurrency."""
+
+    async def _call(*args, **kwargs):
+        state["cur"] += 1
+        state["max"] = max(state["max"], state["cur"])
+        await asyncio.sleep(0.01)  # force a scheduling point mid-call
+        state["cur"] -= 1
+        return return_value
+
+    return _call
+
+
+# ---------------------------------------------------------------------------
+# Serialization: one on-chain tx at a time, ACROSS models (nonce is per-wallet,
+# not per-model — the old per-model lock allowed cross-model collisions).
+# ---------------------------------------------------------------------------
+
+
+async def test_open_session_serializes_onchain_across_models(service):
+    state = {"cur": 0, "max": 0}
+    with _patch_get_db(_make_db()), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(side_effect=_overlap_tracker(state, {"sessionID": "0xsid"})),
+    ):
+        await asyncio.gather(
+            *[service._open_session_for_model(model_id=f"0xmodel{i}") for i in range(8)]
+        )
+    assert state["max"] == 1, "concurrent opens for different models must not overlap on-chain"
+
+
+async def test_open_and_close_share_one_wallet_lock(service):
+    """An open and a background close must not issue overlapping on-chain txs."""
+    state = {"cur": 0, "max": 0}
+    with _patch_get_db(_make_db()), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(side_effect=_overlap_tracker(state, {"sessionID": "0xsid"})),
+    ), patch(
+        "src.services.session_routing_service.proxy_router_service.closeSession",
+        new=AsyncMock(side_effect=_overlap_tracker(state, {"success": True})),
+    ):
+        await asyncio.gather(
+            service._open_session_for_model(model_id="0xmodel"),
+            service._close_invalidated_session("0xdead"),
+        )
+    assert state["max"] == 1, "open and close share the wallet and must serialize"
+
+
+async def test_unbounded_openers_queue_without_a_cap(service):
+    """Many more concurrent openers than any old cap all complete (no shedding)."""
+    state = {"cur": 0, "max": 0, "done": 0}
+
+    async def _open(*args, **kwargs):
+        state["cur"] += 1
+        state["max"] = max(state["max"], state["cur"])
+        await asyncio.sleep(0.001)
+        state["cur"] -= 1
+        state["done"] += 1
+        return {"sessionID": "0xsid"}
+
+    with _patch_get_db(_make_db()), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(side_effect=_open),
+    ):
+        results = await asyncio.gather(
+            *[service._open_session_for_model(model_id="0xmodel") for _ in range(50)]
+        )
+
+    assert state["done"] == 50, "every queued opener must complete; none shed"
+    assert all(r == "0xsid" for r in results)
+    assert state["max"] == 1, "still strictly serialized on the wallet lock"
+
+
+# ---------------------------------------------------------------------------
+# No DB connection is acquired while the on-chain open is in flight (so an
+# unbounded queue cannot exhaust the pool).
+# ---------------------------------------------------------------------------
+
+
+async def test_no_db_connection_held_during_onchain_open(service):
+    """get_db() must not be entered until AFTER openSession returns."""
+    db_entered_during_open = {"value": False}
+    open_in_flight = {"value": False}
+
+    async def _open(*args, **kwargs):
+        open_in_flight["value"] = True
+        await asyncio.sleep(0.01)
+        open_in_flight["value"] = False
+        return {"sessionID": "0xnew"}
+
+    @asynccontextmanager
+    async def _tracking_get_db():
+        if open_in_flight["value"]:
+            db_entered_during_open["value"] = True
+        yield _make_db()
+
+    with patch("src.services.session_routing_service.get_db", _tracking_get_db), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(side_effect=_open),
+    ):
+        await service._open_session_for_model(model_id="0xmodel")
+
+    assert db_entered_during_open["value"] is False, (
+        "a DB connection was checked out while the on-chain open was in flight"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create-assigned: request-path sessions are persisted with active_requests=1.
+# ---------------------------------------------------------------------------
+
+
+async def test_request_path_session_created_already_assigned(service):
+    db = _make_db()
+    added = []
+    db.add = MagicMock(side_effect=added.append)
+
+    with _patch_get_db(db), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(return_value={"sessionID": "0xnew"}),
+    ):
+        sid = await service._open_session_for_model(
+            model_id="0xmodel", initial_active_requests=1
+        )
+
+    assert sid == "0xnew"
+    assert len(added) == 1
+    assert added[0].active_requests == 1, "request-path session must be created already assigned"
+    assert added[0].state == SessionState.OPEN
+
+
+async def test_automation_path_session_created_idle(service):
+    db = _make_db()
+    added = []
+    db.add = MagicMock(side_effect=added.append)
+
+    with _patch_get_db(db), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        new=AsyncMock(return_value={"sessionID": "0xidle"}),
+    ):
+        await service._open_session_for_model(model_id="0xmodel")  # default 0
+
+    assert added[0].active_requests == 0, "automation pre-warm session must be idle"


### PR DESCRIPTION
 - **Adaptive wallet throttle** (`SessionRoutingService._run_onchain`, wraps all 4
    on-chain ops — open + 3 close paths):
    - **Happy path:** runs fully concurrently, no lock.
    - **On a nonce conflict:** opens a sliding **THROTTLED** window
      (`SESSION_ONCHAIN_THROTTLE_COOLDOWN_SECONDS`, default **20s**), during which all
      on-chain ops serialize on a single per-replica wallet lock (draining the burst
      in nonce order), and retries the conflicting op **once**, serialized.
    - Detection mirrors the C-Node's nonce signatures (new
      `proxy_router_service.is_nonce_error` / `NONCE_ERROR_PATTERNS`).
  - **Nonce errors are now non-retriable in `_execute_request`** — re-sending the
    identical request never fixes a nonce race, so blind backoff retries only
    amplified the storm. Surfacing after one attempt lets the throttle engage
    immediately. Non-nonce 5xx still retry as before.
  - **No DB connection is held across the on-chain call** (`route_request` /
    `_open_session_for_model` manage their own short-lived sessions), so a throttled
    queue can grow without pinning the DB pool.
  - **New request-path sessions are created already assigned** (`active_requests=1`),
    closing a create-then-assign claim race; removed the separate
    `_assign_request_to_session` step.