### PR TITLE
feat(session-routing): price-tiered session duration for expensive models

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -184,6 +184,28 @@ class Settings(BaseSettings):
     SESSION_DEFAULT_DURATION_SECONDS: int = Field(default=int(os.getenv("SESSION_DEFAULT_DURATION_SECONDS", "1800")))
     # Comma-separated list of preferred models (keep at least one idle session)
     SESSION_PREFERRED_MODELS: str = Field(default=os.getenv("SESSION_PREFERRED_MODELS", ""))
+
+    # --- Expensive-model session tier ---------------------------------------
+    # The on-chain stake pulled at openSession scales linearly with duration and
+    # is amplified by (total MOR supply / today's emissions budget), so a
+    # high-priced model at the normal duration can stake enough MOR to exhaust
+    # the shared consumer wallet and bounce concurrent opens. This tier gives
+    # models whose lowest rated bid is >= a cutoff a shorter duration (smaller
+    # per-session stake -> more concurrent premium sessions) with their own idle
+    # grace, decoupled from the global session settings above.
+    #
+    # Cutoff is MOR per second (a bid's PricePerSecond / 1e18). 0 DISABLES the
+    # tier entirely (every model uses the global SESSION_* settings) — the
+    # feature ships inert and is turned on per-environment via secrets.
+    SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND: float = Field(default=float(os.getenv("SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND", "0")))
+    # Session duration (seconds) for expensive models. Kept short to bound the
+    # amplified on-chain stake per session.
+    SESSION_EXPENSIVE_DEFAULT_DURATION_SECONDS: int = Field(default=int(os.getenv("SESSION_EXPENSIVE_DEFAULT_DURATION_SECONDS", "1200")))
+    # Idle grace (seconds) for expensive models, overriding SESSION_IDLE_GRACE_SECONDS.
+    # Keep this >= SESSION_EXPENSIVE_DEFAULT_DURATION_SECONDS so an idle expensive
+    # session rides to its natural on-chain expiry instead of being early-closed —
+    # an early close pushes the unused stake into userStakesOnHold (locked ~1 day).
+    SESSION_EXPENSIVE_IDLE_GRACE_SECONDS: int = Field(default=int(os.getenv("SESSION_EXPENSIVE_IDLE_GRACE_SECONDS", "1440")))
     # Adaptive on-chain wallet throttle: after a nonce conflict is observed on a
     # session open/close, on-chain ops serialize on the wallet lock for this many
     # seconds (sliding; each new conflict re-arms it). 0 disables the throttle

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -87,7 +87,16 @@ class SessionRoutingService:
         # Strong refs to fire-and-forget close tasks (event loop keeps only
         # weak refs; an unreferenced task can be GC'd before it runs).
         self._background_close_tasks: set = set()
-        
+
+        # Short-lived per-model "is this an expensive model?" cache. The tier
+        # decision needs the model's lowest rated-bid price (an on-chain read
+        # via the proxy-router); cache it so neither the open path nor the
+        # per-tick automation loop hammers that lookup. Keyed by model_id ->
+        # (monotonic_expiry, is_expensive). Per-replica and deterministic from
+        # the cutoff + price, so no cross-replica coordination is needed.
+        self._expensive_tier_cache: Dict[str, tuple] = {}
+        self._expensive_tier_cache_ttl = 300.0
+
         logger.info("SessionRoutingService initialized",
                    event_type="session_routing_service_init")
     
@@ -96,6 +105,70 @@ class SessionRoutingService:
         if not settings.SESSION_PREFERRED_MODELS:
             return set()
         return set(m.strip() for m in settings.SESSION_PREFERRED_MODELS.split(",") if m.strip())
+
+    # =========================================================================
+    # EXPENSIVE-MODEL TIER
+    # =========================================================================
+
+    async def _get_model_min_price_per_second(self, model_id: str) -> Optional[float]:
+        """Lowest rated-bid price for a model in MOR/sec, or None on failure.
+
+        Best-effort: never raises. A price lookup must never block (or fail) a
+        session open — callers treat None as "not expensive" and fall back to
+        the global session settings. Bid PricePerSecond is in wei (1e18 = 1 MOR).
+        """
+        try:
+            response = await proxy_router_service.getRatedBids(model_id)
+            result = response.json()
+            if isinstance(result, dict):
+                bids = result.get("bids", []) or []
+            elif isinstance(result, list):
+                bids = result
+            else:
+                bids = []
+
+            prices: List[float] = []
+            for bid in bids:
+                if not isinstance(bid, dict):
+                    continue
+                pps = bid.get("PricePerSecond")
+                if pps is None:
+                    continue
+                try:
+                    prices.append(int(str(pps)) / 1e18)
+                except (ValueError, TypeError):
+                    continue
+
+            return min(prices) if prices else None
+        except Exception as e:
+            logger.warning("Rated-bid price lookup failed; treating model as non-expensive",
+                           model_id=model_id,
+                           error=str(e),
+                           event_type="expensive_tier_price_lookup_error")
+            return None
+
+    async def _is_expensive_model(self, model_id: str) -> bool:
+        """True if the model's lowest rated bid is >= the expensive cutoff.
+
+        Returns False when the tier is disabled (cutoff <= 0) or the price
+        cannot be determined. Result is cached per model for a short TTL so the
+        on-chain bid read is not repeated on every open / automation tick.
+        """
+        cutoff = settings.SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND
+        if cutoff <= 0:
+            return False
+
+        cached = self._expensive_tier_cache.get(model_id)
+        if cached is not None and time.monotonic() < cached[0]:
+            return cached[1]
+
+        price = await self._get_model_min_price_per_second(model_id)
+        is_expensive = price is not None and price >= cutoff
+        self._expensive_tier_cache[model_id] = (
+            time.monotonic() + self._expensive_tier_cache_ttl,
+            is_expensive,
+        )
+        return is_expensive
 
     # =========================================================================
     # ADAPTIVE ON-CHAIN WALLET THROTTLE
@@ -423,7 +496,21 @@ class SessionRoutingService:
         open_logger.info("Opening new session for model",
                         event_type="session_open_start")
 
-        session_duration = settings.SESSION_DEFAULT_DURATION_SECONDS
+        # Expensive models open with a shorter duration so the amplified
+        # on-chain stake pulled per session stays small (more concurrent
+        # premium sessions before the shared wallet is exhausted). Best-effort:
+        # if the tier is disabled or the price can't be read, use the global
+        # default duration.
+        is_expensive = await self._is_expensive_model(model_id)
+        session_duration = (
+            settings.SESSION_EXPENSIVE_DEFAULT_DURATION_SECONDS
+            if is_expensive
+            else settings.SESSION_DEFAULT_DURATION_SECONDS
+        )
+        open_logger = open_logger.bind(
+            expensive_tier=is_expensive,
+            session_duration=session_duration,
+        )
         expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=session_duration)
 
         try:
@@ -855,9 +942,16 @@ class SessionRoutingService:
         utilized = [s for s in sessions if s.is_utilized]
         unutilized = [s for s in sessions if not s.is_utilized]
         
-        # Filter unutilized by idle grace period
+        # Filter unutilized by idle grace period. Expensive models use their own
+        # (longer) grace so an idle session rides to natural on-chain expiry
+        # rather than being early-closed — an early close locks the unused stake
+        # in userStakesOnHold for ~1 day. Falls back to the global grace when the
+        # tier is disabled or the price is unknown.
+        idle_grace_seconds = settings.SESSION_IDLE_GRACE_SECONDS
+        if await self._is_expensive_model(model_id):
+            idle_grace_seconds = settings.SESSION_EXPENSIVE_IDLE_GRACE_SECONDS
         now = datetime.now(timezone.utc).replace(tzinfo=None)
-        grace_threshold = now - timedelta(seconds=settings.SESSION_IDLE_GRACE_SECONDS)
+        grace_threshold = now - timedelta(seconds=idle_grace_seconds)
         
         idle_long_enough = [
             s for s in unutilized

--- a/tests/unit/test_session_expensive_tier.py
+++ b/tests/unit/test_session_expensive_tier.py
@@ -1,0 +1,168 @@
+"""Tests for the expensive-model session tier in SessionRoutingService.
+
+Expensive models (lowest rated bid >= a MOR/sec cutoff) open with a shorter
+duration to bound the amplified on-chain stake, and use their own idle grace.
+The tier is disabled by default (cutoff <= 0) and every decision is best-effort:
+a failed / missing price lookup must never block an open, so it falls back to
+the global session settings. The proxy-router bid read is mocked here.
+"""
+import os
+import sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.core.config import settings
+from src.db.models import SessionState
+from src.services.session_routing_service import SessionRoutingService
+
+
+@pytest.fixture
+def service():
+    return SessionRoutingService()
+
+
+def _bids_response(bids):
+    """A getRatedBids() response object whose .json() yields ``bids``."""
+    resp = MagicMock()
+    resp.json.return_value = bids
+    return resp
+
+
+def _patch_rated_bids(bids):
+    return patch(
+        "src.services.session_routing_service.proxy_router_service.getRatedBids",
+        new_callable=AsyncMock,
+        return_value=_bids_response(bids),
+    )
+
+
+# 1e16 wei = 0.01 MOR/sec (premium), 1e14 wei = 0.0001 MOR/sec (cheap)
+PREMIUM_PPS = "10000000000000000"
+CHEAP_PPS = "100000000000000"
+
+
+# ---------------------------------------------------------------------------
+# _get_model_min_price_per_second: parsing + best-effort failure
+# ---------------------------------------------------------------------------
+
+
+async def test_min_price_picks_lowest_and_converts_wei_to_mor(service):
+    with _patch_rated_bids([{"PricePerSecond": PREMIUM_PPS}, {"PricePerSecond": CHEAP_PPS}]):
+        price = await service._get_model_min_price_per_second("0xmodel")
+    assert price == pytest.approx(0.0001)
+
+
+async def test_min_price_supports_dict_bids_envelope(service):
+    with _patch_rated_bids({"bids": [{"PricePerSecond": PREMIUM_PPS}]}):
+        price = await service._get_model_min_price_per_second("0xmodel")
+    assert price == pytest.approx(0.01)
+
+
+async def test_min_price_none_when_no_bids(service):
+    with _patch_rated_bids([]):
+        assert await service._get_model_min_price_per_second("0xmodel") is None
+
+
+async def test_min_price_none_on_lookup_error(service):
+    with patch(
+        "src.services.session_routing_service.proxy_router_service.getRatedBids",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("proxy down"),
+    ):
+        assert await service._get_model_min_price_per_second("0xmodel") is None
+
+
+# ---------------------------------------------------------------------------
+# _is_expensive_model: cutoff gate, comparison, caching
+# ---------------------------------------------------------------------------
+
+
+async def test_disabled_when_cutoff_zero_skips_price_lookup(service):
+    with patch.object(settings, "SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND", 0.0), patch(
+        "src.services.session_routing_service.proxy_router_service.getRatedBids",
+        new_callable=AsyncMock,
+    ) as get_bids:
+        assert await service._is_expensive_model("0xmodel") is False
+        get_bids.assert_not_awaited()
+
+
+async def test_expensive_when_price_at_or_above_cutoff(service):
+    with patch.object(settings, "SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND", 0.001), _patch_rated_bids(
+        [{"PricePerSecond": PREMIUM_PPS}]
+    ):
+        assert await service._is_expensive_model("0xmodel") is True
+
+
+async def test_not_expensive_when_price_below_cutoff(service):
+    with patch.object(settings, "SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND", 0.001), _patch_rated_bids(
+        [{"PricePerSecond": CHEAP_PPS}]
+    ):
+        assert await service._is_expensive_model("0xmodel") is False
+
+
+async def test_not_expensive_when_price_unknown(service):
+    with patch.object(settings, "SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND", 0.001), _patch_rated_bids([]):
+        assert await service._is_expensive_model("0xmodel") is False
+
+
+async def test_decision_is_cached_within_ttl(service):
+    with patch.object(settings, "SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND", 0.001), patch(
+        "src.services.session_routing_service.proxy_router_service.getRatedBids",
+        new_callable=AsyncMock,
+        return_value=_bids_response([{"PricePerSecond": PREMIUM_PPS}]),
+    ) as get_bids:
+        assert await service._is_expensive_model("0xmodel") is True
+        assert await service._is_expensive_model("0xmodel") is True
+        get_bids.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# open path: duration follows the tier
+# ---------------------------------------------------------------------------
+
+
+def _patch_get_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+
+    @asynccontextmanager
+    async def _fake_get_db():
+        yield db
+
+    return patch("src.services.session_routing_service.get_db", _fake_get_db)
+
+
+async def test_open_uses_expensive_duration_for_expensive_model(service):
+    service._is_expensive_model = AsyncMock(return_value=True)
+    open_session = AsyncMock(return_value={"sessionID": "0xnew"})
+
+    with _patch_get_db(), patch.object(
+        settings, "SESSION_EXPENSIVE_DEFAULT_DURATION_SECONDS", 1200
+    ), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        open_session,
+    ):
+        sid = await service._open_session_for_model(model_id="0xmodel", model_name="m")
+
+    assert sid == "0xnew"
+    assert open_session.call_args.kwargs["session_duration"] == 1200
+
+
+async def test_open_uses_default_duration_for_cheap_model(service):
+    service._is_expensive_model = AsyncMock(return_value=False)
+    open_session = AsyncMock(return_value={"sessionID": "0xnew"})
+
+    with _patch_get_db(), patch.object(
+        settings, "SESSION_DEFAULT_DURATION_SECONDS", 4200
+    ), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        open_session,
+    ):
+        sid = await service._open_session_for_model(model_id="0xmodel", model_name="m")
+
+    assert sid == "0xnew"
+    assert open_session.call_args.kwargs["session_duration"] == 4200


### PR DESCRIPTION
## Summary
Adds an optional **expensive-model session tier** so high-priced models can actually be opened under load. The on-chain stake pulled at `openSession` scales linearly with session duration and is amplified by `(total MOR supply / today's emissions budget)`, so a premium model (e.g. 0.01 MOR/s) at the normal duration stakes enough MOR to exhaust the shared consumer wallet and bounce concurrent opens with `insufficient MOR` / `ERC20: transfer amount exceeds balance`.

When enabled, models whose **lowest rated bid ≥ a MOR/sec cutoff**:
- open with a **shorter duration** → smaller per-session stake → more concurrent premium sessions before the wallet is exhausted;
- use their **own idle grace**, kept `>=` their duration so an idle session rides to **natural on-chain expiry** instead of an early close (an early close pushes the unused stake into `userStakesOnHold`, locked ~1 day — see `chat_failover.py`).

## Config (all via `src/core/config.py`, sourced from secrets)
| Setting | Default | Meaning |
|---|---|---|
| `SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND` | `0` (disabled) | Bid price (MOR/s) at/above which a model is "expensive". `0` = tier off, every model uses the global `SESSION_*` settings. |
| `SESSION_EXPENSIVE_DEFAULT_DURATION_SECONDS` | `1200` (20 min) | Duration for expensive models. |
| `SESSION_EXPENSIVE_IDLE_GRACE_SECONDS` | `1440` (24 min) | Idle grace for expensive models (keep ≥ the expensive duration). |

**Ships inert:** with the default cutoff of `0`, `_is_expensive_model` short-circuits before any RPC and behavior is identical to today. Turn it on per-environment via secrets, exactly like the 70-minute default duration.

## Implementation
- `_get_model_min_price_per_second` — reads the proxy-router rated bids (`PricePerSecond` is wei, `/1e18`), lowest price wins. **Best-effort**: never raises; a failed/missing lookup returns `None`.
- `_is_expensive_model` — gate on cutoff, compare, and **cache per model** (5-min TTL) so neither the open path nor the per-tick automation loop hammers the on-chain read. `None`/disabled ⇒ not expensive ⇒ global settings (never blocks an open).
- `_open_session_for_model` — picks duration by tier; logs `expensive_tier` + `session_duration`.
- `_process_model_sessions` — expensive models use `SESSION_EXPENSIVE_IDLE_GRACE_SECONDS` for idle-close decisions.

## Tests
- New `tests/unit/test_session_expensive_tier.py` (11 tests): wei→MOR parsing, list/dict bid envelopes, cutoff gate skips the RPC when disabled, at/above vs below cutoff, unknown-price fallback, TTL caching, and open-duration-follows-tier.
- Full run locally: **11 new + 19 existing session-routing tests pass**, no regressions.

## Notes
- Independent of the RUM/Canary removal (#261, already merged to `dev`); this branch is cut from the cleaned `dev`.
- No DB migration, no schema change.
- Promotion vehicle for `dev` → `test` (builds the DEV env) → `main` (prod).

Made with [Cursor](https://cursor.com)