### PR TITLE
fix(models): resolve veniceId and catalog-name slug aliases

### DIFF
--- a/src/core/direct_model_service.py
+++ b/src/core/direct_model_service.py
@@ -3,16 +3,51 @@ Direct model fetching service with in-memory cache and hash optimization.
 Replaces the complex model sync system with a simple, efficient approach.
 """
 
-import json
 import hashlib
-from typing import Dict, List, Optional
+import re
+from collections import defaultdict
 from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Set
+
 import httpx
 
 from src.core.config import settings
 from src.core.logging_config import get_models_logger
 
 logger = get_models_logger()
+
+
+def catalog_name_slug(name: str) -> str:
+    """Deterministic kebab slug of a catalog Name (spaces/underscores → '-').
+
+    Keeps dots and feature suffixes like ':web'. Not fuzzy — just a
+    predictable form of the on-chain/display name for API clients.
+    """
+    s = str(name or "").strip().lower()
+    if not s:
+        return ""
+    s = re.sub(r"[\s_]+", "-", s)
+    s = re.sub(r"-{2,}", "-", s)
+    return s.strip("-")
+
+
+def _alias_candidates(model_name: str, enrichment: Optional[dict]) -> Set[str]:
+    """Extra lowercase resolve keys for a catalog model (excluding the name itself)."""
+    aliases: Set[str] = set()
+    name_key = model_name.lower()
+
+    slug = catalog_name_slug(model_name)
+    if slug and slug != name_key:
+        aliases.add(slug)
+
+    venice_id = (enrichment or {}).get("veniceId") or (enrichment or {}).get("venice_id")
+    if isinstance(venice_id, str):
+        vid = venice_id.strip().lower()
+        if vid and vid != name_key:
+            aliases.add(vid)
+
+    return aliases
+
 
 class DirectModelService:
     """
@@ -198,26 +233,62 @@ class DirectModelService:
                 raise
     
     def _update_cache(self, models: List[Dict], content_hash: str, etag: Optional[str]):
-        """Update the internal cache with new model data."""
-        new_mapping = {}
-        new_id_to_name = {}
-        new_mapping_type = {}
-        new_blockchain_ids = set()
-        
+        """Update the internal cache with new model data.
+
+        Resolve keys (all lowercase):
+          1. Catalog Name (authoritative — never overwritten)
+          2. enrichment.veniceId when unique
+          3. kebab slug of catalog Name when unique and distinct from (1)
+        Colliding aliases are skipped so we never guess between two models.
+        """
+        new_mapping: Dict[str, str] = {}
+        new_id_to_name: Dict[str, str] = {}
+        new_mapping_type: Dict[str, str] = {}
+        new_blockchain_ids: set = set()
+        alias_claims: Dict[str, Set[str]] = defaultdict(set)
+
         for model in models:
             if model.get("IsDeleted", False):
                 continue
-                
+
             model_name = model.get("Name")
             blockchain_id = model.get("Id")
             model_type = model.get("ModelType")
-            
-            if model_name and blockchain_id:
-                new_mapping[model_name.lower()] = blockchain_id
-                new_id_to_name[blockchain_id] = model_name
-                new_mapping_type[model_name.lower()] = model_type
-                new_blockchain_ids.add(blockchain_id)
-        
+
+            if not model_name or not blockchain_id:
+                continue
+
+            name_key = model_name.lower()
+            new_mapping[name_key] = blockchain_id
+            new_id_to_name[blockchain_id] = model_name
+            new_mapping_type[name_key] = model_type
+            new_blockchain_ids.add(blockchain_id)
+
+            for alias in _alias_candidates(model_name, model.get("enrichment")):
+                if alias in new_mapping:
+                    # Catalog name (or earlier authoritative key) wins — never override.
+                    continue
+                alias_claims[alias].add(blockchain_id)
+
+        aliases_added = 0
+        aliases_skipped_collision = 0
+        for alias, ids in alias_claims.items():
+            if alias in new_mapping:
+                continue
+            if len(ids) != 1:
+                aliases_skipped_collision += 1
+                logger.info(
+                    "Skipping ambiguous model alias",
+                    alias=alias,
+                    claimant_count=len(ids),
+                    event_type="model_alias_collision",
+                )
+                continue
+            blockchain_id = next(iter(ids))
+            new_mapping[alias] = blockchain_id
+            # Type lookups for aliases use id→catalog name; no type entry needed.
+            aliases_added += 1
+
         self._model_mapping = new_mapping
         self._id_to_name = new_id_to_name
         self._model_mapping_type = new_mapping_type
@@ -226,8 +297,15 @@ class DirectModelService:
         self._last_hash = content_hash
         self._last_etag = etag
         self._cache_expiry = datetime.now() + timedelta(seconds=self.cache_duration)
-        
-        logger.info(f"Cache updated: {len(new_mapping)} model mappings, {len(new_blockchain_ids)} blockchain IDs")
+
+        logger.info(
+            "Cache updated",
+            model_mappings=len(new_mapping),
+            blockchain_ids=len(new_blockchain_ids),
+            aliases_added=aliases_added,
+            aliases_skipped_collision=aliases_skipped_collision,
+            event_type="model_cache_updated",
+        )
     
     def _extend_cache(self):
         """Extend the current cache expiry without changing data."""

--- a/tests/unit/test_direct_model_service_aliases.py
+++ b/tests/unit/test_direct_model_service_aliases.py
@@ -1,0 +1,135 @@
+"""Unit tests for catalog / veniceId / slug model-name aliases."""
+
+import pytest
+
+from src.core.direct_model_service import (
+    DirectModelService,
+    _alias_candidates,
+    catalog_name_slug,
+)
+
+
+SONNET_ID = "0x" + "11" * 32
+OPUS_ID = "0x" + "22" * 32
+LUNA_ID = "0x" + "33" * 32
+DEEPSEEK_SPACED_ID = "0x" + "44" * 32
+DEEPSEEK_KEBAB_ID = "0x" + "55" * 32
+GLM_ID = "0x" + "66" * 32
+
+
+def _svc_with_models(models):
+    svc = DirectModelService(cache_duration_seconds=300)
+    svc._update_cache(models, content_hash="testhash", etag=None)
+    return svc
+
+
+class TestCatalogNameSlug:
+    def test_spaced_title_case(self):
+        assert catalog_name_slug("Claude Sonnet 5") == "claude-sonnet-5"
+        assert catalog_name_slug("Claude Opus 4.5") == "claude-opus-4.5"
+        assert catalog_name_slug("GPT-5.6 Luna") == "gpt-5.6-luna"
+
+    def test_already_kebab(self):
+        assert catalog_name_slug("glm-5.1") == "glm-5.1"
+
+    def test_web_suffix_preserved(self):
+        assert catalog_name_slug("glm-5.1:web") == "glm-5.1:web"
+
+
+class TestAliasCandidates:
+    def test_venice_and_slug(self):
+        aliases = _alias_candidates(
+            "Claude Sonnet 5",
+            {"veniceId": "claude-sonnet-5", "capability": "code"},
+        )
+        assert aliases == {"claude-sonnet-5"}
+
+    def test_distinct_venice_and_slug(self):
+        aliases = _alias_candidates(
+            "Claude Opus 4.5",
+            {"veniceId": "claude-opus-4-5"},
+        )
+        assert aliases == {"claude-opus-4.5", "claude-opus-4-5"}
+
+    def test_no_alias_when_name_already_kebab(self):
+        aliases = _alias_candidates("llama-3.2-3b", {"veniceId": "llama-3.2-3b"})
+        assert aliases == set()
+
+
+@pytest.mark.asyncio
+async def test_resolves_catalog_venice_and_slug():
+    svc = _svc_with_models(
+        [
+            {
+                "Name": "Claude Sonnet 5",
+                "Id": SONNET_ID,
+                "ModelType": "LLM",
+                "enrichment": {"veniceId": "claude-sonnet-5", "capability": "code"},
+            },
+            {
+                "Name": "Claude Opus 4.5",
+                "Id": OPUS_ID,
+                "ModelType": "LLM",
+                "enrichment": {"veniceId": "claude-opus-4-5", "capability": "code"},
+            },
+            {
+                "Name": "GPT-5.6 Luna",
+                "Id": LUNA_ID,
+                "ModelType": "LLM",
+                "enrichment": {"veniceId": "openai-gpt-56-luna", "capability": "chat"},
+            },
+            {
+                "Name": "glm-5.1",
+                "Id": GLM_ID,
+                "ModelType": "LLM",
+                "enrichment": {"veniceId": "zai-org-glm-5-1"},
+            },
+        ]
+    )
+
+    # Catalog names
+    assert await svc.resolve_model_id("Claude Sonnet 5") == SONNET_ID
+    assert await svc.resolve_model_id("Claude Opus 4.5") == OPUS_ID
+    assert await svc.resolve_model_id("GPT-5.6 Luna") == LUNA_ID
+
+    # Catalog slug (client kebab guess)
+    assert await svc.resolve_model_id("claude-sonnet-5") == SONNET_ID
+    assert await svc.resolve_model_id("claude-opus-4.5") == OPUS_ID
+    assert await svc.resolve_model_id("gpt-5.6-luna") == LUNA_ID
+
+    # Venice ids that differ from slug
+    assert await svc.resolve_model_id("claude-opus-4-5") == OPUS_ID
+    assert await svc.resolve_model_id("openai-gpt-56-luna") == LUNA_ID
+    assert await svc.resolve_model_id("zai-org-glm-5-1") == GLM_ID
+
+    # Reverse lookup always returns catalog Name
+    assert await svc.get_model_name_from_id(SONNET_ID) == "Claude Sonnet 5"
+    assert await svc.get_model_name_from_id(OPUS_ID) == "Claude Opus 4.5"
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_slug_not_registered_when_catalog_twin_exists():
+    """Spaced + kebab twins: slug of spaced name collides with kebab catalog name."""
+    svc = _svc_with_models(
+        [
+            {
+                "Name": "DeepSeek V4 Flash",
+                "Id": DEEPSEEK_SPACED_ID,
+                "ModelType": "UNKNOWN",
+                "enrichment": {"veniceId": "deepseek-v4-flash", "capability": "chat"},
+            },
+            {
+                "Name": "deepseek-v4-flash",
+                "Id": DEEPSEEK_KEBAB_ID,
+                "ModelType": "LLM",
+                "enrichment": {"veniceId": "deepseek-v4-flash", "capability": "chat"},
+            },
+        ]
+    )
+
+    # Catalog names always win
+    assert await svc.resolve_model_id("DeepSeek V4 Flash") == DEEPSEEK_SPACED_ID
+    assert await svc.resolve_model_id("deepseek-v4-flash") == DEEPSEEK_KEBAB_ID
+
+    # Ambiguous veniceId claimed by both → not used as override (kebab catalog kept)
+    assert await svc.resolve_model_id("deepseek-v4-flash") == DEEPSEEK_KEBAB_ID


### PR DESCRIPTION
## Summary
- Register unique `enrichment.veniceId` and deterministic kebab slugs of catalog `Name` as resolve aliases in `DirectModelService` (catalog name stays authoritative).
- Skip colliding aliases so twins like `DeepSeek V4 Flash` / `deepseek-v4-flash` never guess wrong.
- Add unit coverage for Sonnet/Opus/Luna exact + kebab + veniceId cases from the client acceptance script.

## Test plan
- [x] `pytest tests/unit/test_direct_model_service_aliases.py`
- [ ] After deploy to test: run the sample chat script with exact + kebab names; confirm `returned_model` is the catalog Title Case name (not default fallback)


Made with [Cursor](https://cursor.com)