### PR TITLE
fix: enforce owner scoping on Coinbase payment-link lookup

### DIFF
--- a/src/api/v1/billing/coinbase.py
+++ b/src/api/v1/billing/coinbase.py
@@ -2,6 +2,7 @@
 Coinbase Business Payment Link billing endpoints.
 Authenticated user endpoints for creating payment links and checking status.
 """
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from ....db.models import User
@@ -79,10 +80,49 @@ async def get_payment_link(
 ):
     """
     Get a specific Coinbase Business Payment Link by ID.
+
+    The lookup is scoped to the authenticated caller: the link's
+    ``metadata.user_id`` (stamped at creation) must match the caller's
+    Cognito user id. Requests for links the caller does not own return 404,
+    identical to a link that does not exist, so ownership cannot be probed
+    by enumerating ids.
     """
     try:
         result = await coinbase_payment_link_service.get_payment_link(payment_link_id)
+
+        owner_id = (result.get("metadata") or {}).get("user_id")
+        if owner_id != current_user.cognito_user_id:
+            logger.warning(
+                "Blocked cross-user payment link access",
+                payment_link_id=payment_link_id,
+                requester_user_id=current_user.id,
+                event_type="coinbase_payment_link_forbidden",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Payment link not found",
+            )
+
         return result
+    except HTTPException:
+        raise
+    except httpx.HTTPStatusError as e:
+        if e.response is not None and e.response.status_code == status.HTTP_404_NOT_FOUND:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Payment link not found",
+            )
+        logger.error(
+            "Upstream error getting payment link",
+            payment_link_id=payment_link_id,
+            status_code=e.response.status_code if e.response is not None else None,
+            error_type=type(e).__name__,
+            event_type="coinbase_payment_link_get_error",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Error getting payment link",
+        )
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -98,7 +138,7 @@ async def get_payment_link(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error getting payment link: {str(e)}",
+            detail="Error getting payment link",
         )
 
 

--- a/tests/unit/test_coinbase_payment_link_ownership.py
+++ b/tests/unit/test_coinbase_payment_link_ownership.py
@@ -1,0 +1,93 @@
+"""
+Regression tests for cross-user access control on the Coinbase payment-link
+lookup endpoint (BOLA/IDOR).
+
+The GET /billing/coinbase/payment-links/{id} handler must only return a link
+whose ``metadata.user_id`` matches the authenticated caller's Cognito id.
+Any other id (including one that exists but belongs to another user) must
+return 404 so ownership cannot be probed by enumerating ids.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, status
+
+# Add the project root to the Python path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.api.v1.billing import coinbase as coinbase_api
+
+
+def _user(cognito_user_id: str, user_id: int = 1) -> MagicMock:
+    user = MagicMock()
+    user.id = user_id
+    user.cognito_user_id = cognito_user_id
+    return user
+
+
+def _link(owner_cognito_id):
+    metadata = {"user_id": owner_cognito_id} if owner_cognito_id is not None else {}
+    return {
+        "id": "6a54d6b6ec41fe24d35f3c43",
+        "url": "https://payments.coinbase.com/payment-links/pl_x",
+        "status": "ACTIVE",
+        "amount": "42.00",
+        "currency": "USDC",
+        "metadata": metadata,
+    }
+
+
+@pytest.mark.asyncio
+async def test_owner_can_read_own_payment_link():
+    """The user who created the link (matching metadata.user_id) gets it back."""
+    owner = _user("owner-sub-123")
+    with patch.object(
+        coinbase_api.coinbase_payment_link_service,
+        "get_payment_link",
+        AsyncMock(return_value=_link("owner-sub-123")),
+    ):
+        result = await coinbase_api.get_payment_link(
+            payment_link_id="6a54d6b6ec41fe24d35f3c43",
+            current_user=owner,
+        )
+
+    assert result["id"] == "6a54d6b6ec41fe24d35f3c43"
+    assert result["metadata"]["user_id"] == "owner-sub-123"
+
+
+@pytest.mark.asyncio
+async def test_other_user_gets_404_not_the_record():
+    """A different authenticated user must not be able to read the link."""
+    attacker = _user("attacker-sub-999", user_id=2)
+    with patch.object(
+        coinbase_api.coinbase_payment_link_service,
+        "get_payment_link",
+        AsyncMock(return_value=_link("owner-sub-123")),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await coinbase_api.get_payment_link(
+                payment_link_id="6a54d6b6ec41fe24d35f3c43",
+                current_user=attacker,
+            )
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_link_without_owner_metadata_is_denied():
+    """A link lacking metadata.user_id cannot be claimed by any caller."""
+    caller = _user("someone-sub-123")
+    with patch.object(
+        coinbase_api.coinbase_payment_link_service,
+        "get_payment_link",
+        AsyncMock(return_value=_link(None)),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await coinbase_api.get_payment_link(
+                payment_link_id="6a54d6b6ec41fe24d35f3c43",
+                current_user=caller,
+            )
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary

`GET /api/v1/billing/coinbase/payment-links/{payment_link_id}` returned any payment link by ID without checking that it belonged to the caller. Any authenticated user could read any other user's payment link by supplying its ID — leaking the owner's payment amount, description, status, live Coinbase payment URL, and internal Cognito `user_id`. Because the link IDs are sequential MongoDB ObjectIds drawn from one global counter, a single attacker could enumerate and bulk-read the entire population of payment records.

This MR scopes the lookup to the authenticated user and hardens the handler's error paths.

## Root cause

The handler resolved `current_user` (so a valid token was required) but never used it — it passed the caller-supplied `payment_link_id` straight to the shared Coinbase Business account and returned the record. All Morpheus users' links live under one Coinbase Business account, so nothing scoped the result to the caller. The `POST` creation path is the only place ownership was ever recorded (it stamps `metadata.user_id = current_user.cognito_user_id`), but the `GET` never checked it.

## Changes

- **Ownership check:** After fetching the link, compare its `metadata.user_id` against the caller's `cognito_user_id`. On mismatch (or missing metadata), return **404** — identical to a non-existent link — so ownership can't be probed by enumerating IDs. A blocked attempt is logged as `coinbase_payment_link_forbidden`.
- **Re-raise `HTTPException` first:** the pre-existing bare `except Exception` would otherwise have swallowed the new 404 and turned it into a 500, defeating the fix.
- **Upstream error mapping:** a Coinbase `404` now maps to a clean `404`; other upstream `HTTPStatusError`s map to `502` instead of a generic `500`.
- **Stop leaking internals:** the `500`/`502` responses no longer echo raw `str(e)` exception text.

## Tests

Added `tests/unit/test_coinbase_payment_link_ownership.py`:
- owner reads their own link → success
- different user requests the link → `404`
- link without `metadata.user_id` → `404`

All 3 pass (`3 passed`).