### PR TITLE
Promote: model resolve hard-fail + request slug (test → main)

### DIFF
--- a/src/api/v1/chat/chat_exceptions.py
+++ b/src/api/v1/chat/chat_exceptions.py
@@ -223,6 +223,53 @@ class RateLimitError(ChatError):
         return JSONResponse(status_code=self.status_code, content=content, headers=headers)
 
 
+@dataclass
+class ModelRoutingChatError(ChatError):
+    """Client-facing model resolution failure (type mismatch or near-miss).
+
+    Adds ``X-Morpheus-Error`` so agents that only inspect status/headers
+    can stop or alert without parsing the body.
+    """
+
+    message: str = "Model routing error"
+    status_code: int = status.HTTP_400_BAD_REQUEST
+    error_type: str = "model_routing_error"
+    code: str = "model_routing_error"
+
+    def __post_init__(self):
+        self.details = {**self.details, "code": self.code}
+        super().__post_init__()
+
+    def to_response(self) -> JSONResponse:
+        content = {
+            "error": {
+                "message": sanitize_error_message(self.message),
+                "type": self.error_type,
+                **self.details,
+            }
+        }
+        return JSONResponse(
+            status_code=self.status_code,
+            content=content,
+            headers={"X-Morpheus-Error": self.code},
+        )
+
+
+def model_routing_chat_error(exc: "ModelRoutingError") -> ModelRoutingChatError:
+    """Convert a core ModelRoutingError into a ChatError response type."""
+    from src.core.model_errors import ModelRoutingError as _MRE
+
+    if not isinstance(exc, _MRE):
+        raise TypeError(exc)
+    return ModelRoutingChatError(
+        message=exc.message,
+        status_code=exc.status_code,
+        error_type=exc.error_type,
+        code=exc.code,
+        details=dict(exc.details),
+    )
+
+
 def handle_chat_error(error: ChatError, logger, request_id: str) -> JSONResponse:
     """
     Handle a ChatError by logging and converting to response.
@@ -258,6 +305,8 @@ __all__ = [
     "GatewayError",
     "RequestParseError",
     "RateLimitError",
+    "ModelRoutingChatError",
+    "model_routing_chat_error",
     "handle_chat_error",
 ]
 

--- a/src/api/v1/chat/index.py
+++ b/src/api/v1/chat/index.py
@@ -51,7 +51,9 @@ from .chat_exceptions import (
     GatewayError,
     RateLimitError,
     handle_chat_error,
+    model_routing_chat_error,
 )
+from src.core.model_errors import ModelRoutingError
 
 router = APIRouter(tags=["Chat"])
 
@@ -414,7 +416,9 @@ async def _create_billing_hold(
         )
         
         return ledger_entry_id, model_id, token_estimate, real_model_name
-        
+
+    except ModelRoutingError as e:
+        raise model_routing_chat_error(e) from e
     except ChatError:
         raise
     except Exception as e:

--- a/src/api/v1/embeddings/index.py
+++ b/src/api/v1/embeddings/index.py
@@ -15,6 +15,7 @@ import uuid
 
 from ....schemas.billing import UsageHoldRequest, UsageFinalizeRequest, UsageVoidRequest
 from ....core.model_routing import model_router
+from ....core.model_errors import ModelRoutingError
 from ....services import session_routing_service, NoSessionAvailableError, SessionOpenError
 from ....services import proxy_router_service
 from ....services.billing_service import billing_service
@@ -25,6 +26,14 @@ from ....dependencies import get_api_key_user, get_current_api_key
 from ....db.models import User, APIKey
 from ....utils.error_sanitizer import sanitize_error_message
 from ....core.logging_config import get_api_logger
+
+
+def _model_routing_response(exc: ModelRoutingError) -> JSONResponse:
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=exc.to_error_body(),
+        headers={"X-Morpheus-Error": exc.code},
+    )
 
 router = APIRouter(tags=["Embeddings"])
 
@@ -106,6 +115,16 @@ async def create_embeddings(
                         request_id=request_id,
                         session_id=session_id,
                         event_type="session_routing_success")
+        except ModelRoutingError as e:
+            embeddings_logger.warning(
+                "Model routing rejected embeddings session route",
+                request_id=request_id,
+                error=e.message,
+                error_type=e.error_type,
+                event_type="model_routing_error",
+            )
+            await _void_billing_hold(user.id, ledger_entry_id, e.code, e.message, embeddings_logger)
+            return _model_routing_response(e)
         except NoSessionAvailableError as e:
             embeddings_logger.error("No session available",
                             request_id=request_id,
@@ -236,6 +255,15 @@ async def create_embeddings(
                                              error=str(release_err),
                                              event_type="session_release_error")
     
+    except ModelRoutingError as e:
+        embeddings_logger.warning(
+            "Model routing rejected embeddings request",
+            error=e.message,
+            error_type=e.error_type,
+            model=request_data.model,
+            event_type="model_routing_error",
+        )
+        return _model_routing_response(e)
     except HTTPException:
         raise
     except Exception as e:
@@ -426,7 +454,9 @@ async def _create_billing_hold(
         )
         
         return ledger_entry_id, model_id, real_model_name
-        
+
+    except ModelRoutingError:
+        raise
     except HTTPException:
         raise
     except Exception as e:

--- a/src/core/direct_model_service.py
+++ b/src/core/direct_model_service.py
@@ -7,6 +7,7 @@ import hashlib
 import re
 from collections import defaultdict
 from datetime import datetime, timedelta
+from difflib import get_close_matches
 from typing import Dict, List, Optional, Set
 
 import httpx
@@ -15,6 +16,13 @@ from src.core.config import settings
 from src.core.logging_config import get_models_logger
 
 logger = get_models_logger()
+
+# Client suffixes that often appear on otherwise-valid catalog names.
+# Stripped only when looking for near-miss suggestions (not for exact resolve).
+_NEAR_MISS_STRIP_SUFFIXES = (
+    "-turbo",
+    "-instruct-turbo",
+)
 
 
 def catalog_name_slug(name: str) -> str:
@@ -47,6 +55,70 @@ def _alias_candidates(model_name: str, enrichment: Optional[dict]) -> Set[str]:
             aliases.add(vid)
 
     return aliases
+
+
+def _strip_near_miss_suffixes(slug: str) -> List[str]:
+    """Return progressively stripped variants of a request slug."""
+    out: List[str] = []
+    current = slug
+    changed = True
+    while changed:
+        changed = False
+        for suffix in _NEAR_MISS_STRIP_SUFFIXES:
+            if current.endswith(suffix) and len(current) > len(suffix):
+                current = current[: -len(suffix)]
+                out.append(current)
+                changed = True
+                break
+    return out
+
+
+def suggest_near_miss_models(
+    requested: str,
+    catalog_keys: Set[str],
+    id_to_name: Dict[str, str],
+    model_mapping: Dict[str, str],
+    *,
+    limit: int = 5,
+) -> List[str]:
+    """Suggest active catalog Names for a near-miss client string.
+
+    Strategies (in order):
+      1. Exact hit after stripping known junk suffixes (e.g. ``-turbo``)
+      2. difflib close matches against resolve keys (slug/spaced/venice)
+    Returns unique catalog display Names (not alias keys).
+    """
+    if not requested or not catalog_keys:
+        return []
+
+    def _display_name(resolve_key: str) -> Optional[str]:
+        blockchain_id = model_mapping.get(resolve_key)
+        if not blockchain_id:
+            return None
+        return id_to_name.get(blockchain_id)
+
+    slug = catalog_name_slug(requested)
+    candidates: List[str] = []
+
+    for variant in _strip_near_miss_suffixes(slug):
+        name = _display_name(variant)
+        if name and name not in candidates:
+            candidates.append(name)
+
+    if len(candidates) >= limit:
+        return candidates[:limit]
+
+    pool = sorted(catalog_keys)
+    needles = [slug, requested.lower(), *_strip_near_miss_suffixes(slug)]
+    for needle in dict.fromkeys(n for n in needles if n):
+        for hit in get_close_matches(needle, pool, n=limit, cutoff=0.72):
+            name = _display_name(hit)
+            if name and name not in candidates:
+                candidates.append(name)
+            if len(candidates) >= limit:
+                return candidates[:limit]
+
+    return candidates[:limit]
 
 
 class DirectModelService:
@@ -136,8 +208,30 @@ class DirectModelService:
         # Check if it's already a blockchain ID
         if model_identifier in self._blockchain_ids:
             return model_identifier
-        
-        return self._model_mapping.get(model_identifier.lower())
+
+        key = model_identifier.lower()
+        hit = self._model_mapping.get(key)
+        if hit:
+            return hit
+
+        # Request-side slug: clients often send spaced Title Case
+        # ("Llama 3.2 3B") for kebab catalog names ("llama-3.2-3b").
+        # Cache-time aliases only go catalog→slug; this is the reverse.
+        slug = catalog_name_slug(model_identifier)
+        if slug and slug != key:
+            return self._model_mapping.get(slug)
+        return None
+
+    async def suggest_models(self, requested: str, *, limit: int = 5) -> List[str]:
+        """Return near-miss catalog Names for a requested model string."""
+        await self._ensure_fresh_cache()
+        return suggest_near_miss_models(
+            requested,
+            set(self._model_mapping.keys()),
+            self._id_to_name,
+            self._model_mapping,
+            limit=limit,
+        )
     
     async def get_model_name_from_id(self, blockchain_id: str) -> Optional[str]:
         """

--- a/src/core/model_errors.py
+++ b/src/core/model_errors.py
@@ -1,0 +1,95 @@
+"""Model resolution errors raised by ModelRouter / DirectModelService.
+
+These are intentional client-facing failures (wrong capability, near-miss name).
+API layers convert them to OpenAI-compatible JSON responses so agents can
+stop/alert instead of silently continuing on a substitute model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+
+@dataclass
+class ModelRoutingError(Exception):
+    """Base class for hard model-resolution failures."""
+
+    message: str
+    error_type: str = "model_routing_error"
+    code: str = "model_routing_error"
+    status_code: int = 400
+    details: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        super().__init__(self.message)
+
+    def to_error_body(self) -> dict:
+        """OpenAI-compatible error object (plus machine-readable code/details)."""
+        body: dict[str, Any] = {
+            "message": self.message,
+            "type": self.error_type,
+            "code": self.code,
+            **self.details,
+        }
+        return {"error": body}
+
+
+@dataclass
+class ModelTypeMismatchError(ModelRoutingError):
+    """Requested model exists but is incompatible with the endpoint type."""
+
+    requested_model: Optional[str] = None
+    resolved_model: Optional[str] = None
+    resolved_id: Optional[str] = None
+    requested_type: Optional[str] = None
+    model_type: Optional[str] = None
+    message: str = "Model type is incompatible with this endpoint"
+    error_type: str = "model_type_mismatch"
+    code: str = "model_type_mismatch"
+    status_code: int = 400
+
+    def __post_init__(self):
+        endpoint_hint = {
+            "LLM": "use /v1/chat/completions with an LLM model",
+            "EMBEDDINGS": "use /v1/embeddings with an embedding model",
+        }.get(self.requested_type or "", "use the matching endpoint for this model type")
+
+        self.message = (
+            f"Model '{self.requested_model}' is type '{self.model_type or 'unknown'}' "
+            f"and cannot be used for '{self.requested_type}' requests; {endpoint_hint}."
+        )
+        self.details = {
+            "requested_model": self.requested_model,
+            "resolved_model": self.resolved_model,
+            "resolved_id": self.resolved_id,
+            "requested_type": self.requested_type,
+            "model_type": self.model_type,
+            "code": self.code,
+        }
+        super().__post_init__()
+
+
+@dataclass
+class ModelNearMissError(ModelRoutingError):
+    """Requested name is not in the catalog, but close matches exist."""
+
+    requested_model: Optional[str] = None
+    suggestions: List[str] = field(default_factory=list)
+    message: str = "Model not found"
+    error_type: str = "model_not_found"
+    code: str = "model_not_found_near_miss"
+    status_code: int = 400
+
+    def __post_init__(self):
+        suggestion_txt = ", ".join(f"'{s}'" for s in self.suggestions[:5]) or "(none)"
+        self.message = (
+            f"Model '{self.requested_model}' was not found in active models. "
+            f"Did you mean: {suggestion_txt}?"
+        )
+        self.details = {
+            "requested_model": self.requested_model,
+            "suggestions": list(self.suggestions),
+            "code": self.code,
+        }
+        super().__post_init__()

--- a/src/core/model_routing.py
+++ b/src/core/model_routing.py
@@ -1,7 +1,9 @@
 from typing import Dict, Optional
+
 from .direct_model_service import direct_model_service
 from .config import settings
 from .logging_config import get_models_logger
+from .model_errors import ModelNearMissError, ModelTypeMismatchError
 
 # Configure logger
 logger = get_models_logger()
@@ -39,6 +41,10 @@ class ModelRouter:
             
         Returns:
             str: The blockchain ID to use
+
+        Raises:
+            ModelTypeMismatchError: Model exists but is wrong type for the endpoint
+            ModelNearMissError: Name not found, but close catalog matches exist
         """
         # return "0xe086adc275c99e32bb10b0aff5e8bfc391aad18cbb184727a75b2569149425c6"
         logger.info("Getting target model for requested model",
@@ -63,16 +69,27 @@ class ModelRouter:
             # A resolved model must be usable by this endpoint type. Without
             # this check a chat completion naming an EMBEDDING model opens a
             # session with the embedding provider, whose backend then rejects
-            # the chat payload ("Router.aembedding() missing ... 'input'").
-            # Treat a mismatch like an unknown model: fall back to the
-            # default model for the requested type.
+            # the chat payload. Hard-fail so agents don't silently get Gemma.
             if resolved_id and not await self._is_type_compatible(resolved_id, type):
+                model_name = await direct_model_service.get_model_name_from_id(resolved_id)
+                model_types = await direct_model_service.get_model_mapping_type()
+                actual_type = (
+                    model_types.get(model_name.lower()) if model_name else None
+                )
                 logger.warning("Requested model type is incompatible with endpoint",
                               requested_model=requested_model,
                               resolved_id=resolved_id,
+                              resolved_model=model_name,
                               requested_type=type,
+                              model_type=actual_type,
                               event_type="model_type_mismatch")
-                resolved_id = None
+                raise ModelTypeMismatchError(
+                    requested_model=requested_model,
+                    resolved_model=model_name,
+                    resolved_id=resolved_id,
+                    requested_type=type,
+                    model_type=actual_type,
+                )
 
             if resolved_id:
                 logger.info("Found model mapping",
@@ -80,24 +97,39 @@ class ModelRouter:
                            resolved_id=resolved_id,
                            event_type="model_resolved")
                 return resolved_id
-            else:
-                # Model not found, use default
-                logger.warning("Model not found in active models",
+
+            # Not found — if we have close matches, hard-fail with suggestions
+            # so agents stop / alert instead of continuing on the default model.
+            # True unknowns (no near miss) still soft-fallback for operability.
+            logger.warning("Model not found in active models",
+                          requested_model=requested_model,
+                          event_type="model_not_found")
+            suggestions = await direct_model_service.suggest_models(requested_model)
+            if suggestions:
+                logger.warning("Near-miss model name; returning suggestions",
                               requested_model=requested_model,
-                              event_type="model_not_found")
-                model_mapping = await direct_model_service.get_model_mapping()
-                blockchain_ids = await direct_model_service.get_blockchain_ids()
-                logger.info("Available models for debugging",
-                           available_models=sorted(list(model_mapping.keys())),
-                           available_blockchain_ids=sorted(list(blockchain_ids)),
-                           requested_model=requested_model)
-                
-                default_id = await self._get_default_model_id(type)
-                logger.warning("Using default model fallback",
-                              requested_model=requested_model,
-                              default_model_id=default_id,
-                              event_type="default_model_fallback")
-                return default_id
+                              suggestions=suggestions,
+                              event_type="model_not_found_near_miss")
+                raise ModelNearMissError(
+                    requested_model=requested_model,
+                    suggestions=suggestions,
+                )
+
+            model_mapping = await direct_model_service.get_model_mapping()
+            blockchain_ids = await direct_model_service.get_blockchain_ids()
+            logger.info("Available models for debugging",
+                       available_models=sorted(list(model_mapping.keys())),
+                       available_blockchain_ids=sorted(list(blockchain_ids)),
+                       requested_model=requested_model)
+
+            default_id = await self._get_default_model_id(type)
+            logger.warning("Using default model fallback",
+                          requested_model=requested_model,
+                          default_model_id=default_id,
+                          event_type="default_model_fallback")
+            return default_id
+        except (ModelTypeMismatchError, ModelNearMissError):
+            raise
         except Exception as e:
             logger.error("Error resolving model - using default fallback",
                         requested_model=requested_model,
@@ -255,4 +287,4 @@ class ModelRouter:
 model_router = ModelRouter()
 
 # Create an async alias for backward compatibility
-async_model_router = model_router 
+async_model_router = model_router

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ import platform
 
 from src.api.v1 import models, chat, auth, chat_history, embeddings, audio, billing, billing_admin, webhooks, wallet
 from src.api.v1.chat.chat_exceptions import ChatError
+from src.core.model_errors import ModelRoutingError
 from src.services import session_routing_service
 from src.utils.error_sanitizer import sanitize_error_message
 from src.services.staking_service import staking_service
@@ -180,6 +181,16 @@ async def enforce_https(request: Request, call_next):
 async def chat_error_handler(request: Request, exc: ChatError):
     """Handle ChatError exceptions with structured responses."""
     return exc.to_response()
+
+
+@app.exception_handler(ModelRoutingError)
+async def model_routing_error_handler(request: Request, exc: ModelRoutingError):
+    """Hard model-resolution failures (type mismatch / near-miss) for all routes."""
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=exc.to_error_body(),
+        headers={"X-Morpheus-Error": exc.code},
+    )
 
 
 # Error handler for OpenAI-compatible error responses

--- a/tests/unit/test_direct_model_service_aliases.py
+++ b/tests/unit/test_direct_model_service_aliases.py
@@ -6,6 +6,7 @@ from src.core.direct_model_service import (
     DirectModelService,
     _alias_candidates,
     catalog_name_slug,
+    suggest_near_miss_models,
 )
 
 
@@ -28,6 +29,7 @@ class TestCatalogNameSlug:
         assert catalog_name_slug("Claude Sonnet 5") == "claude-sonnet-5"
         assert catalog_name_slug("Claude Opus 4.5") == "claude-opus-4.5"
         assert catalog_name_slug("GPT-5.6 Luna") == "gpt-5.6-luna"
+        assert catalog_name_slug("Llama 3.2 3B") == "llama-3.2-3b"
 
     def test_already_kebab(self):
         assert catalog_name_slug("glm-5.1") == "glm-5.1"
@@ -133,3 +135,37 @@ async def test_ambiguous_slug_not_registered_when_catalog_twin_exists():
 
     # Ambiguous veniceId claimed by both → not used as override (kebab catalog kept)
     assert await svc.resolve_model_id("deepseek-v4-flash") == DEEPSEEK_KEBAB_ID
+
+
+LLAMA_KEBAB_ID = "0x" + "77" * 32
+QWEN_ID = "0x" + "88" * 32
+
+
+@pytest.mark.asyncio
+async def test_request_side_slug_resolves_spaced_title_case_to_kebab_catalog():
+    """Clients send 'Llama 3.2 3B'; catalog Name is already kebab."""
+    svc = _svc_with_models(
+        [
+            {
+                "Name": "llama-3.2-3b",
+                "Id": LLAMA_KEBAB_ID,
+                "ModelType": "LLM",
+                "enrichment": {"veniceId": "llama-3.2-3b"},
+            },
+        ]
+    )
+    assert await svc.resolve_model_id("Llama 3.2 3B") == LLAMA_KEBAB_ID
+    assert await svc.resolve_model_id("llama 3.2 3b") == LLAMA_KEBAB_ID
+    assert await svc.resolve_model_id("llama-3.2-3b") == LLAMA_KEBAB_ID
+
+
+def test_suggest_near_miss_strips_turbo_suffix():
+    mapping = {"qwen3-coder-480b-a35b-instruct": QWEN_ID}
+    id_to_name = {QWEN_ID: "qwen3-coder-480b-a35b-instruct"}
+    suggestions = suggest_near_miss_models(
+        "qwen3-coder-480b-a35b-instruct-turbo",
+        set(mapping.keys()),
+        id_to_name,
+        mapping,
+    )
+    assert suggestions == ["qwen3-coder-480b-a35b-instruct"]

--- a/tests/unit/test_model_router.py
+++ b/tests/unit/test_model_router.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, patch
 
+from src.core.model_errors import ModelNearMissError, ModelTypeMismatchError
 from src.core.model_routing import ModelRouter
 
 @pytest.fixture
@@ -12,6 +13,7 @@ EMBED_ID = "0x" + "aa" * 32
 LLM_ID = "0x" + "bb" * 32
 DEFAULT_LLM_ID = "0x" + "cc" * 32
 DEFAULT_EMBED_ID = EMBED_ID
+QWEN_ID = "0x" + "dd" * 32
 
 
 def _patched_model_service():
@@ -20,13 +22,21 @@ def _patched_model_service():
         "text-embedding-bge-m3": EMBED_ID,
         "some-llm": LLM_ID,
         "mistral-31-24b": DEFAULT_LLM_ID,
+        "qwen3-coder-480b-a35b-instruct": QWEN_ID,
     }
     id_to_name = {v: k for k, v in mapping.items()}
     mapping_type = {
         "text-embedding-bge-m3": "EMBEDDING",
         "some-llm": "LLM",
         "mistral-31-24b": "LLM",
+        "qwen3-coder-480b-a35b-instruct": "LLM",
     }
+
+    async def _suggest(requested, limit=5):
+        if "turbo" in (requested or "").lower():
+            return ["qwen3-coder-480b-a35b-instruct"]
+        return []
+
     service = patch.multiple(
         "src.core.model_routing.direct_model_service",
         resolve_model_id=AsyncMock(side_effect=lambda m: mapping.get(m.lower())),
@@ -34,25 +44,41 @@ def _patched_model_service():
         get_model_mapping_type=AsyncMock(return_value=mapping_type),
         get_model_mapping=AsyncMock(return_value=mapping),
         get_blockchain_ids=AsyncMock(return_value=set(mapping.values())),
+        suggest_models=AsyncMock(side_effect=_suggest),
     )
     return service
 
 
 @pytest.mark.asyncio
-async def test_chat_request_for_embedding_model_falls_back_to_default_llm(model_router):
-    # A chat completion (type="LLM") naming an EMBEDDING model must NOT route
-    # to the embedding provider (its backend rejects chat payloads with
-    # "Router.aembedding() missing 1 required positional argument: 'input'").
+async def test_chat_request_for_embedding_model_hard_fails(model_router):
+    # A chat completion (type="LLM") naming an EMBEDDING model must NOT silently
+    # fall back to Gemma — agents need a clear 400 / model_type_mismatch.
     with _patched_model_service():
-        result = await model_router.get_target_model("text-embedding-bge-m3", type="LLM")
-    assert result == DEFAULT_LLM_ID
+        with pytest.raises(ModelTypeMismatchError) as exc:
+            await model_router.get_target_model("text-embedding-bge-m3", type="LLM")
+    assert exc.value.code == "model_type_mismatch"
+    assert exc.value.model_type == "EMBEDDING"
+    assert exc.value.requested_type == "LLM"
 
 
 @pytest.mark.asyncio
-async def test_embeddings_request_for_llm_model_falls_back_to_default_embeddings(model_router):
+async def test_embeddings_request_for_llm_model_hard_fails(model_router):
     with _patched_model_service():
-        result = await model_router.get_target_model("some-llm", type="EMBEDDINGS")
-    assert result == DEFAULT_EMBED_ID
+        with pytest.raises(ModelTypeMismatchError) as exc:
+            await model_router.get_target_model("some-llm", type="EMBEDDINGS")
+    assert exc.value.code == "model_type_mismatch"
+    assert exc.value.model_type == "LLM"
+
+
+@pytest.mark.asyncio
+async def test_near_miss_turbo_suffix_returns_suggestions(model_router):
+    with _patched_model_service():
+        with pytest.raises(ModelNearMissError) as exc:
+            await model_router.get_target_model(
+                "qwen3-coder-480b-a35b-instruct-turbo", type="LLM"
+            )
+    assert exc.value.code == "model_not_found_near_miss"
+    assert "qwen3-coder-480b-a35b-instruct" in exc.value.suggestions
 
 
 @pytest.mark.asyncio
@@ -88,17 +114,20 @@ async def test_get_target_model_valid_blockchain_id(model_router):
 
 @pytest.mark.asyncio
 async def test_get_target_model_invalid_name(model_router):
-    # Test graceful handling of invalid model name by returning default
-    result = await model_router.get_target_model("invalid-model")
-    # Should return default model blockchain ID instead of raising error
-    assert result.startswith("0x")  # Should be a valid blockchain ID
+    # Unknown names soft-fallback; near-misses hard-fail with suggestions.
+    name = "zz-definitely-not-a-real-model-xyzzy-99999"
+    try:
+        result = await model_router.get_target_model(name)
+        assert result.startswith("0x")
+    except ModelNearMissError as exc:
+        assert exc.code == "model_not_found_near_miss"
+        assert exc.suggestions
 
 @pytest.mark.asyncio
 async def test_get_target_model_invalid_blockchain_id(model_router):
-    # Test graceful handling of invalid blockchain ID by returning default
+    # Invalid hex id is not a near-miss of a catalog name — soft fallback.
     result = await model_router.get_target_model("0xinvalid")
-    # Should return default model blockchain ID instead of raising error
-    assert result.startswith("0x")  # Should be a valid blockchain ID
+    assert result.startswith("0x")
 
 @pytest.mark.asyncio
 async def test_get_target_model_empty_input(model_router):


### PR DESCRIPTION
## Summary
- Promotes the model-routing fix from `test` → `main` after a successful TEST (AWS DEV) deploy
- Source: [PR #279](https://github.com/MorpheusAIs/Morpheus-Marketplace-API/pull/279) → [PR #280](https://github.com/MorpheusAIs/Morpheus-Marketplace-API/pull/280)
- TEST CI/CD: [run 29588337761](https://github.com/MorpheusAIs/Morpheus-Marketplace-API/actions/runs/29588337761) — build, deploy, and release all green
- Hard-fail chat/embedding type mismatches and near-miss catalog names (400 + machine-readable codes/`X-Morpheus-Error`) instead of silent default-model fallback
- Resolve spaced Title Case request names against kebab catalog slugs (e.g. `Llama 3.2 3B` → `llama-3.2-3b`); soft fallback remains for true unknowns only

## Test plan
- [ ] Review TEST deploy health / version after merge of #280
- [ ] Chat with `Llama 3.2 3B` resolves to the on-chain model (no Gemma soft fallback)
- [ ] Chat with an embedding model name returns 400 + `X-Morpheus-Error: model_type_mismatch`
- [ ] Chat with a near-miss name (e.g. `*-turbo`) returns 400 + suggestions, not silent default
- [ ] Truly unknown model names still soft-fallback as before
- [ ] After merge to `main`, confirm PRD deploy + release succeed


Made with [Cursor](https://cursor.com)