### PR TITLE
fix(chat): single-bid sessions ride to expiry (check alternate-bid before invalidating)

### DIFF
--- a/docs/failover.md
+++ b/docs/failover.md
@@ -4,26 +4,23 @@ Two separate mechanisms, both bounded to exactly one retry per request:
 
 ## 1. Provider failover (different provider)
 
-Applies only when the provider becomes **unreachable during a session** — a
-*transport* failure: connection refused / can't connect or write to provider,
-provider closed the connection, provider not found, read timeout, LB 502/503/504,
-or a gateway↔proxy transport failure.
+Applies only when the provider becomes **unavailable during a session**
+(connection refused, dial/read timeouts, provider death, proxy 5xx,
+gateway↔proxy transport failures) **and the model has an alternate bid**.
 
-It deliberately does **not** trigger when the provider *answered* with an
-application/config error — e.g. `api adapter not found` (bid is misconfigured)
-or an upstream `EOF` mid-prompt (the bid's backend failed). Those arrive as a
-bare `5xx` wrapped in the generic `provider request failed: ...` envelope;
-retrying them on a fresh session cannot fix a broken bid and only churns
-sessions (open → fail → early on-chain close → reopen), so a plain `5xx` is no
-longer sufficient on its own — a transport signature is required.
-
-1. The `routed_sessions` row is marked `FAILED` (it will never be routed to
-   again) and closed on the proxy-router in the background (best-effort;
-   close works against a dead provider via the self-signed user report, and
-   the proxy-router's expiry handler is the backstop).
-2. The model must have **more than one** rated bid
-   (`GET blockchain/models/{id}/bids/rated`), otherwise the original error
-   is surfaced with no retry.
+1. **Alternate-bid check first.** The model must have **more than one** rated
+   bid (`GET blockchain/models/{id}/bids/rated`). If it has only one bid there
+   is nowhere to fail over to, so the session is **left OPEN** (NOT invalidated
+   or closed early): it rides to its natural on-chain expiry, the user's MOR is
+   **not** locked, and the original error is surfaced with no retry. This is
+   the pre-failover behavior and avoids the open→fail→early-close→reopen churn
+   (the bulk of it, since the dead single-bid legacy models drive ~98% of
+   failover attempts).
+2. With a sibling bid present, the `routed_sessions` row is marked `FAILED`
+   (it will never be routed to again) and closed on the proxy-router in the
+   background (best-effort; close works against a dead provider via the
+   self-signed user report, and the proxy-router's expiry handler is the
+   backstop).
 3. A fresh session is opened by model: the proxy-router tries bids
    best-first with a per-bid provider handshake, so the dead provider is
    skipped automatically and the session lands on the surviving provider.

--- a/docs/failover.md
+++ b/docs/failover.md
@@ -4,9 +4,18 @@ Two separate mechanisms, both bounded to exactly one retry per request:
 
 ## 1. Provider failover (different provider)
 
-Applies only when the provider becomes **unavailable during a session**:
-connection refused, dial/read timeouts, provider death, proxy 5xx,
-gateway↔proxy transport failures.
+Applies only when the provider becomes **unreachable during a session** — a
+*transport* failure: connection refused / can't connect or write to provider,
+provider closed the connection, provider not found, read timeout, LB 502/503/504,
+or a gateway↔proxy transport failure.
+
+It deliberately does **not** trigger when the provider *answered* with an
+application/config error — e.g. `api adapter not found` (bid is misconfigured)
+or an upstream `EOF` mid-prompt (the bid's backend failed). Those arrive as a
+bare `5xx` wrapped in the generic `provider request failed: ...` envelope;
+retrying them on a fresh session cannot fix a broken bid and only churns
+sessions (open → fail → early on-chain close → reopen), so a plain `5xx` is no
+longer sufficient on its own — a transport signature is required.
 
 1. The `routed_sessions` row is marked `FAILED` (it will never be routed to
    again) and closed on the proxy-router in the background (best-effort;

--- a/src/api/v1/chat/chat_failover.py
+++ b/src/api/v1/chat/chat_failover.py
@@ -2,18 +2,18 @@
 Gateway-owned provider failover.
 
 Failover = open a new session with a DIFFERENT provider. It applies ONLY
-when the provider becomes UNREACHABLE during a session — i.e. a transport
-failure (conn refused / write failure / provider closed the connection /
-provider-task gone / read timeout / LB 502-504). On such a failure the
-gateway marks the dead RoutedSession FAILED, opens a fresh session for the
-same model (the proxy-router's per-bid handshake skips the dead provider),
-and the caller retries the prompt exactly once.
+when the provider becomes unavailable during a session (conn refused /
+timeouts / 5xx / provider death) AND the model has an alternate bid to fail
+over to. On such a failure the gateway marks the dead RoutedSession FAILED,
+opens a fresh session for the same model (the proxy-router's per-bid
+handshake skips the dead provider), and the caller retries the prompt
+exactly once.
 
-It deliberately does NOT trigger on errors where the provider ANSWERED with
-an application/config error (e.g. "api adapter not found", an upstream EOF
-mid-prompt). Those mean the bid is reachable but misconfigured/broken;
-retrying them on a fresh session cannot fix the model and previously caused
-an open/fail/early-close reopen storm (see narrowing rationale below).
+Single-bid models are left untouched: with no alternate bid there is nothing
+to fail over to, so the session is NOT invalidated or closed early (which
+would lock the user's MOR for ~1 day). It rides to natural expiry and the
+original error is surfaced — the pre-failover behavior. The alternate-bid
+check therefore runs BEFORE any invalidation.
 
 Session expiry ("session expired") is a SEPARATE mechanism — the renewal
 flow in the chat handlers — and is explicitly EXCLUDED here.
@@ -44,49 +44,29 @@ NON_FAILOVER_ERROR_PATTERNS = [
     "request cancelled while waiting in queue",
 ]
 
-# Transport-level signatures meaning a node became UNREACHABLE — the only
-# class of failure that warrants opening a new session on a different bid.
-#
-# These are the proxy-router's provider-transport sentinels (see
-# proxy-router/internal/proxyapi/proxy_sender.go) plus the gateway<->proxy
-# stream-setup transport wrapper. A provider that ANSWERS with an
-# application/config error (e.g. "api adapter not found", or an upstream
-# "...EOF" mid-prompt) is reachable and is NOT listed here on purpose:
-# failover cannot fix a broken/misconfigured bid, and treating those as
-# provider-unavailability caused a reopen storm (open -> immediate fail ->
-# early on-chain close (MOR lock) -> reopen) that amplified session volume.
-#
-# NB: the generic envelope "provider request failed: ..." was REMOVED — the
-# proxy-router wraps EVERY provider error in it (including adapter-not-found
-# and upstream EOF), so it matched far more than genuine provider death.
-PROVIDER_TRANSPORT_PATTERNS = [
+# Provider-unavailability signatures from the proxy-router (see
+# proxy-router/internal/proxyapi/proxy_sender.go sentinel errors).
+# Used when no status code is available on the exception.
+PROVIDER_FAILURE_PATTERNS = [
     "failed to connect to provider",
     "failed to write to provider",
+    "provider request failed",
     "provider closed connection",
     "provider not found",
     "read timed out",
-    # chatCompletionsStream wraps gateway<->proxy transport failures with
-    # status=None ("Failed to create chat completions stream: <transport
-    # error>"). App errors arrive as ProxyRouterServiceError with a status and
-    # are re-raised before this wrap, so this only catches real transport.
+    # chatCompletionsStream wraps transport errors with status=None and
+    # error_type="unknown" (proxy_router_service.py:786-792). Mid-stream
+    # wraps match too, but those are excluded by the chunk_count==0 gate.
     "failed to create chat completions stream",
 ]
 
 
 def is_failover_eligible(exc: proxy_router_service.ProxyRouterServiceError) -> bool:
-    """Decide whether a proxy error means the provider became UNREACHABLE.
+    """Decide whether a proxy error means the provider is unavailable.
 
-    Eligible (transport failure -> a different bid may work):
-      - LB infra errors (502/503/504): the node could not be reached.
-      - gateway<->proxy transport failure (error_type == "network_error").
-      - proxy-router provider-transport sentinels (PROVIDER_TRANSPORT_PATTERNS).
-
-    NOT eligible:
-      - session expired/not found (handled by the separate renewal mechanism),
-      - user/4xx errors, TEE failures, client-cancelled requests,
-      - a bare 5xx whose body is an application/config error (e.g.
-        "api adapter not found", upstream "EOF") — the bid is reachable but
-        broken; failover just churns sessions and locks MOR.
+    Eligible: provider unreachable / 5xx / timeouts / transport failures.
+    Not eligible: session expired/not found (separate renewal mechanism),
+    user/4xx errors, TEE failures, client-cancelled requests.
     """
     if not settings.CHAT_FAILOVER_ENABLED:
         return False
@@ -96,20 +76,14 @@ def is_failover_eligible(exc: proxy_router_service.ProxyRouterServiceError) -> b
         return False
 
     status = exc.status_code
-    # Caller/config errors (4xx) never warrant failover.
     if status is not None and 400 <= status < 500:
         return False
-    # Infra-level gateway errors: the load balancer could not reach the node
-    # (e.g. a provider/proxy task cycling during a deploy) — transport failure.
-    if status in (502, 503, 504):
+    if status is not None and status >= 500:
         return True
-    # No/other status: gateway<->proxy transport failure.
+    # No status: gateway<->proxy transport failure, or wrapped errors.
     if exc.error_type == "network_error":
         return True
-    # A bare 5xx is NOT sufficient on its own; require a transport signature.
-    # The provider may have ANSWERED with an application error, which failover
-    # cannot fix.
-    return any(p in message for p in PROVIDER_TRANSPORT_PATTERNS)
+    return any(p in message for p in PROVIDER_FAILURE_PATTERNS)
 
 
 async def _release_new_session_quiet(session_id: str, logger) -> None:
@@ -163,10 +137,18 @@ async def attempt_failover(
     failure_reason: str = "",
 ) -> Optional[str]:
     """
-    Gateway-owned provider failover: mark the dead session FAILED (with a
-    background on-chain close), verify the model has an alternate bid,
-    and route to a fresh session for the same model — the proxy-router's
-    per-bid handshake lands it on a surviving provider.
+    Gateway-owned provider failover: when a model has an ALTERNATE bid, mark
+    the dead session FAILED (with a background on-chain close) and route to a
+    fresh session for the same model — the proxy-router's per-bid handshake
+    lands it on a surviving provider.
+
+    Single-bid guardrail (checked FIRST): if the model has no alternate bid,
+    there is nowhere to fail over to. We do NOT invalidate or early-close the
+    session — that would lock the user's MOR for ~1 day (an early on-chain
+    close pushes the unused stake into userStakesOnHold) and force a fresh,
+    equally-dead session on the next prompt. Instead we leave the session
+    OPEN so it rides to its natural expiry (stake returns, no lock) and
+    surface the original error to the caller — the pre-failover behavior.
 
     Returns the new session id (already assigned to this request), or None
     when failover is not possible (caller surfaces the original error).
@@ -181,12 +163,25 @@ async def attempt_failover(
         model_id=model_id,
         request_id=request_id,
     )
+
+    # 1. Single-bid guardrail FIRST. With no alternate bid there is nothing to
+    #    fail over to, so do nothing destructive: leave the session OPEN to
+    #    expire naturally (no early on-chain close, no MOR lock). Must run
+    #    BEFORE invalidate so single-bid models don't pay the early-close cost.
+    if model_id and not await _has_alternate_bids(model_id, failover_logger):
+        failover_logger.warning(
+            "No alternate bid available; leaving session to expire naturally",
+            failure_reason=failure_reason[:300],
+            event_type="failover_no_alternate_bids")
+        return None
+
     failover_logger.warning("Attempting gateway failover to a new provider",
                             failure_reason=failure_reason[:300],
                             event_type="failover_triggered")
 
-    # 1. Unpin the dead session so no request routes to it again.
-    #    Do this even if we end up unable to retry.
+    # 2. A sibling bid exists and is worth trying. Unpin the dead session so no
+    #    request routes to it again (marks FAILED + best-effort background
+    #    on-chain close).
     try:
         async with get_db() as db:
             await session_routing_service.invalidate_session(
@@ -196,12 +191,6 @@ async def attempt_failover(
         failover_logger.error("Failover invalidation failed",
                               error=str(e),
                               event_type="failover_invalidate_failed")
-        return None
-
-    # 2. Only retry when the model has >1 bid (spec guardrail).
-    if model_id and not await _has_alternate_bids(model_id, failover_logger):
-        failover_logger.warning("No alternate bid available, not retrying",
-                                event_type="failover_no_alternate_bids")
         return None
 
     # 3. Open/route a fresh session by model. The proxy-router tries bids

--- a/src/api/v1/chat/chat_failover.py
+++ b/src/api/v1/chat/chat_failover.py
@@ -2,11 +2,18 @@
 Gateway-owned provider failover.
 
 Failover = open a new session with a DIFFERENT provider. It applies ONLY
-when the provider becomes unavailable during a session (conn refused /
-timeouts / 5xx / provider death). On such a failure the gateway marks the
-dead RoutedSession FAILED, opens a fresh session for the same model (the
-proxy-router's per-bid handshake skips the dead provider), and the caller
-retries the prompt exactly once.
+when the provider becomes UNREACHABLE during a session — i.e. a transport
+failure (conn refused / write failure / provider closed the connection /
+provider-task gone / read timeout / LB 502-504). On such a failure the
+gateway marks the dead RoutedSession FAILED, opens a fresh session for the
+same model (the proxy-router's per-bid handshake skips the dead provider),
+and the caller retries the prompt exactly once.
+
+It deliberately does NOT trigger on errors where the provider ANSWERED with
+an application/config error (e.g. "api adapter not found", an upstream EOF
+mid-prompt). Those mean the bid is reachable but misconfigured/broken;
+retrying them on a fresh session cannot fix the model and previously caused
+an open/fail/early-close reopen storm (see narrowing rationale below).
 
 Session expiry ("session expired") is a SEPARATE mechanism — the renewal
 flow in the chat handlers — and is explicitly EXCLUDED here.
@@ -37,29 +44,49 @@ NON_FAILOVER_ERROR_PATTERNS = [
     "request cancelled while waiting in queue",
 ]
 
-# Provider-unavailability signatures from the proxy-router (see
-# proxy-router/internal/proxyapi/proxy_sender.go sentinel errors).
-# Used when no status code is available on the exception.
-PROVIDER_FAILURE_PATTERNS = [
+# Transport-level signatures meaning a node became UNREACHABLE — the only
+# class of failure that warrants opening a new session on a different bid.
+#
+# These are the proxy-router's provider-transport sentinels (see
+# proxy-router/internal/proxyapi/proxy_sender.go) plus the gateway<->proxy
+# stream-setup transport wrapper. A provider that ANSWERS with an
+# application/config error (e.g. "api adapter not found", or an upstream
+# "...EOF" mid-prompt) is reachable and is NOT listed here on purpose:
+# failover cannot fix a broken/misconfigured bid, and treating those as
+# provider-unavailability caused a reopen storm (open -> immediate fail ->
+# early on-chain close (MOR lock) -> reopen) that amplified session volume.
+#
+# NB: the generic envelope "provider request failed: ..." was REMOVED — the
+# proxy-router wraps EVERY provider error in it (including adapter-not-found
+# and upstream EOF), so it matched far more than genuine provider death.
+PROVIDER_TRANSPORT_PATTERNS = [
     "failed to connect to provider",
     "failed to write to provider",
-    "provider request failed",
     "provider closed connection",
     "provider not found",
     "read timed out",
-    # chatCompletionsStream wraps transport errors with status=None and
-    # error_type="unknown" (proxy_router_service.py:786-792). Mid-stream
-    # wraps match too, but those are excluded by the chunk_count==0 gate.
+    # chatCompletionsStream wraps gateway<->proxy transport failures with
+    # status=None ("Failed to create chat completions stream: <transport
+    # error>"). App errors arrive as ProxyRouterServiceError with a status and
+    # are re-raised before this wrap, so this only catches real transport.
     "failed to create chat completions stream",
 ]
 
 
 def is_failover_eligible(exc: proxy_router_service.ProxyRouterServiceError) -> bool:
-    """Decide whether a proxy error means the provider is unavailable.
+    """Decide whether a proxy error means the provider became UNREACHABLE.
 
-    Eligible: provider unreachable / 5xx / timeouts / transport failures.
-    Not eligible: session expired/not found (separate renewal mechanism),
-    user/4xx errors, TEE failures, client-cancelled requests.
+    Eligible (transport failure -> a different bid may work):
+      - LB infra errors (502/503/504): the node could not be reached.
+      - gateway<->proxy transport failure (error_type == "network_error").
+      - proxy-router provider-transport sentinels (PROVIDER_TRANSPORT_PATTERNS).
+
+    NOT eligible:
+      - session expired/not found (handled by the separate renewal mechanism),
+      - user/4xx errors, TEE failures, client-cancelled requests,
+      - a bare 5xx whose body is an application/config error (e.g.
+        "api adapter not found", upstream "EOF") — the bid is reachable but
+        broken; failover just churns sessions and locks MOR.
     """
     if not settings.CHAT_FAILOVER_ENABLED:
         return False
@@ -69,14 +96,20 @@ def is_failover_eligible(exc: proxy_router_service.ProxyRouterServiceError) -> b
         return False
 
     status = exc.status_code
+    # Caller/config errors (4xx) never warrant failover.
     if status is not None and 400 <= status < 500:
         return False
-    if status is not None and status >= 500:
+    # Infra-level gateway errors: the load balancer could not reach the node
+    # (e.g. a provider/proxy task cycling during a deploy) — transport failure.
+    if status in (502, 503, 504):
         return True
-    # No status: gateway<->proxy transport failure, or wrapped errors.
+    # No/other status: gateway<->proxy transport failure.
     if exc.error_type == "network_error":
         return True
-    return any(p in message for p in PROVIDER_FAILURE_PATTERNS)
+    # A bare 5xx is NOT sufficient on its own; require a transport signature.
+    # The provider may have ANSWERED with an application error, which failover
+    # cannot fix.
+    return any(p in message for p in PROVIDER_TRANSPORT_PATTERNS)
 
 
 async def _release_new_session_quiet(session_id: str, logger) -> None:

--- a/tests/unit/test_chat_failover.py
+++ b/tests/unit/test_chat_failover.py
@@ -17,19 +17,14 @@ def _err(message, status_code=None, error_type="unknown"):
 
 class TestIsFailoverEligible:
     @pytest.mark.parametrize("exc", [
-        # Provider-transport sentinels: the node became unreachable mid-session.
         _err('HTTP 500: {"error":"provider request failed: failed to connect to provider: dial tcp 1.2.3.4:8083: connect: connection refused"}', 500, "server_error"),
         _err('HTTP 500: {"error":"provider request failed: read timed out after 3 retries"}', 500, "server_error"),
         _err('HTTP 500: {"error":"provider request failed: provider closed connection without sending any data"}', 500, "server_error"),
         _err('HTTP 500: {"error":"provider not found"}', 500, "server_error"),
-        # Infra/LB errors: the load balancer could not reach the node (e.g. a
-        # provider/proxy task cycling during a deploy).
         _err('HTTP 502: {"error":"bad gateway"}', 502, "server_error"),
-        _err('HTTP 503: {"error":"service unavailable"}', 503, "server_error"),
-        _err('HTTP 504: {"error":"gateway timeout"}', 504, "server_error"),
         _err("Request failed after 1 attempts: All connection attempts failed", None, "network_error"),
         # Streaming transport failure: chatCompletionsStream's catch-all wrap
-        # produces status=None ("Failed to create chat completions stream: ...").
+        # (proxy_router_service.py:786-792) produces status=None, type="unknown".
         _err("Failed to create chat completions stream: All connection attempts failed", None, "unknown"),
     ])
     def test_provider_unavailability_is_eligible(self, exc):
@@ -47,22 +42,12 @@ class TestIsFailoverEligible:
         _err('HTTP 500: {"error":"llm tee verification failed"}', 500, "server_error"),
         _err('HTTP 500: {"error":"request cancelled while waiting in queue: context canceled"}', 500, "server_error"),
         _err("something odd with no status and no known pattern", None, "unknown"),
-        # NARROWING REGRESSION GUARDS: the provider ANSWERED with an
-        # application/config error. The bid is reachable but broken — failover
-        # cannot fix it and must NOT churn sessions. These arrive as a bare 5xx
-        # wrapped in the generic "provider request failed" envelope, which is
-        # exactly what used to (wrongly) trigger failover.
-        _err('HTTP 500: {"error":"provider request failed: provider error: failed to get adapter: api adapter not found: "}', 500, "server_error"),
-        _err('HTTP 500: {"error":"provider request failed: provider error: failed to prompt: failed to send request: Post \\"http://10.0.0.5:8080/v1/chat/completions\\": EOF"}', 500, "server_error"),
-        _err('HTTP 500: {"error":"provider request failed"}', 500, "server_error"),
     ])
     def test_not_eligible(self, exc):
         assert chat_failover.is_failover_eligible(exc) is False
 
     def test_kill_switch_disables_failover(self):
-        # A genuine transport failure that WOULD be eligible, suppressed by the switch.
-        exc = _err('HTTP 500: {"error":"failed to connect to provider: connection refused"}', 500, "server_error")
-        assert chat_failover.is_failover_eligible(exc) is True
+        exc = _err('HTTP 500: {"error":"provider request failed"}', 500, "server_error")
         with patch.object(chat_failover.settings, "CHAT_FAILOVER_ENABLED", False):
             assert chat_failover.is_failover_eligible(exc) is False
 
@@ -123,11 +108,14 @@ class TestAttemptFailover:
         failover_mocks["bids"].assert_awaited_once()
         failover_mocks["route"].assert_awaited_once()
 
-    async def test_single_bid_blocks_retry_but_still_invalidates(self, failover_mocks):
+    async def test_single_bid_skips_invalidate_and_retry(self, failover_mocks):
+        # Single-bid: nothing to fail over to. The session must be left OPEN
+        # (NOT invalidated/early-closed) so it rides to natural expiry and the
+        # user's MOR is not locked; no retry is attempted.
         failover_mocks["bids"].return_value = _rated_bids_response(1)
         new_id = await _failover(failover_mocks)
         assert new_id is None
-        failover_mocks["invalidate"].assert_awaited_once()
+        failover_mocks["invalidate"].assert_not_awaited()
         failover_mocks["route"].assert_not_awaited()
 
     async def test_bids_lookup_failure_proceeds_optimistically(self, failover_mocks):

--- a/tests/unit/test_chat_failover.py
+++ b/tests/unit/test_chat_failover.py
@@ -17,14 +17,19 @@ def _err(message, status_code=None, error_type="unknown"):
 
 class TestIsFailoverEligible:
     @pytest.mark.parametrize("exc", [
+        # Provider-transport sentinels: the node became unreachable mid-session.
         _err('HTTP 500: {"error":"provider request failed: failed to connect to provider: dial tcp 1.2.3.4:8083: connect: connection refused"}', 500, "server_error"),
         _err('HTTP 500: {"error":"provider request failed: read timed out after 3 retries"}', 500, "server_error"),
         _err('HTTP 500: {"error":"provider request failed: provider closed connection without sending any data"}', 500, "server_error"),
         _err('HTTP 500: {"error":"provider not found"}', 500, "server_error"),
+        # Infra/LB errors: the load balancer could not reach the node (e.g. a
+        # provider/proxy task cycling during a deploy).
         _err('HTTP 502: {"error":"bad gateway"}', 502, "server_error"),
+        _err('HTTP 503: {"error":"service unavailable"}', 503, "server_error"),
+        _err('HTTP 504: {"error":"gateway timeout"}', 504, "server_error"),
         _err("Request failed after 1 attempts: All connection attempts failed", None, "network_error"),
         # Streaming transport failure: chatCompletionsStream's catch-all wrap
-        # (proxy_router_service.py:786-792) produces status=None, type="unknown".
+        # produces status=None ("Failed to create chat completions stream: ...").
         _err("Failed to create chat completions stream: All connection attempts failed", None, "unknown"),
     ])
     def test_provider_unavailability_is_eligible(self, exc):
@@ -42,12 +47,22 @@ class TestIsFailoverEligible:
         _err('HTTP 500: {"error":"llm tee verification failed"}', 500, "server_error"),
         _err('HTTP 500: {"error":"request cancelled while waiting in queue: context canceled"}', 500, "server_error"),
         _err("something odd with no status and no known pattern", None, "unknown"),
+        # NARROWING REGRESSION GUARDS: the provider ANSWERED with an
+        # application/config error. The bid is reachable but broken — failover
+        # cannot fix it and must NOT churn sessions. These arrive as a bare 5xx
+        # wrapped in the generic "provider request failed" envelope, which is
+        # exactly what used to (wrongly) trigger failover.
+        _err('HTTP 500: {"error":"provider request failed: provider error: failed to get adapter: api adapter not found: "}', 500, "server_error"),
+        _err('HTTP 500: {"error":"provider request failed: provider error: failed to prompt: failed to send request: Post \\"http://10.0.0.5:8080/v1/chat/completions\\": EOF"}', 500, "server_error"),
+        _err('HTTP 500: {"error":"provider request failed"}', 500, "server_error"),
     ])
     def test_not_eligible(self, exc):
         assert chat_failover.is_failover_eligible(exc) is False
 
     def test_kill_switch_disables_failover(self):
-        exc = _err('HTTP 500: {"error":"provider request failed"}', 500, "server_error")
+        # A genuine transport failure that WOULD be eligible, suppressed by the switch.
+        exc = _err('HTTP 500: {"error":"failed to connect to provider: connection refused"}', 500, "server_error")
+        assert chat_failover.is_failover_eligible(exc) is True
         with patch.object(chat_failover.settings, "CHAT_FAILOVER_ENABLED", False):
             assert chat_failover.is_failover_eligible(exc) is False
 


### PR DESCRIPTION
Supersedes #255 (that branch was renamed; GitHub closed the old PR).

## Summary
Fixes the dominant driver of `FAILED`-session churn and MOR locks: the **ordering** of the single-bid guardrail in `attempt_failover`.

Today `attempt_failover` calls `invalidate_session` **first** (mark `FAILED` + fire an early on-chain close) and only **then** checks whether the model has an alternate bid. So single-bid models — which have nowhere to fail over to — still pay the full cost on every failed prompt:
- the early on-chain close locks the unused MOR stake for ~1 day (`userStakesOnHold`), and
- the next prompt can't reuse the `FAILED` row, so it opens a brand-new (equally dead) session → fails → repeats.

This change moves the **alternate-bid check first**. With no alternate bid, the session is left `OPEN` (no invalidate, no early close) so it **rides to its natural expiry** — stake returns, no lock — and the original error is surfaced. This restores the pre-1.24.0 behavior for single-bid models. The multi-bid HA path is unchanged (invalidate → reopen → retry), and the **original broad eligibility triggers are kept** (this PR reverts the trigger-narrowing that was on the old branch).

## Evidence (gateway logs, 7d)
`failover_no_alternate_bids` = **17,699 of 18,042** failover attempts (**98%**) — i.e. single-bid, retry already correctly skipped, but still invalidated + early-closed + MOR-locked. Only **353 (2%)** were genuine multi-bid reopens (`failover_new_session`).

The single-bid storm is four dead legacy models, all `bids=1`:

| Model | failover checks/7d | bids |
|---|---|---|
| Qwen 2.5 7B | 4,958 | 1 |
| Llama 3.2 3B | 4,299 | 1 |
| Hermes 3 8B | 4,226 | 1 |
| Mistral 7B | 4,211 | 1 |

## What this helps / hurts
- **Helps:** eliminates ~98% of failover-driven invalidations, early on-chain closes, and 1-day MOR locks; restores natural-expiry (no lock) for single-bid models; eases the consumer-wallet MOR drain and DB `FAILED` churn.
- **Unchanged:** multi-bid HA failover (the v7.3.0-roll scenario) still invalidates + reopens on a sibling bid, with the original broad triggers — no reduction in HA aggressiveness.
- **Not addressed here (by design):** a *multi-bid* model whose bids are *all* dead can still churn (~2%). That's the per-bid circuit breaker (a separate, later change).

## Test plan
- [x] Unit test updated: `test_single_bid_skips_invalidate_and_retry` now asserts single-bid does **NOT** invalidate and does **NOT** route.
- [x] Existing multi-bid tests unchanged and still valid (happy path, route failure, invalidate failure, optimistic-on-bid-lookup-failure).
- [x] `is_failover_eligible` reverted to the original broad classifier (its tests are unchanged from `dev`).
- [ ] CI runs `tests/unit/test_chat_failover.py` (Poetry/py3.11 env, not runnable locally).

Made with [Cursor](https://cursor.com)