### PR TITLE
Promote model-type-aware routing fix to production (test -> main)

### DIFF
--- a/src/core/model_routing.py
+++ b/src/core/model_routing.py
@@ -16,7 +16,15 @@ class ModelRouter:
     """
     Handles routing of model names to blockchain IDs using DirectModelService.
     """
-    
+
+    # Acceptable active_models.json ModelType values per request type. Request
+    # types not listed here (e.g. TTS/STT, which the feed does not type
+    # distinctly yet) skip the compatibility check.
+    COMPATIBLE_MODEL_TYPES = {
+        "LLM": {"LLM"},
+        "EMBEDDINGS": {"EMBEDDING"},
+    }
+
     def __init__(self):
         logger.info("Initialized ModelRouter with DirectModelService",
                    event_type="model_router_init")
@@ -51,6 +59,21 @@ class ModelRouter:
         # Try to resolve using DirectModelService
         try:
             resolved_id = await direct_model_service.resolve_model_id(requested_model)
+
+            # A resolved model must be usable by this endpoint type. Without
+            # this check a chat completion naming an EMBEDDING model opens a
+            # session with the embedding provider, whose backend then rejects
+            # the chat payload ("Router.aembedding() missing ... 'input'").
+            # Treat a mismatch like an unknown model: fall back to the
+            # default model for the requested type.
+            if resolved_id and not await self._is_type_compatible(resolved_id, type):
+                logger.warning("Requested model type is incompatible with endpoint",
+                              requested_model=requested_model,
+                              resolved_id=resolved_id,
+                              requested_type=type,
+                              event_type="model_type_mismatch")
+                resolved_id = None
+
             if resolved_id:
                 logger.info("Found model mapping",
                            requested_model=requested_model,
@@ -88,6 +111,36 @@ class ModelRouter:
                           event_type="default_model_error_fallback")
             return default_id
     
+    async def _is_type_compatible(self, blockchain_id: str, type: Optional[str]) -> bool:
+        """
+        Check whether a resolved model's ModelType is usable for the requested
+        endpoint type ("LLM", "EMBEDDINGS", ...).
+
+        Returns True when the request type has no compatibility rule, or the
+        model's type cannot be determined (fail open - never block routing on
+        missing metadata).
+        """
+        compatible_types = self.COMPATIBLE_MODEL_TYPES.get(type)
+        if not compatible_types:
+            return True
+
+        try:
+            model_name = await direct_model_service.get_model_name_from_id(blockchain_id)
+            if not model_name:
+                return True
+            model_types = await direct_model_service.get_model_mapping_type()
+            model_type = model_types.get(model_name.lower())
+            if not model_type:
+                return True
+            return model_type in compatible_types
+        except Exception as e:
+            logger.error("Error checking model type compatibility - failing open",
+                        blockchain_id=blockchain_id,
+                        requested_type=type,
+                        error=str(e),
+                        event_type="model_type_check_error")
+            return True
+
     async def _get_default_model_id(self, type: Optional[str] = "LLM") -> str:
         """Get the blockchain ID for the default model"""
         try:

--- a/tests/unit/test_model_router.py
+++ b/tests/unit/test_model_router.py
@@ -1,9 +1,74 @@
 import pytest
+from unittest.mock import AsyncMock, patch
+
 from src.core.model_routing import ModelRouter
 
 @pytest.fixture
 def model_router():
     return ModelRouter()
+
+
+EMBED_ID = "0x" + "aa" * 32
+LLM_ID = "0x" + "bb" * 32
+DEFAULT_LLM_ID = "0x" + "cc" * 32
+DEFAULT_EMBED_ID = EMBED_ID
+
+
+def _patched_model_service():
+    """Patch direct_model_service with a small fixed catalog."""
+    mapping = {
+        "text-embedding-bge-m3": EMBED_ID,
+        "some-llm": LLM_ID,
+        "mistral-31-24b": DEFAULT_LLM_ID,
+    }
+    id_to_name = {v: k for k, v in mapping.items()}
+    mapping_type = {
+        "text-embedding-bge-m3": "EMBEDDING",
+        "some-llm": "LLM",
+        "mistral-31-24b": "LLM",
+    }
+    service = patch.multiple(
+        "src.core.model_routing.direct_model_service",
+        resolve_model_id=AsyncMock(side_effect=lambda m: mapping.get(m.lower())),
+        get_model_name_from_id=AsyncMock(side_effect=lambda i: id_to_name.get(i)),
+        get_model_mapping_type=AsyncMock(return_value=mapping_type),
+        get_model_mapping=AsyncMock(return_value=mapping),
+        get_blockchain_ids=AsyncMock(return_value=set(mapping.values())),
+    )
+    return service
+
+
+@pytest.mark.asyncio
+async def test_chat_request_for_embedding_model_falls_back_to_default_llm(model_router):
+    # A chat completion (type="LLM") naming an EMBEDDING model must NOT route
+    # to the embedding provider (its backend rejects chat payloads with
+    # "Router.aembedding() missing 1 required positional argument: 'input'").
+    with _patched_model_service():
+        result = await model_router.get_target_model("text-embedding-bge-m3", type="LLM")
+    assert result == DEFAULT_LLM_ID
+
+
+@pytest.mark.asyncio
+async def test_embeddings_request_for_llm_model_falls_back_to_default_embeddings(model_router):
+    with _patched_model_service():
+        result = await model_router.get_target_model("some-llm", type="EMBEDDINGS")
+    assert result == DEFAULT_EMBED_ID
+
+
+@pytest.mark.asyncio
+async def test_matching_types_resolve_normally(model_router):
+    with _patched_model_service():
+        assert await model_router.get_target_model("some-llm", type="LLM") == LLM_ID
+        assert await model_router.get_target_model(
+            "text-embedding-bge-m3", type="EMBEDDINGS"
+        ) == EMBED_ID
+
+
+@pytest.mark.asyncio
+async def test_unlisted_request_type_skips_compatibility_check(model_router):
+    # TTS/STT are not typed distinctly in active_models.json - no rule, no block.
+    with _patched_model_service():
+        assert await model_router.get_target_model("some-llm", type="TTS") == LLM_ID
 
 @pytest.mark.asyncio
 async def test_get_target_model_valid_name(model_router):


### PR DESCRIPTION
## Summary
Promotes the model-type-aware routing fix from `test` (deployed to `api.dev.mor.org` as `v1.30.1-test`) to `main` (production).

Rolls up 3 commits:
- `495da43` fix(model-routing): don't route chat completions to embedding-type models
- `#270` merge fix into `dev`
- `#271` merge `dev` -> `test`

## What it fixes
Chat-completion requests that named an EMBEDDING-type model (e.g. `text-embedding-bge-m3`) were being routed to the embedding provider, whose litellm backend then failed with `Router.aembedding() missing 1 required positional argument: 'input'`. `ModelRouter.get_target_model` now validates the resolved model's `ModelType` against the endpoint type and falls back to the default model for that type on a mismatch (logs a `model_type_mismatch` warning). Fails open when model metadata is unavailable.

## Verification on test (api.dev.mor.org)
- CI/CD run 28942164276: unit tests, Docker build, DB migrations, ECS deploy, health check, release — all green.
- Live `/health`: `status: ok`, `version: v1.30.1-test`, database/redis/model-service healthy (19 models).
- Post-deploy logs (30m): real request traffic flowing, 0 `aembedding` errors, 0 unexpected errors. New container startup clean.

## Test plan
- [ ] Merge triggers prod CI/CD deploy to `api.mor.org`
- [ ] Confirm `/health` reports the new version and healthy subsystems
- [ ] Confirm `Router.aembedding() missing ... 'input'` errors stop in prod logs
- [ ] Watch for `model_type_mismatch` warnings (expected from the prober user sending chat requests with an embedding model)

Made with [Cursor](https://cursor.com)