### PR TITLE
fix(sessions): classify expensive-model tier on highest rated bid

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -199,9 +199,12 @@ class Settings(BaseSettings):
     # is amplified by (total MOR supply / today's emissions budget), so a
     # high-priced model at the normal duration can stake enough MOR to exhaust
     # the shared consumer wallet and bounce concurrent opens. This tier gives
-    # models whose lowest rated bid is >= a cutoff a shorter duration (smaller
-    # per-session stake -> more concurrent premium sessions) with their own idle
-    # grace, decoupled from the global session settings above.
+    # models with ANY rated bid >= a cutoff (max(bid.PricePerSecond) >= cutoff)
+    # a shorter duration (smaller per-session stake -> more concurrent premium
+    # sessions) with their own idle grace, decoupled from the global session
+    # settings above. Classifying on the HIGHEST bid — not the lowest — matters
+    # because HA failover can re-land a session on the model's priciest peer:
+    # a cheap underbidder must not earn the model the long (70 min) stake.
     #
     # Cutoff is MOR per second (a bid's PricePerSecond / 1e18). 0 DISABLES the
     # tier entirely (every model uses the global SESSION_* settings) — the

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -89,7 +89,7 @@ class SessionRoutingService:
         self._background_close_tasks: set = set()
 
         # Short-lived per-model "is this an expensive model?" cache. The tier
-        # decision needs the model's lowest rated-bid price (an on-chain read
+        # decision needs the model's highest rated-bid price (an on-chain read
         # via the proxy-router); cache it so neither the open path nor the
         # per-tick automation loop hammers that lookup. Keyed by model_id ->
         # (monotonic_expiry, is_expensive). Per-replica and deterministic from
@@ -110,8 +110,13 @@ class SessionRoutingService:
     # EXPENSIVE-MODEL TIER
     # =========================================================================
 
-    async def _get_model_min_price_per_second(self, model_id: str) -> Optional[float]:
-        """Lowest rated-bid price for a model in MOR/sec, or None on failure.
+    async def _get_model_max_price_per_second(self, model_id: str) -> Optional[float]:
+        """Highest rated-bid price for a model in MOR/sec, or None on failure.
+
+        The MAX (not min) matters: sessions can fail over between the model's
+        providers, so the stake exposure is bounded by the priciest peer, not
+        the cheapest. A cheap underbidder must not demote a model whose other
+        bids are premium-priced.
 
         Best-effort: never raises. A price lookup must never block (or fail) a
         session open — callers treat None as "not expensive" and fall back to
@@ -143,7 +148,7 @@ class SessionRoutingService:
                 except (ValueError, TypeError):
                     continue
 
-            return min(prices) if prices else None
+            return max(prices) if prices else None
         except Exception as e:
             logger.warning("Rated-bid price lookup failed; treating model as non-expensive",
                            model_id=model_id,
@@ -152,7 +157,8 @@ class SessionRoutingService:
             return None
 
     async def _is_expensive_model(self, model_id: str) -> bool:
-        """True if the model's lowest rated bid is >= the expensive cutoff.
+        """True if ANY of the model's rated bids is >= the expensive cutoff,
+        i.e. max(bid.PricePerSecond) >= cutoff.
 
         Returns False when the tier is disabled (cutoff <= 0) or the price
         cannot be determined. Result is cached per model for a short TTL so the
@@ -166,7 +172,7 @@ class SessionRoutingService:
         if cached is not None and time.monotonic() < cached[0]:
             return cached[1]
 
-        price = await self._get_model_min_price_per_second(model_id)
+        price = await self._get_model_max_price_per_second(model_id)
         is_expensive = price is not None and price >= cutoff
         self._expensive_tier_cache[model_id] = (
             time.monotonic() + self._expensive_tier_cache_ttl,

--- a/tests/unit/test_session_expensive_tier.py
+++ b/tests/unit/test_session_expensive_tier.py
@@ -1,7 +1,10 @@
 """Tests for the expensive-model session tier in SessionRoutingService.
 
-Expensive models (lowest rated bid >= a MOR/sec cutoff) open with a shorter
-duration to bound the amplified on-chain stake, and use their own idle grace.
+Expensive models (ANY rated bid >= a MOR/sec cutoff, i.e. max(bid.price) >=
+cutoff) open with a shorter duration to bound the amplified on-chain stake, and
+use their own idle grace. Classification uses the HIGHEST bid because HA
+failover can land a session on the model's priciest peer — a cheap underbidder
+must not earn the model the long-duration stake.
 The tier is disabled by default (cutoff <= 0) and every decision is best-effort:
 a failed / missing price lookup must never block an open, so it falls back to
 the global session settings. The proxy-router bid read is mocked here.
@@ -65,42 +68,43 @@ def _rated(*pps_values):
 
 
 # ---------------------------------------------------------------------------
-# _get_model_min_price_per_second: parsing + best-effort failure
+# _get_model_max_price_per_second: parsing + best-effort failure
 # ---------------------------------------------------------------------------
 
 
-async def test_min_price_picks_lowest_and_converts_wei_to_mor(service):
+async def test_max_price_picks_highest_and_converts_wei_to_mor(service):
+    """A cheap underbid must not mask the premium bid: max wins."""
     with _patch_rated_bids(_rated(PREMIUM_PPS, CHEAP_PPS)):
-        price = await service._get_model_min_price_per_second("0xmodel")
-    assert price == pytest.approx(0.0001)
+        price = await service._get_model_max_price_per_second("0xmodel")
+    assert price == pytest.approx(0.01)
 
 
-async def test_min_price_parses_real_rated_envelope(service):
+async def test_max_price_parses_real_rated_envelope(service):
     """Regression: /bids/rated nests PricePerSecond under "Bid" (not top level)."""
     with _patch_rated_bids(_rated(PREMIUM_PPS)):
-        price = await service._get_model_min_price_per_second("0xmodel")
+        price = await service._get_model_max_price_per_second("0xmodel")
     assert price == pytest.approx(0.01)
 
 
-async def test_min_price_supports_flat_bids_fallback(service):
+async def test_max_price_supports_flat_bids_fallback(service):
     """Older/flat shape (PricePerSecond at the top level) still parses."""
     with _patch_rated_bids({"bids": [{"PricePerSecond": PREMIUM_PPS}]}):
-        price = await service._get_model_min_price_per_second("0xmodel")
+        price = await service._get_model_max_price_per_second("0xmodel")
     assert price == pytest.approx(0.01)
 
 
-async def test_min_price_none_when_no_bids(service):
+async def test_max_price_none_when_no_bids(service):
     with _patch_rated_bids([]):
-        assert await service._get_model_min_price_per_second("0xmodel") is None
+        assert await service._get_model_max_price_per_second("0xmodel") is None
 
 
-async def test_min_price_none_on_lookup_error(service):
+async def test_max_price_none_on_lookup_error(service):
     with patch(
         "src.services.session_routing_service.proxy_router_service.getRatedBids",
         new_callable=AsyncMock,
         side_effect=RuntimeError("proxy down"),
     ):
-        assert await service._get_model_min_price_per_second("0xmodel") is None
+        assert await service._get_model_max_price_per_second("0xmodel") is None
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +133,16 @@ async def test_not_expensive_when_price_below_cutoff(service):
         _rated(CHEAP_PPS)
     ):
         assert await service._is_expensive_model("0xmodel") is False
+
+
+async def test_expensive_despite_cheap_underbid(service):
+    """Acceptance: any premium-tier bid makes the model expensive even when a
+    cheap underbidder exists — HA failover could land on the pricey peer, so
+    the stake must be bounded by the shorter (20 min) duration."""
+    with patch.object(settings, "SESSION_EXPENSIVE_CUTOFF_MOR_PER_SECOND", 0.001), _patch_rated_bids(
+        _rated(CHEAP_PPS, PREMIUM_PPS)
+    ):
+        assert await service._is_expensive_model("0xmodel") is True
 
 
 async def test_not_expensive_when_price_unknown(service):


### PR DESCRIPTION
The expensive tier previously keyed off the model's LOWEST rated-bid price, so a single cheap underbidder made a premium model look cheap and open at the global (70 min) duration. HA failover could then re-land the session on the priciest peer and escrow a large stipend.

Classify on max(bid.PricePerSecond) >= cutoff instead: any premium-tier bid gives the model the short (20 min) expensive duration, bounding wallet stake under failover. Duration / idle-grace behavior, best-effort fallbacks, and the per-model cache are unchanged.