### PR TITLE
Promote to TEST: anchor session expires_at to on-chain endsAt

### DIFF
--- a/env.example
+++ b/env.example
@@ -194,6 +194,12 @@ SESSION_AUTOMATION_INTERVAL_SECONDS=30
 SESSION_IDLE_GRACE_SECONDS=300
 # Default session duration when creating new sessions (in seconds)
 SESSION_DEFAULT_DURATION_SECONDS=1800
+# Buffer (seconds) added to the ACTUAL on-chain endsAt when setting a session's
+# expires_at. The expiry sweep closes a session once now >= expires_at; anchoring
+# to the real on-chain endsAt (read back after open) + this buffer keeps the close
+# AT/AFTER endsAt (a "late" close), returning the full stake straight to the
+# wallet instead of locking a stipend chunk in userStakesOnHold. Keep small.
+SESSION_EXPIRY_BUFFER_SECONDS=60
 # Comma-separated list of preferred models (keep at least one idle session)
 SESSION_PREFERRED_MODELS=
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -182,6 +182,15 @@ class Settings(BaseSettings):
     SESSION_IDLE_GRACE_SECONDS: int = Field(default=int(os.getenv("SESSION_IDLE_GRACE_SECONDS", "300")))
     # Default session duration when creating new sessions (in seconds)
     SESSION_DEFAULT_DURATION_SECONDS: int = Field(default=int(os.getenv("SESSION_DEFAULT_DURATION_SECONDS", "1800")))
+    # Buffer (seconds) added on top of the ACTUAL on-chain endsAt when setting a
+    # routed session's DB expires_at. The cleanup sweep closes a session once
+    # now >= expires_at; anchoring to the real on-chain endsAt (read back after
+    # open) plus this small buffer guarantees the close lands AT/AFTER endsAt (a
+    # "late" close), so the full stake returns straight to the wallet instead of
+    # a stipend chunk being locked in userStakesOnHold (which then needs the
+    # housekeeping Lambda's withdrawUserStakes to recover). Keep small — just
+    # enough to clear host/chain clock skew and block/mining latency, not slop.
+    SESSION_EXPIRY_BUFFER_SECONDS: int = Field(default=int(os.getenv("SESSION_EXPIRY_BUFFER_SECONDS", "60")))
     # Comma-separated list of preferred models (keep at least one idle session)
     SESSION_PREFERRED_MODELS: str = Field(default=os.getenv("SESSION_PREFERRED_MODELS", ""))
 

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -454,6 +454,69 @@ class SessionRoutingService:
     # SESSION LIFECYCLE: Open and close sessions
     # =========================================================================
     
+    @staticmethod
+    def _parse_onchain_ends_at(status: Any) -> Optional[int]:
+        """Extract the on-chain endsAt (unix seconds) from a getSessionStatus body.
+
+        The C-Node serialises its Session struct with Go field names (no json
+        tags), so the field is ``EndsAt`` nested under ``session``. Accept a few
+        shapes/casings defensively and return None if absent/invalid so callers
+        can fall back rather than raise.
+        """
+        if not isinstance(status, dict):
+            return None
+        session = status.get("session") or status.get("Session") or status
+        if not isinstance(session, dict):
+            return None
+        raw = session.get("EndsAt", session.get("endsAt"))
+        if raw is None:
+            return None
+        try:
+            ends_at = int(raw)
+        except (TypeError, ValueError):
+            return None
+        return ends_at if ends_at > 0 else None
+
+    async def _resolve_expires_at(
+        self, session_id: str, fallback: datetime, open_logger
+    ) -> datetime:
+        """Return expires_at anchored to the on-chain endsAt (+ configured buffer).
+
+        Reads the freshly-opened session's on-chain endsAt via the proxy router
+        and adds SESSION_EXPIRY_BUFFER_SECONDS so the cleanup sweep closes the
+        session at/after its true end (a "late" close → full stake back to the
+        wallet). Best-effort: any failure returns ``fallback`` (the call-start
+        estimate) so a session open is never blocked on this read.
+        """
+        try:
+            status = await proxy_router_service.getSessionStatus(session_id)
+            ends_at = self._parse_onchain_ends_at(status)
+        except Exception as e:
+            open_logger.warning(
+                "Could not read on-chain endsAt; using estimated expiry",
+                error=str(e),
+                event_type="expires_at_read_error",
+            )
+            return fallback
+
+        if ends_at is None:
+            open_logger.warning(
+                "on-chain endsAt missing/invalid; using estimated expiry",
+                event_type="expires_at_missing",
+            )
+            return fallback
+
+        expires_at = datetime.fromtimestamp(ends_at, tz=timezone.utc).replace(
+            tzinfo=None
+        ) + timedelta(seconds=settings.SESSION_EXPIRY_BUFFER_SECONDS)
+        open_logger.info(
+            "Anchored expires_at to on-chain endsAt",
+            onchain_ends_at=ends_at,
+            buffer_seconds=settings.SESSION_EXPIRY_BUFFER_SECONDS,
+            event_type="expires_at_onchain",
+        )
+        return expires_at
+
     async def _open_session_for_model(
         self,
         model_id: str,
@@ -515,7 +578,18 @@ class SessionRoutingService:
             expensive_tier=is_expensive,
             session_duration=session_duration,
         )
-        expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=session_duration)
+        # Fallback ONLY. The authoritative expiry is the actual on-chain endsAt,
+        # read back after the open (see below). This call-start estimate is used
+        # solely if that read fails, because it is systematically too short: it
+        # ignores how long the open tx takes to mine, so the on-chain
+        # openedAt (== mine time) is later and the true endsAt is later still.
+        # Closing at this estimate lands a few seconds BEFORE endsAt under load,
+        # turning an intended "late" close into an early one — which locks the
+        # elapsed-time stipend in userStakesOnHold and forces housekeeping to
+        # recover it via withdrawUserStakes.
+        estimated_expires_at = (
+            datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=session_duration)
+        )
 
         try:
             # Call proxy router to open session
@@ -547,6 +621,15 @@ class SessionRoutingService:
                     "No session ID returned from proxy router",
                     model_id=model_id
                 )
+
+            # Anchor expires_at to the REAL on-chain endsAt (+ small buffer) so
+            # the cleanup sweep closes the session AT/AFTER endsAt (a "late"
+            # close returns the full stake straight to the wallet). Best-effort:
+            # falls back to the call-start estimate if the read fails, so an
+            # open is never blocked on it.
+            expires_at = await self._resolve_expires_at(
+                blockchain_session_id, estimated_expires_at, open_logger
+            )
 
             # Create session record only after successful open
             now = datetime.now(timezone.utc).replace(tzinfo=None)

--- a/tests/unit/test_session_expensive_tier.py
+++ b/tests/unit/test_session_expensive_tier.py
@@ -9,6 +9,7 @@ the global session settings. The proxy-router bid read is mocked here.
 import os
 import sys
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -162,6 +163,20 @@ def _patch_get_db():
     return patch("src.services.session_routing_service.get_db", _fake_get_db)
 
 
+def _patch_session_status(ends_at=None, side_effect=None):
+    """Patch getSessionStatus to return an on-chain endsAt (Go-style keys)."""
+    kwargs = {}
+    if side_effect is not None:
+        kwargs["side_effect"] = side_effect
+    else:
+        kwargs["return_value"] = {"session": {"Id": "0xnew", "EndsAt": ends_at}}
+    return patch(
+        "src.services.session_routing_service.proxy_router_service.getSessionStatus",
+        new_callable=AsyncMock,
+        **kwargs,
+    )
+
+
 async def test_open_uses_expensive_duration_for_expensive_model(service):
     service._is_expensive_model = AsyncMock(return_value=True)
     open_session = AsyncMock(return_value={"sessionID": "0xnew"})
@@ -171,7 +186,7 @@ async def test_open_uses_expensive_duration_for_expensive_model(service):
     ), patch(
         "src.services.session_routing_service.proxy_router_service.openSession",
         open_session,
-    ):
+    ), _patch_session_status(ends_at=2_000_000_000):
         sid = await service._open_session_for_model(model_id="0xmodel", model_name="m")
 
     assert sid == "0xnew"
@@ -187,8 +202,82 @@ async def test_open_uses_default_duration_for_cheap_model(service):
     ), patch(
         "src.services.session_routing_service.proxy_router_service.openSession",
         open_session,
-    ):
+    ), _patch_session_status(ends_at=2_000_000_000):
         sid = await service._open_session_for_model(model_id="0xmodel", model_name="m")
 
     assert sid == "0xnew"
     assert open_session.call_args.kwargs["session_duration"] == 4200
+
+
+# ---------------------------------------------------------------------------
+# expires_at anchoring: align to the on-chain endsAt (+ buffer), not a
+# call-start estimate, so cleanup closes land AT/AFTER endsAt (late close ->
+# full stake straight to the wallet, no userStakesOnHold / housekeeping).
+# ---------------------------------------------------------------------------
+
+
+def test_parse_onchain_ends_at_go_style_keys(service):
+    assert service._parse_onchain_ends_at({"session": {"EndsAt": 1783364629}}) == 1783364629
+
+
+def test_parse_onchain_ends_at_rejects_zero_and_missing(service):
+    assert service._parse_onchain_ends_at({"session": {"EndsAt": 0}}) is None
+    assert service._parse_onchain_ends_at({"session": {}}) is None
+    assert service._parse_onchain_ends_at({}) is None
+    assert service._parse_onchain_ends_at(None) is None
+
+
+async def test_open_anchors_expires_at_to_onchain_ends_at(service):
+    """expires_at is derived from the on-chain endsAt + buffer, not the estimate."""
+    service._is_expensive_model = AsyncMock(return_value=False)
+    open_session = AsyncMock(return_value={"sessionID": "0xnew"})
+    ends_at = 2_000_000_000  # on-chain endsAt (unix seconds)
+
+    captured = {}
+    db = AsyncMock()
+    db.add = MagicMock(side_effect=lambda row: captured.update(expires_at=row.expires_at))
+
+    @asynccontextmanager
+    async def _fake_get_db():
+        yield db
+
+    with patch("src.services.session_routing_service.get_db", _fake_get_db), patch.object(
+        settings, "SESSION_DEFAULT_DURATION_SECONDS", 4200
+    ), patch.object(settings, "SESSION_EXPIRY_BUFFER_SECONDS", 60), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        open_session,
+    ), _patch_session_status(ends_at=ends_at):
+        await service._open_session_for_model(model_id="0xmodel", model_name="m")
+
+    expected = datetime.fromtimestamp(ends_at, tz=timezone.utc).replace(tzinfo=None) + timedelta(
+        seconds=60
+    )
+    assert captured["expires_at"] == expected
+
+
+async def test_open_falls_back_to_estimate_when_status_read_fails(service):
+    """A failed endsAt read must not block the open; fall back to the estimate."""
+    service._is_expensive_model = AsyncMock(return_value=False)
+    open_session = AsyncMock(return_value={"sessionID": "0xnew"})
+
+    captured = {}
+    db = AsyncMock()
+    db.add = MagicMock(side_effect=lambda row: captured.update(expires_at=row.expires_at))
+
+    @asynccontextmanager
+    async def _fake_get_db():
+        yield db
+
+    before = datetime.now(timezone.utc).replace(tzinfo=None)
+    with patch("src.services.session_routing_service.get_db", _fake_get_db), patch.object(
+        settings, "SESSION_DEFAULT_DURATION_SECONDS", 4200
+    ), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        open_session,
+    ), _patch_session_status(side_effect=RuntimeError("proxy down")):
+        sid = await service._open_session_for_model(model_id="0xmodel", model_name="m")
+
+    assert sid == "0xnew"
+    # Fallback estimate ~ now + duration (far below the year-2033 on-chain value).
+    assert captured["expires_at"] >= before + timedelta(seconds=4200)
+    assert captured["expires_at"] < before + timedelta(seconds=4200 + 3600)


### PR DESCRIPTION
Promotion **dev → test** for review.

### Included (dev ahead of test)
- `fix(session-routing): anchor session expires_at to on-chain endsAt` (#267)

### What it does
Sets a routed session's `expires_at` from the **actual on-chain `endsAt`** (read back after open via `getSessionStatus`) plus a small `SESSION_EXPIRY_BUFFER_SECONDS` (default 60s), instead of the old `call_start + requested_duration` estimate. This makes the expiry sweep close sessions **at/after** `endsAt` (a "late" close → full stake straight to the wallet) rather than a few seconds early — which was locking stake in `userStakesOnHold` and forcing housekeeping `withdrawUserStakes` recovery.

### Deploy note
New env var `SESSION_EXPIRY_BUFFER_SECONDS` (default 60). Ships inert-safe; set per-env alongside the other `SESSION_*` vars if you want to override.

### Validation
- Unit: 16 (expensive-tier + new anchoring/fallback) + 21 (related session suites) passing; no lint.
- prd measurement: on-chain duration == requested (4199s); ~7% of closes were landing early on the boundary and are flipped to late by this change.

Review and merge to TEST when ready.

Made with [Cursor](https://cursor.com)