### PR TITLE
Promote expensive-tier rated-bids parse fix to production (test → main)

### DIFF
--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -131,7 +131,11 @@ class SessionRoutingService:
             for bid in bids:
                 if not isinstance(bid, dict):
                     continue
-                pps = bid.get("PricePerSecond")
+                # /bids/rated wraps each entry as {"ID":..., "Bid": {...,
+                # "PricePerSecond": ...}, "Score": ...}. Read the nested Bid,
+                # falling back to the flat shape for robustness.
+                inner = bid.get("Bid") if isinstance(bid.get("Bid"), dict) else bid
+                pps = inner.get("PricePerSecond")
                 if pps is None:
                     continue
                 try:

--- a/tests/unit/test_session_expensive_tier.py
+++ b/tests/unit/test_session_expensive_tier.py
@@ -45,18 +45,44 @@ PREMIUM_PPS = "10000000000000000"
 CHEAP_PPS = "100000000000000"
 
 
+def _rated(*pps_values):
+    """Build a /bids/rated response envelope (price nested under "Bid").
+
+    Mirrors the real proxy-router shape:
+    {"bids": [{"ID": "0x..", "Bid": {"PricePerSecond": ...}, "Score": ..}]}.
+    """
+    return {
+        "bids": [
+            {
+                "ID": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "Bid": {"Id": "0xbid", "PricePerSecond": pps, "Provider": "0xprov"},
+                "Score": 65.0,
+            }
+            for pps in pps_values
+        ]
+    }
+
+
 # ---------------------------------------------------------------------------
 # _get_model_min_price_per_second: parsing + best-effort failure
 # ---------------------------------------------------------------------------
 
 
 async def test_min_price_picks_lowest_and_converts_wei_to_mor(service):
-    with _patch_rated_bids([{"PricePerSecond": PREMIUM_PPS}, {"PricePerSecond": CHEAP_PPS}]):
+    with _patch_rated_bids(_rated(PREMIUM_PPS, CHEAP_PPS)):
         price = await service._get_model_min_price_per_second("0xmodel")
     assert price == pytest.approx(0.0001)
 
 
-async def test_min_price_supports_dict_bids_envelope(service):
+async def test_min_price_parses_real_rated_envelope(service):
+    """Regression: /bids/rated nests PricePerSecond under "Bid" (not top level)."""
+    with _patch_rated_bids(_rated(PREMIUM_PPS)):
+        price = await service._get_model_min_price_per_second("0xmodel")
+    assert price == pytest.approx(0.01)
+
+
+async def test_min_price_supports_flat_bids_fallback(service):
+    """Older/flat shape (PricePerSecond at the top level) still parses."""
     with _patch_rated_bids({"bids": [{"PricePerSecond": PREMIUM_PPS}]}):
         price = await service._get_model_min_price_per_second("0xmodel")
     assert price == pytest.approx(0.01)
@@ -92,14 +118,14 @@ async def test_disabled_when_cutoff_zero_skips_price_lookup(service):
 
 async def test_expensive_when_price_at_or_above_cutoff(service):
     with patch.object(settings, "SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND", 0.001), _patch_rated_bids(
-        [{"PricePerSecond": PREMIUM_PPS}]
+        _rated(PREMIUM_PPS)
     ):
         assert await service._is_expensive_model("0xmodel") is True
 
 
 async def test_not_expensive_when_price_below_cutoff(service):
     with patch.object(settings, "SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND", 0.001), _patch_rated_bids(
-        [{"PricePerSecond": CHEAP_PPS}]
+        _rated(CHEAP_PPS)
     ):
         assert await service._is_expensive_model("0xmodel") is False
 
@@ -113,7 +139,7 @@ async def test_decision_is_cached_within_ttl(service):
     with patch.object(settings, "SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND", 0.001), patch(
         "src.services.session_routing_service.proxy_router_service.getRatedBids",
         new_callable=AsyncMock,
-        return_value=_bids_response([{"PricePerSecond": PREMIUM_PPS}]),
+        return_value=_bids_response(_rated(PREMIUM_PPS)),
     ) as get_bids:
         assert await service._is_expensive_model("0xmodel") is True
         assert await service._is_expensive_model("0xmodel") is True


### PR DESCRIPTION
## Summary
Promotes the rated-bids parsing fix (#264 → #265) to production. Net diff is **only** the fix (2 files); TEST build `v1.28.1-test` deployed healthy to `dev.api.mor.org`.

### The bug
The expensive-model session tier was **silently inert in production**. `/bids/rated` nests the price under `bid["Bid"]["PricePerSecond"]`:

```
{"bids":[{"ID":"0x…","Bid":{"PricePerSecond":"10000000000000000",…},"Score":65.04}]}
```

`_get_model_min_price_per_second` read `PricePerSecond` off the outer element → every bid parsed to `None` → `_is_expensive_model` always `False`. Premium models (e.g. `claude-opus-4.8` @ `0.01 MOR/s`, above the `0.001` cutoff) opened at the global **4200s** instead of **1200s**, and intermittently bounced on-chain with `ERC20: transfer amount exceeds balance` (HTTP 500). No `expensive_tier_price_lookup_error` was logged because the HTTP call succeeds — only the parse was wrong.

### The fix
- Read nested `Bid.PricePerSecond`; flat-shape fallback retained.
- Tests corrected to the real rated-bids envelope + regression test `test_min_price_parses_real_rated_envelope`.

## Test plan
- [x] `pytest tests/unit/test_session_expensive_tier.py` → 12 passed
- [x] TEST build green (`v1.28.1-test`), `dev.api.mor.org` healthy
- [ ] After prod deploy: a real `claude-opus-4.8` open logs `expensive_tier=true` / `session_duration=1200` and does not bounce; session-creation-failure alarm stays quiet

## Note
Cutoff stays `0.001` (correct — opus is `0.01`). Dev can't functionally exercise the premium path (dev bids < cutoff), so the unit regression test is the guard; final confirmation is on prod traffic.

Made with [Cursor](https://cursor.com)