### PR TITLE
feat(failover): fail over on impaired providers and exclude them on r…

### DIFF
--- a/alembic/versions/2026_07_14_0001_add_provider_address_to_routed_sessions.py
+++ b/alembic/versions/2026_07_14_0001_add_provider_address_to_routed_sessions.py
@@ -1,0 +1,31 @@
+"""Add provider_address to routed_sessions
+
+Stores the on-chain provider address serving each session so that failover
+can exclude the failed provider (proxy-router omitProvider) when opening
+the retry session instead of potentially landing on the same impaired one.
+
+Revision ID: add_provider_address
+Revises: add_rate_limit_mult
+Create Date: 2026-07-14 00:01:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'add_provider_address'
+down_revision: Union[str, None] = 'add_rate_limit_mult'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'routed_sessions',
+        sa.Column('provider_address', sa.String(length=42), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('routed_sessions', 'provider_address')

--- a/src/api/v1/chat/chat_failover.py
+++ b/src/api/v1/chat/chat_failover.py
@@ -74,12 +74,12 @@ IMPAIRED_PROVIDER_PATTERNS = [
     "model unavailable",
     "model is unavailable",
     "service unavailable",
-    # upstreamStatusCode emitted by newer providers but collapsed to HTTP 400
-    # by an older consumer node in between.
-    '"upstreamstatuscode":429',
-    '"upstreamstatuscode": 429',
-    '"upstreamstatuscode":503',
-    '"upstreamstatuscode": 503',
+    # statusCode emitted by newer providers (proxy-router AiEngineErrorResponse)
+    # but collapsed to HTTP 400 by an older consumer node in between.
+    '"statuscode":429',
+    '"statuscode": 429',
+    '"statuscode":503',
+    '"statuscode": 503',
 ]
 
 

--- a/src/api/v1/chat/chat_failover.py
+++ b/src/api/v1/chat/chat_failover.py
@@ -60,13 +60,48 @@ PROVIDER_FAILURE_PATTERNS = [
     "failed to create chat completions stream",
 ]
 
+# Impaired-provider signatures inside a providerModelError body: the provider
+# is reachable but its model backend (Venice etc.) is rate-limited or out of
+# capacity. Newer proxy-routers surface these with the real upstream status
+# (429/503); older ones collapse them into HTTP 400, so these patterns are
+# the fallback for recognizing them in the embedded error text.
+IMPAIRED_PROVIDER_PATTERNS = [
+    "rate limit",
+    "rate_limit",
+    "too many requests",
+    "capacity",
+    "overloaded",
+    "model unavailable",
+    "model is unavailable",
+    "service unavailable",
+    # upstreamStatusCode emitted by newer providers but collapsed to HTTP 400
+    # by an older consumer node in between.
+    '"upstreamstatuscode":429',
+    '"upstreamstatuscode": 429',
+    '"upstreamstatuscode":503',
+    '"upstreamstatuscode": 503',
+]
+
+
+def _is_impaired_provider_error(message: str) -> bool:
+    """True for providerModelError bodies that signal rate-limit/capacity.
+
+    Only applies to provider model errors (backend reached, backend degraded);
+    other 4xx bodies (auth failed, malformed request) stay ineligible.
+    """
+    if "providermodelerror" not in message:
+        return False
+    return any(p in message for p in IMPAIRED_PROVIDER_PATTERNS)
+
 
 def is_failover_eligible(exc: proxy_router_service.ProxyRouterServiceError) -> bool:
-    """Decide whether a proxy error means the provider is unavailable.
+    """Decide whether a proxy error means the provider is unavailable/impaired.
 
-    Eligible: provider unreachable / 5xx / timeouts / transport failures.
+    Eligible: provider unreachable / 5xx / timeouts / transport failures /
+    rate-limited or out-of-capacity model backends (429, or capacity patterns
+    inside a providerModelError body).
     Not eligible: session expired/not found (separate renewal mechanism),
-    user/4xx errors, TEE failures, client-cancelled requests.
+    genuine user/4xx errors, TEE failures, client-cancelled requests.
     """
     if not settings.CHAT_FAILOVER_ENABLED:
         return False
@@ -76,8 +111,13 @@ def is_failover_eligible(exc: proxy_router_service.ProxyRouterServiceError) -> b
         return False
 
     status = exc.status_code
+    if status == 429:
+        # Provider's model backend is rate-limited — treat as impaired.
+        return True
     if status is not None and 400 <= status < 500:
-        return False
+        # Older proxy-routers collapse backend 429/503 into HTTP 400 with a
+        # providerModelError body; recognize those by pattern as a fallback.
+        return _is_impaired_provider_error(message)
     if status is not None and status >= 500:
         return True
     # No status: gateway<->proxy transport failure, or wrapped errors.
@@ -179,11 +219,18 @@ async def attempt_failover(
                             failure_reason=failure_reason[:300],
                             event_type="failover_triggered")
 
-    # 2. A sibling bid exists and is worth trying. Unpin the dead session so no
-    #    request routes to it again (marks FAILED + best-effort background
-    #    on-chain close).
+    # 2. A sibling bid exists and is worth trying. Look up which provider
+    #    served the dead session (so the reroute can exclude it), then unpin
+    #    the session so no request routes to it again (marks FAILED +
+    #    best-effort background on-chain close).
+    failed_provider: Optional[str] = None
     try:
         async with get_db() as db:
+            session_row = await session_routing_service.get_session_info(
+                db, original_session_id
+            )
+            if session_row is not None:
+                failed_provider = session_row.provider_address
             await session_routing_service.invalidate_session(
                 db, original_session_id, failure_reason[:300]
             )
@@ -193,14 +240,18 @@ async def attempt_failover(
                               event_type="failover_invalidate_failed")
         return None
 
-    # 3. Open/route a fresh session by model. The proxy-router tries bids
-    #    best-first with a provider handshake per bid, so the dead
-    #    provider is skipped automatically.
+    # 3. Open/route a fresh session by model, excluding the failed provider
+    #    (omitProvider in the proxy-router's bid selection + skipping its
+    #    sibling idle sessions). Crucial for IMPAIRED providers: they pass the
+    #    session-open handshake (TCP is fine, only the backend is broken), so
+    #    without the exclusion the top-rated — broken — bid would be picked
+    #    again. Transport-dead providers were already skipped by the handshake.
     try:
         new_session_id = await session_routing_service.route_request(
             user_id=user.id,
             requested_model=requested_model,
             model_type="LLM",
+            omit_provider=failed_provider,
         )
     except Exception as e:
         failover_logger.error("Failover rerouting failed",

--- a/src/db/models/routed_session.py
+++ b/src/db/models/routed_session.py
@@ -65,6 +65,9 @@ class RoutedSession(Base):
     # Optional tracking
     endpoint = Column(String, nullable=True)  # e.g., "/v1/chat/completions"
     error_reason = Column(String, nullable=True)
+    # On-chain provider address serving this session (0x hex). Used by
+    # failover to exclude the failed provider when opening the retry session.
+    provider_address = Column(String(42), nullable=True)
     
     # Indexes for efficient queries
     __table_args__ = (

--- a/src/services/proxy_router_service.py
+++ b/src/services/proxy_router_service.py
@@ -293,7 +293,7 @@ async def _execute_request(
             # providerModelError body) are the provider's fault, not the
             # client's — surface them as 502 so clients don't mistake them
             # for their own auth/request errors. The original status stays
-            # visible in the message body (upstreamStatusCode).
+            # visible in the message body (statusCode).
             remapped = remap_provider_upstream_error(status_code, response.text)
             if remapped:
                 req_logger.warning("Remapping provider upstream config error to 502",

--- a/src/services/proxy_router_service.py
+++ b/src/services/proxy_router_service.py
@@ -94,6 +94,8 @@ class ProxyRouterServiceError(Exception):
             "validation_error": 400,
             "not_found_error": 404,
             "client_error": 400,
+            "rate_limit_error": 429,
+            "provider_error": 502,
             "server_error": 503,
             "network_error": 503,
             "timeout_error": 504,
@@ -139,6 +141,30 @@ def is_nonce_error(message: str) -> bool:
         return False
     text_lower = message.lower()
     return any(pattern in text_lower for pattern in NONCE_ERROR_PATTERNS)
+
+
+# Backend statuses inside a providerModelError that mean the PROVIDER is
+# misconfigured or broken (its own credentials/model config for the backend),
+# not the gateway client. Surfacing them as-is would mislead clients — e.g. a
+# passed-through 401 makes an OpenAI SDK believe its own gateway API key is
+# invalid — so they are remapped to 502 Bad Gateway (upstream failure), which
+# also makes them failover-eligible like any other impaired-provider error.
+PROVIDER_CONFIG_ERROR_STATUSES = {401, 403, 404}
+
+
+def remap_provider_upstream_error(status_code: int, response_text: str):
+    """Remap provider-backend config failures to (502, "provider_error").
+
+    Applies only to providerModelError bodies (the provider reached its model
+    backend and the backend rejected the PROVIDER'S request). Other statuses,
+    including 429 (propagated as-is for client backoff) and 400/422 (the
+    client's request may genuinely be malformed), are left untouched.
+
+    Returns (status_code, error_type) or None when no remap applies.
+    """
+    if status_code in PROVIDER_CONFIG_ERROR_STATUSES and "providermodelerror" in response_text.lower():
+        return 502, "provider_error"
+    return None
 
 
 
@@ -255,8 +281,25 @@ async def _execute_request(
             error_type = "http_error"
             if status_code >= 500:
                 error_type = "server_error"
+            elif status_code == 429:
+                # Provider's model backend rate-limited the request; keep it
+                # distinguishable from genuine client errors so failover logic
+                # and clients can react appropriately.
+                error_type = "rate_limit_error"
             elif status_code >= 400:
                 error_type = "client_error"
+
+            # Provider-side backend config failures (401/403/404 with a
+            # providerModelError body) are the provider's fault, not the
+            # client's — surface them as 502 so clients don't mistake them
+            # for their own auth/request errors. The original status stays
+            # visible in the message body (upstreamStatusCode).
+            remapped = remap_provider_upstream_error(status_code, response.text)
+            if remapped:
+                req_logger.warning("Remapping provider upstream config error to 502",
+                              original_status_code=status_code,
+                              event_type="provider_upstream_error_remap")
+                status_code, error_type = remapped
             
             # Nonce conflicts are non-retriable HERE: re-sending the identical
             # request never fixes a nonce race. Surfacing it immediately lets the
@@ -337,6 +380,7 @@ async def openSession(
     session_duration: int = 3600,
     failover: bool = False,
     direct_payment: bool = False,
+    omit_provider: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Open a new session with the proxy router.
@@ -347,6 +391,10 @@ async def openSession(
         user_id: User ID for logging
         failover: Whether to enable failover
         direct_payment: Whether to use direct payment
+        omit_provider: Provider address (0x hex) to exclude from bid
+            selection — used by failover to avoid reopening on the provider
+            that just failed. Requires a proxy-router that supports the
+            omitProvider field (older ones ignore unknown JSON fields).
         
     Returns:
         Dict containing session information including sessionID
@@ -356,6 +404,7 @@ async def openSession(
     """
     logger.info("Opening proxy router session",
                target_model=target_model,
+               omit_provider=omit_provider,
                event_type="session_open_start")
     
     # Validate model format
@@ -371,6 +420,8 @@ async def openSession(
         "failover": failover,
         "directPayment": direct_payment
     }
+    if omit_provider:
+        session_data["omitProvider"] = omit_provider
     
     headers = {"Content-Type": "application/json"}
     
@@ -804,10 +855,22 @@ async def chatCompletionsStream(
                     # Read the error response body to get detailed error information
                     error_body = await response.aread()
                     error_text = error_body.decode("utf-8", errors="replace")
-                    error_type = "server_error" if response.status_code >= 500 else "client_error"
+                    status_code = response.status_code
+                    if status_code >= 500:
+                        error_type = "server_error"
+                    elif status_code == 429:
+                        error_type = "rate_limit_error"
+                    else:
+                        error_type = "client_error"
+                    remapped = remap_provider_upstream_error(status_code, error_text)
+                    if remapped:
+                        req_logger.warning("Remapping provider upstream config error to 502",
+                                      original_status_code=status_code,
+                                      event_type="provider_upstream_error_remap")
+                        status_code, error_type = remapped
                     raise ProxyRouterServiceError(
-                        sanitize_error_message(f"HTTP {response.status_code}: {error_text}"),
-                        status_code=response.status_code,
+                        sanitize_error_message(f"HTTP {status_code}: {error_text}"),
+                        status_code=status_code,
                         error_type=error_type
                     )
                 yield response

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -240,7 +240,8 @@ class SessionRoutingService:
         self,
         user_id: int,
         requested_model: Optional[str] = None,
-        model_type: str = "LLM"
+        model_type: str = "LLM",
+        omit_provider: Optional[str] = None,
     ) -> str:
         """
         Route an authorized request to an appropriate session.
@@ -254,6 +255,12 @@ class SessionRoutingService:
         This means any number of concurrent requests can queue for an open
         without pinning the DB pool (the wallet lock itself is the queue).
 
+        Args:
+            omit_provider: Provider address (0x hex) to avoid — set by
+                failover after a prompt failure. Idle sessions on that
+                provider are skipped and a newly opened session excludes it
+                from the proxy-router's bid selection.
+
         Returns:
             str: Session ID to use for the request
 
@@ -264,7 +271,8 @@ class SessionRoutingService:
         route_logger = logger.bind(
             user_id=user_id,
             requested_model=requested_model,
-            model_type=model_type
+            model_type=model_type,
+            omit_provider=omit_provider,
         )
 
         # Resolve model to blockchain ID
@@ -280,7 +288,7 @@ class SessionRoutingService:
         # a session to exactly one request, correct across replicas, and the
         # connection is released immediately (never held across the open below).
         async with get_db() as db:
-            claimed_id = await self._claim_idle_session(db, model_id)
+            claimed_id = await self._claim_idle_session(db, model_id, omit_provider=omit_provider)
         if claimed_id is not None:
             route_logger.info("Routed to idle session (atomic claim)",
                              session_id=claimed_id,
@@ -303,6 +311,7 @@ class SessionRoutingService:
             model_type=model_type,
             user_id=user_id,
             initial_active_requests=1,
+            omit_provider=omit_provider,
         )
 
     async def release_session(self, db: AsyncSession, session_id: str) -> None:
@@ -477,27 +486,51 @@ class SessionRoutingService:
             return None
         return ends_at if ends_at > 0 else None
 
-    async def _resolve_expires_at(
-        self, session_id: str, fallback: datetime, open_logger
+    @staticmethod
+    def _parse_provider_address(status: Any) -> Optional[str]:
+        """Extract the provider address (0x hex) from a getSessionStatus body.
+
+        Same defensive shape handling as _parse_onchain_ends_at. Returns None
+        when absent/invalid — provider tracking is best-effort and must never
+        block a session open.
+        """
+        if not isinstance(status, dict):
+            return None
+        session = status.get("session") or status.get("Session") or status
+        if not isinstance(session, dict):
+            return None
+        raw = session.get("Provider", session.get("provider"))
+        if not isinstance(raw, str):
+            return None
+        raw = raw.strip()
+        if len(raw) == 42 and raw.startswith("0x"):
+            return raw
+        return None
+
+    async def _fetch_session_status(self, session_id: str, open_logger) -> Optional[Any]:
+        """Best-effort read of the freshly-opened session's on-chain status."""
+        try:
+            return await proxy_router_service.getSessionStatus(session_id)
+        except Exception as e:
+            open_logger.warning(
+                "Could not read session status from proxy router",
+                error=str(e),
+                event_type="expires_at_read_error",
+            )
+            return None
+
+    def _resolve_expires_at(
+        self, status: Any, fallback: datetime, open_logger
     ) -> datetime:
         """Return expires_at anchored to the on-chain endsAt (+ configured buffer).
 
-        Reads the freshly-opened session's on-chain endsAt via the proxy router
-        and adds SESSION_EXPIRY_BUFFER_SECONDS so the cleanup sweep closes the
+        Parses the session's on-chain endsAt from ``status`` and adds
+        SESSION_EXPIRY_BUFFER_SECONDS so the cleanup sweep closes the
         session at/after its true end (a "late" close → full stake back to the
         wallet). Best-effort: any failure returns ``fallback`` (the call-start
         estimate) so a session open is never blocked on this read.
         """
-        try:
-            status = await proxy_router_service.getSessionStatus(session_id)
-            ends_at = self._parse_onchain_ends_at(status)
-        except Exception as e:
-            open_logger.warning(
-                "Could not read on-chain endsAt; using estimated expiry",
-                error=str(e),
-                event_type="expires_at_read_error",
-            )
-            return fallback
+        ends_at = self._parse_onchain_ends_at(status)
 
         if ends_at is None:
             open_logger.warning(
@@ -524,6 +557,7 @@ class SessionRoutingService:
         model_type: str = "LLM",
         user_id: Optional[int] = None,
         initial_active_requests: int = 0,
+        omit_provider: Optional[str] = None,
     ) -> str:
         """
         Open a new on-chain session for a model and persist its row.
@@ -548,6 +582,8 @@ class SessionRoutingService:
                 to its caller (never momentarily idle / claimable by another
                 request between insert and use); the automation path passes 0 to
                 create an idle, pre-warmed session.
+            omit_provider: Provider address to exclude from the proxy-router's
+                bid selection (failover away from an impaired provider).
 
         Returns:
             str: The blockchain session id of the newly opened session.
@@ -609,6 +645,7 @@ class SessionRoutingService:
                     session_duration=session_duration,
                     failover=False,
                     direct_payment=False,
+                    omit_provider=omit_provider,
                 ),
                 op_name="openSession",
                 op_logger=open_logger,
@@ -622,14 +659,23 @@ class SessionRoutingService:
                     model_id=model_id
                 )
 
+            # Read the session's on-chain status once and use it for both the
+            # authoritative expiry and the provider address. Best-effort: any
+            # failure falls back to the call-start expiry estimate and a NULL
+            # provider, so an open is never blocked on this read.
+            status = await self._fetch_session_status(blockchain_session_id, open_logger)
+
             # Anchor expires_at to the REAL on-chain endsAt (+ small buffer) so
             # the cleanup sweep closes the session AT/AFTER endsAt (a "late"
-            # close returns the full stake straight to the wallet). Best-effort:
-            # falls back to the call-start estimate if the read fails, so an
-            # open is never blocked on it.
-            expires_at = await self._resolve_expires_at(
-                blockchain_session_id, estimated_expires_at, open_logger
+            # close returns the full stake straight to the wallet).
+            expires_at = self._resolve_expires_at(
+                status, estimated_expires_at, open_logger
             )
+
+            # Provider serving this session — lets failover exclude it later
+            # (omitProvider) instead of possibly reopening on the same
+            # impaired provider.
+            provider_address = self._parse_provider_address(status)
 
             # Create session record only after successful open
             now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -653,7 +699,8 @@ class SessionRoutingService:
                     active_requests=initial_active_requests,
                     created_at=now,
                     updated_at=now,
-                    endpoint=endpoint
+                    endpoint=endpoint,
+                    provider_address=provider_address
                 )
                 db.add(session)
                 await db.commit()
@@ -766,7 +813,8 @@ class SessionRoutingService:
     async def _claim_idle_session(
         self,
         db: AsyncSession,
-        model_id: str
+        model_id: str,
+        omit_provider: Optional[str] = None,
     ) -> Optional[str]:
         """
         Atomically claim one idle (active_requests == 0), OPEN, non-expired
@@ -786,6 +834,11 @@ class SessionRoutingService:
         - routing the common case costs one statement served by
           idx_routed_sessions_model_state, with no lock held across I/O.
 
+        When ``omit_provider`` is set (failover), idle sessions known to belong
+        to that provider are skipped so the retry doesn't land on a sibling
+        session of the same impaired provider. Rows with an unknown (NULL)
+        provider stay claimable — optimistic, matches pre-tracking behavior.
+
         Returns the claimed session id, or None when no idle session exists.
         """
         now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -801,6 +854,11 @@ class SessionRoutingService:
                   AND state = :open_state
                   AND active_requests = 0
                   AND expires_at > :now
+                  AND (
+                        CAST(:omit_provider AS VARCHAR) IS NULL
+                        OR provider_address IS NULL
+                        OR lower(provider_address) != lower(:omit_provider)
+                      )
                 ORDER BY last_used_at ASC NULLS FIRST
                 LIMIT 1
                 FOR UPDATE SKIP LOCKED
@@ -815,6 +873,7 @@ class SessionRoutingService:
                     "now": now,
                     "model_id": model_id,
                     "open_state": SessionState.OPEN.value,
+                    "omit_provider": omit_provider,
                 },
             )
             claimed_id = result.scalar_one_or_none()

--- a/tests/unit/test_chat_failover.py
+++ b/tests/unit/test_chat_failover.py
@@ -31,6 +31,29 @@ class TestIsFailoverEligible:
         assert chat_failover.is_failover_eligible(exc) is True
 
     @pytest.mark.parametrize("exc", [
+        # Impaired provider: model backend rate-limited / out of capacity.
+        # Newer proxy-routers propagate the real upstream status (429/503).
+        _err('HTTP 429: {"providerModelError":{"error":{"message":"Rate limit exceeded","code":"rate_limit_exceeded"}},"upstreamStatusCode":429}', 429, "rate_limit_error"),
+        _err('HTTP 503: {"providerModelError":{"error":{"message":"Model is currently overloaded"}},"upstreamStatusCode":503}', 503, "server_error"),
+        # Older proxy-routers collapse backend errors into HTTP 400 with a
+        # providerModelError body; the pattern fallback must catch these.
+        _err('HTTP 400: {"providerModelError":{"error":{"message":"Rate limit exceeded, please try again later"}}}', 400, "client_error"),
+        _err('HTTP 400: {"providerModelError":{"error":{"message":"Too Many Requests"}}}', 400, "client_error"),
+        _err('HTTP 400: {"providerModelError":{"error":{"message":"The model is at capacity"}}}', 400, "client_error"),
+        _err('HTTP 400: {"providerModelError":{"error":{"message":"model unavailable"}}}', 400, "client_error"),
+        # Newer provider behind an older consumer node: upstreamStatusCode is
+        # embedded in the body even though the HTTP status is still 400.
+        _err('HTTP 400: {"providerModelError":{"error":"busy"},"upstreamStatusCode":429}', 400, "client_error"),
+        # Provider-backend config failure (e.g. provider's Venice key is bad):
+        # the gateway remaps 401/403/404 + providerModelError to 502
+        # provider_error, which is failover-eligible — another bid may be
+        # configured correctly.
+        _err('HTTP 502: {"providerModelError":{"error":"Authentication failed"},"upstreamStatusCode":401}', 502, "provider_error"),
+    ])
+    def test_impaired_provider_is_eligible(self, exc):
+        assert chat_failover.is_failover_eligible(exc) is True
+
+    @pytest.mark.parametrize("exc", [
         # Session-state errors belong to the SEPARATE renewal mechanism —
         # failover must NOT trigger even though they arrive as 500.
         _err('HTTP 500: {"error":"session expired"}', 500, "server_error"),
@@ -42,6 +65,12 @@ class TestIsFailoverEligible:
         _err('HTTP 500: {"error":"llm tee verification failed"}', 500, "server_error"),
         _err('HTTP 500: {"error":"request cancelled while waiting in queue: context canceled"}', 500, "server_error"),
         _err("something odd with no status and no known pattern", None, "unknown"),
+        # Genuine provider-side client errors (backend reached, request/config
+        # bad) must NOT fail over even though they carry providerModelError.
+        _err('HTTP 400: {"providerModelError":{"error":"Authentication failed"}}', 400, "client_error"),
+        _err('HTTP 400: {"providerModelError":{"error":{"message":"invalid request body"}}}', 400, "client_error"),
+        # Capacity-like words WITHOUT a providerModelError body stay ineligible.
+        _err('HTTP 400: {"error":"rate limit exceeded"}', 400, "client_error"),
     ])
     def test_not_eligible(self, exc):
         assert chat_failover.is_failover_eligible(exc) is False
@@ -65,6 +94,15 @@ def mock_user():
     return user
 
 
+FAILED_PROVIDER = "0xAbC1234567890abcdef1234567890abcdef12345"
+
+
+def _session_row(provider_address=FAILED_PROVIDER):
+    row = MagicMock()
+    row.provider_address = provider_address
+    return row
+
+
 @pytest.fixture
 def failover_mocks(mock_user):
     """Patch DB, routing service and bids lookup used by attempt_failover."""
@@ -77,6 +115,8 @@ def failover_mocks(mock_user):
             return False
 
     with patch.object(chat_failover, "get_db", lambda: FakeGetDb()), \
+         patch.object(chat_failover.session_routing_service, "get_session_info",
+                      new_callable=AsyncMock, return_value=_session_row()) as session_info, \
          patch.object(chat_failover.session_routing_service, "invalidate_session",
                       new_callable=AsyncMock, return_value=True) as invalidate, \
          patch.object(chat_failover.session_routing_service, "route_request",
@@ -84,7 +124,8 @@ def failover_mocks(mock_user):
          patch.object(chat_failover.proxy_router_service, "getRatedBids",
                       new_callable=AsyncMock, return_value=_rated_bids_response(2)) as bids, \
          patch.object(chat_failover.asyncio, "sleep", new_callable=AsyncMock):
-        yield {"invalidate": invalidate, "route": route, "bids": bids, "user": mock_user}
+        yield {"session_info": session_info, "invalidate": invalidate,
+               "route": route, "bids": bids, "user": mock_user}
 
 
 def _failover(mocks, **overrides):
@@ -107,6 +148,25 @@ class TestAttemptFailover:
         failover_mocks["invalidate"].assert_awaited_once()
         failover_mocks["bids"].assert_awaited_once()
         failover_mocks["route"].assert_awaited_once()
+
+    async def test_reroute_excludes_failed_provider(self, failover_mocks):
+        """The failed session's provider is passed as omit_provider so the
+        retry can't land on the same impaired (but reachable) provider."""
+        await _failover(failover_mocks)
+        assert failover_mocks["route"].await_args.kwargs["omit_provider"] == FAILED_PROVIDER
+
+    async def test_unknown_provider_reroutes_without_exclusion(self, failover_mocks):
+        """Legacy rows without a stored provider still fail over (omit=None)."""
+        failover_mocks["session_info"].return_value = _session_row(provider_address=None)
+        new_id = await _failover(failover_mocks)
+        assert new_id == "0xnew"
+        assert failover_mocks["route"].await_args.kwargs["omit_provider"] is None
+
+    async def test_missing_session_row_reroutes_without_exclusion(self, failover_mocks):
+        failover_mocks["session_info"].return_value = None
+        new_id = await _failover(failover_mocks)
+        assert new_id == "0xnew"
+        assert failover_mocks["route"].await_args.kwargs["omit_provider"] is None
 
     async def test_single_bid_skips_invalidate_and_retry(self, failover_mocks):
         # Single-bid: nothing to fail over to. The session must be left OPEN

--- a/tests/unit/test_chat_failover.py
+++ b/tests/unit/test_chat_failover.py
@@ -33,22 +33,22 @@ class TestIsFailoverEligible:
     @pytest.mark.parametrize("exc", [
         # Impaired provider: model backend rate-limited / out of capacity.
         # Newer proxy-routers propagate the real upstream status (429/503).
-        _err('HTTP 429: {"providerModelError":{"error":{"message":"Rate limit exceeded","code":"rate_limit_exceeded"}},"upstreamStatusCode":429}', 429, "rate_limit_error"),
-        _err('HTTP 503: {"providerModelError":{"error":{"message":"Model is currently overloaded"}},"upstreamStatusCode":503}', 503, "server_error"),
+        _err('HTTP 429: {"providerModelError":{"error":{"message":"Rate limit exceeded","code":"rate_limit_exceeded"}},"statusCode":429}', 429, "rate_limit_error"),
+        _err('HTTP 503: {"providerModelError":{"error":{"message":"Model is currently overloaded"}},"statusCode":503}', 503, "server_error"),
         # Older proxy-routers collapse backend errors into HTTP 400 with a
         # providerModelError body; the pattern fallback must catch these.
         _err('HTTP 400: {"providerModelError":{"error":{"message":"Rate limit exceeded, please try again later"}}}', 400, "client_error"),
         _err('HTTP 400: {"providerModelError":{"error":{"message":"Too Many Requests"}}}', 400, "client_error"),
         _err('HTTP 400: {"providerModelError":{"error":{"message":"The model is at capacity"}}}', 400, "client_error"),
         _err('HTTP 400: {"providerModelError":{"error":{"message":"model unavailable"}}}', 400, "client_error"),
-        # Newer provider behind an older consumer node: upstreamStatusCode is
+        # Newer provider behind an older consumer node: statusCode is
         # embedded in the body even though the HTTP status is still 400.
-        _err('HTTP 400: {"providerModelError":{"error":"busy"},"upstreamStatusCode":429}', 400, "client_error"),
+        _err('HTTP 400: {"providerModelError":{"error":"busy"},"statusCode":429}', 400, "client_error"),
         # Provider-backend config failure (e.g. provider's Venice key is bad):
         # the gateway remaps 401/403/404 + providerModelError to 502
         # provider_error, which is failover-eligible — another bid may be
         # configured correctly.
-        _err('HTTP 502: {"providerModelError":{"error":"Authentication failed"},"upstreamStatusCode":401}', 502, "provider_error"),
+        _err('HTTP 502: {"providerModelError":{"error":"Authentication failed"},"statusCode":401}', 502, "provider_error"),
     ])
     def test_impaired_provider_is_eligible(self, exc):
         assert chat_failover.is_failover_eligible(exc) is True

--- a/tests/unit/test_chat_non_streaming_failover.py
+++ b/tests/unit/test_chat_non_streaming_failover.py
@@ -31,6 +31,25 @@ SESSION_EXPIRED = ProxyRouterServiceError(
 USER_ERROR = ProxyRouterServiceError(
     'HTTP 400: {"error":"invalid request"}', status_code=400, error_type="client_error",
 )
+# Impaired provider: backend returned 429, propagated by newer proxy-routers.
+PROVIDER_RATE_LIMITED = ProxyRouterServiceError(
+    'HTTP 429: {"providerModelError":{"error":{"message":"Rate limit exceeded"}},"upstreamStatusCode":429}',
+    status_code=429,
+    error_type="rate_limit_error",
+)
+# Same condition through an older proxy-router that collapses it into 400.
+PROVIDER_RATE_LIMITED_LEGACY = ProxyRouterServiceError(
+    'HTTP 400: {"providerModelError":{"error":{"message":"Rate limit exceeded, please try again later"}}}',
+    status_code=400,
+    error_type="client_error",
+)
+# Provider's own backend credentials are broken (upstream 401): the service
+# layer remaps this to 502/provider_error before it reaches the handler.
+PROVIDER_AUTH_BROKEN = ProxyRouterServiceError(
+    'HTTP 502: {"providerModelError":{"error":"Authentication failed"},"upstreamStatusCode":401}',
+    status_code=502,
+    error_type="provider_error",
+)
 
 
 def _fake_get_db():
@@ -115,6 +134,52 @@ async def test_session_expired_triggers_renewal_not_failover(mock_user):
     # Renewal session released exactly once; original NOT released here.
     release.assert_awaited_once()
     assert release.await_args.args[1] == "0xrenewed"
+
+
+@pytest.mark.parametrize("impaired_error", [PROVIDER_RATE_LIMITED, PROVIDER_RATE_LIMITED_LEGACY, PROVIDER_AUTH_BROKEN])
+async def test_impaired_provider_triggers_failover_retry(mock_user, impaired_error):
+    """A rate-limited/out-of-capacity backend fails over like a dead provider."""
+    with patch.object(chat_non_streaming.proxy_router_service, "chatCompletions",
+                      new_callable=AsyncMock, side_effect=[impaired_error, _success_response()]) as chat, \
+         patch.object(chat_non_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value="0xnew") as failover, \
+         patch.object(chat_non_streaming.session_routing_service, "release_session",
+                      new_callable=AsyncMock) as release, \
+         patch.object(chat_non_streaming, "get_db", _fake_get_db()):
+        response = await _call(mock_user)
+
+    assert response.status_code == 200
+    assert chat.await_count == 2
+    assert chat.await_args_list[1].kwargs["session_id"] == "0xnew"
+    failover.assert_awaited_once()
+    release.assert_awaited_once()
+    assert release.await_args.args[1] == "0xnew"
+
+
+async def test_impaired_provider_without_alternate_surfaces_429(mock_user):
+    """Single-bid model: no failover possible, real 429 reaches the client."""
+    with patch.object(chat_non_streaming.proxy_router_service, "chatCompletions",
+                      new_callable=AsyncMock, side_effect=[PROVIDER_RATE_LIMITED]), \
+         patch.object(chat_non_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value=None):
+        response = await _call(mock_user)
+
+    assert response.status_code == 429
+    payload = json.loads(response.body)
+    assert payload["error"]["type"] == "rate_limit_error"
+
+
+async def test_provider_auth_failure_without_alternate_surfaces_502(mock_user):
+    """Broken provider backend creds: client sees 502 provider_error, NOT 401."""
+    with patch.object(chat_non_streaming.proxy_router_service, "chatCompletions",
+                      new_callable=AsyncMock, side_effect=[PROVIDER_AUTH_BROKEN]), \
+         patch.object(chat_non_streaming.chat_failover, "attempt_failover",
+                      new_callable=AsyncMock, return_value=None):
+        response = await _call(mock_user)
+
+    assert response.status_code == 502
+    payload = json.loads(response.body)
+    assert payload["error"]["type"] == "provider_error"
 
 
 async def test_user_error_is_not_retried(mock_user):

--- a/tests/unit/test_chat_non_streaming_failover.py
+++ b/tests/unit/test_chat_non_streaming_failover.py
@@ -33,7 +33,7 @@ USER_ERROR = ProxyRouterServiceError(
 )
 # Impaired provider: backend returned 429, propagated by newer proxy-routers.
 PROVIDER_RATE_LIMITED = ProxyRouterServiceError(
-    'HTTP 429: {"providerModelError":{"error":{"message":"Rate limit exceeded"}},"upstreamStatusCode":429}',
+    'HTTP 429: {"providerModelError":{"error":{"message":"Rate limit exceeded"}},"statusCode":429}',
     status_code=429,
     error_type="rate_limit_error",
 )
@@ -46,7 +46,7 @@ PROVIDER_RATE_LIMITED_LEGACY = ProxyRouterServiceError(
 # Provider's own backend credentials are broken (upstream 401): the service
 # layer remaps this to 502/provider_error before it reaches the handler.
 PROVIDER_AUTH_BROKEN = ProxyRouterServiceError(
-    'HTTP 502: {"providerModelError":{"error":"Authentication failed"},"upstreamStatusCode":401}',
+    'HTTP 502: {"providerModelError":{"error":"Authentication failed"},"statusCode":401}',
     status_code=502,
     error_type="provider_error",
 )

--- a/tests/unit/test_provider_error_remap.py
+++ b/tests/unit/test_provider_error_remap.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from src.services.proxy_router_service import remap_provider_upstream_error
 
-PROVIDER_AUTH_BODY = '{"providerModelError":{"error":"Authentication failed"},"upstreamStatusCode":401}'
+PROVIDER_AUTH_BODY = '{"providerModelError":{"error":"Authentication failed"},"statusCode":401}'
 
 
 @pytest.mark.parametrize("status", [401, 403, 404])
@@ -24,12 +24,12 @@ def test_provider_config_statuses_remap_to_502(status):
 
 @pytest.mark.parametrize("status,body", [
     # 429 must pass through untouched so clients back off properly.
-    (429, '{"providerModelError":{"error":{"message":"Rate limit exceeded"}},"upstreamStatusCode":429}'),
+    (429, '{"providerModelError":{"error":{"message":"Rate limit exceeded"}},"statusCode":429}'),
     # 400/422: the client's request may genuinely be malformed.
     (400, '{"providerModelError":{"error":{"message":"invalid request body"}}}'),
     (422, '{"providerModelError":{"error":{"message":"unsupported parameter"}}}'),
     # 5xx already surfaces as server_error / failover.
-    (503, '{"providerModelError":{"error":"overloaded"},"upstreamStatusCode":503}'),
+    (503, '{"providerModelError":{"error":"overloaded"},"statusCode":503}'),
     # 401 WITHOUT a providerModelError body is a real auth error between the
     # gateway and the proxy-router — must not be masked.
     (401, '{"error":"unauthorized"}'),

--- a/tests/unit/test_provider_error_remap.py
+++ b/tests/unit/test_provider_error_remap.py
@@ -1,0 +1,39 @@
+"""Tests for remapping provider-backend config errors (401/403/404) to 502.
+
+A providerModelError with one of these statuses means the PROVIDER's own
+credentials/config for its model backend are broken — not the gateway
+client's fault. Passing e.g. a 401 through would make OpenAI SDK clients
+believe their gateway API key is invalid.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.services.proxy_router_service import remap_provider_upstream_error
+
+PROVIDER_AUTH_BODY = '{"providerModelError":{"error":"Authentication failed"},"upstreamStatusCode":401}'
+
+
+@pytest.mark.parametrize("status", [401, 403, 404])
+def test_provider_config_statuses_remap_to_502(status):
+    assert remap_provider_upstream_error(status, PROVIDER_AUTH_BODY) == (502, "provider_error")
+
+
+@pytest.mark.parametrize("status,body", [
+    # 429 must pass through untouched so clients back off properly.
+    (429, '{"providerModelError":{"error":{"message":"Rate limit exceeded"}},"upstreamStatusCode":429}'),
+    # 400/422: the client's request may genuinely be malformed.
+    (400, '{"providerModelError":{"error":{"message":"invalid request body"}}}'),
+    (422, '{"providerModelError":{"error":{"message":"unsupported parameter"}}}'),
+    # 5xx already surfaces as server_error / failover.
+    (503, '{"providerModelError":{"error":"overloaded"},"upstreamStatusCode":503}'),
+    # 401 WITHOUT a providerModelError body is a real auth error between the
+    # gateway and the proxy-router — must not be masked.
+    (401, '{"error":"unauthorized"}'),
+    (404, '{"error":"not found"}'),
+])
+def test_non_provider_config_errors_are_not_remapped(status, body):
+    assert remap_provider_upstream_error(status, body) is None

--- a/tests/unit/test_session_expensive_tier.py
+++ b/tests/unit/test_session_expensive_tier.py
@@ -163,13 +163,16 @@ def _patch_get_db():
     return patch("src.services.session_routing_service.get_db", _fake_get_db)
 
 
-def _patch_session_status(ends_at=None, side_effect=None):
+PROVIDER_ADDR = "0xAbC1234567890abcdef1234567890abcdef12345"
+
+
+def _patch_session_status(ends_at=None, side_effect=None, provider=PROVIDER_ADDR):
     """Patch getSessionStatus to return an on-chain endsAt (Go-style keys)."""
     kwargs = {}
     if side_effect is not None:
         kwargs["side_effect"] = side_effect
     else:
-        kwargs["return_value"] = {"session": {"Id": "0xnew", "EndsAt": ends_at}}
+        kwargs["return_value"] = {"session": {"Id": "0xnew", "EndsAt": ends_at, "Provider": provider}}
     return patch(
         "src.services.session_routing_service.proxy_router_service.getSessionStatus",
         new_callable=AsyncMock,
@@ -225,6 +228,58 @@ def test_parse_onchain_ends_at_rejects_zero_and_missing(service):
     assert service._parse_onchain_ends_at({"session": {}}) is None
     assert service._parse_onchain_ends_at({}) is None
     assert service._parse_onchain_ends_at(None) is None
+
+
+def test_parse_provider_address_go_style_keys(service):
+    assert service._parse_provider_address(
+        {"session": {"Provider": PROVIDER_ADDR}}
+    ) == PROVIDER_ADDR
+
+
+def test_parse_provider_address_rejects_invalid(service):
+    assert service._parse_provider_address({"session": {"Provider": "not-an-addr"}}) is None
+    assert service._parse_provider_address({"session": {"Provider": 123}}) is None
+    assert service._parse_provider_address({"session": {}}) is None
+    assert service._parse_provider_address({}) is None
+    assert service._parse_provider_address(None) is None
+
+
+async def test_open_stores_provider_address(service):
+    """The provider serving the new session is persisted for later failover."""
+    service._is_expensive_model = AsyncMock(return_value=False)
+    open_session = AsyncMock(return_value={"sessionID": "0xnew"})
+
+    captured = {}
+    db = AsyncMock()
+    db.add = MagicMock(side_effect=lambda row: captured.update(provider=row.provider_address))
+
+    @asynccontextmanager
+    async def _fake_get_db():
+        yield db
+
+    with patch("src.services.session_routing_service.get_db", _fake_get_db), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        open_session,
+    ), _patch_session_status(ends_at=2_000_000_000):
+        await service._open_session_for_model(model_id="0xmodel", model_name="m")
+
+    assert captured["provider"] == PROVIDER_ADDR
+
+
+async def test_open_passes_omit_provider_to_proxy(service):
+    """omit_provider flows through to the proxy-router openSession call."""
+    service._is_expensive_model = AsyncMock(return_value=False)
+    open_session = AsyncMock(return_value={"sessionID": "0xnew"})
+
+    with _patch_get_db(), patch(
+        "src.services.session_routing_service.proxy_router_service.openSession",
+        open_session,
+    ), _patch_session_status(ends_at=2_000_000_000):
+        await service._open_session_for_model(
+            model_id="0xmodel", model_name="m", omit_provider=PROVIDER_ADDR
+        )
+
+    assert open_session.call_args.kwargs["omit_provider"] == PROVIDER_ADDR
 
 
 async def test_open_anchors_expires_at_to_onchain_ends_at(service):

--- a/tests/unit/test_session_routing_claim.py
+++ b/tests/unit/test_session_routing_claim.py
@@ -72,7 +72,7 @@ async def test_fast_path_returns_claimed_session_without_open(service, mock_db):
         session_id = await service.route_request(user_id=1, requested_model="m")
 
     assert session_id == "0xidle"
-    service._claim_idle_session.assert_awaited_once_with(mock_db, "0xmodel")
+    service._claim_idle_session.assert_awaited_once_with(mock_db, "0xmodel", omit_provider=None)
     service._open_session_for_model.assert_not_awaited()
 
 


### PR DESCRIPTION
…etry

A provider whose model backend is degraded (429 rate limit, 503, broken credentials) previously surfaced as a plain HTTP 400 client error: no failover ran, the session stayed OPEN and kept being routed to.

- treat 429 and providerModelError capacity patterns as failover-eligible (503 was already covered by the >=500 rule)
- classify 429 as rate_limit_error and remap provider-backend config failures (401/403/404 with a providerModelError body) to 502 provider_error, which is failover-eligible
- store the session's provider address in routed_sessions and pass it as omitProvider on the failover reroute (and skip its sibling idle sessions) so the retry cannot land on the same impaired provider, which passes the session-open handshake

Requires proxy-router support for upstreamStatusCode/omitProvider; degrades gracefully against older proxy-routers via pattern fallback.