### PR TITLE
feat(billing): migrate Coinbase payment-links to Checkouts API

### DIFF
--- a/src/api/v1/webhooks/coinbase.py
+++ b/src/api/v1/webhooks/coinbase.py
@@ -269,14 +269,14 @@ async def _handle_payment_link_webhook(
         coinbase_status=payload.get("status"),
     )
 
-    if event_type == coinbase_webhook_service.EVENT_TYPE_PL_PAYMENT_SUCCESS:
+    if event_type in coinbase_webhook_service.PAYMENT_SUCCESS_EVENT_TYPES:
         success, message = await coinbase_webhook_service.handle_payment_success(
             db=db,
             payload=payload,
         )
         if not success:
             logger.error(
-                "Failed to process payment_link.payment.success",
+                "Failed to process checkout.payment.success",
                 coinbase_payment_link_id=payment_link_id,
                 error=message,
             )
@@ -285,26 +285,26 @@ async def _handle_payment_link_webhook(
                 detail=f"Failed to process event: {message}",
             )
 
-    elif event_type == coinbase_webhook_service.EVENT_TYPE_PL_PAYMENT_FAILED:
+    elif event_type in coinbase_webhook_service.PAYMENT_FAILED_EVENT_TYPES:
         success, message = await coinbase_webhook_service.handle_payment_failed(
             db=db,
             payload=payload,
         )
         if not success:
             logger.warning(
-                "Error logging payment_link.payment.failed",
+                "Error logging checkout.payment.failed",
                 coinbase_payment_link_id=payment_link_id,
                 error=message,
             )
 
-    elif event_type == coinbase_webhook_service.EVENT_TYPE_PL_PAYMENT_EXPIRED:
+    elif event_type in coinbase_webhook_service.PAYMENT_EXPIRED_EVENT_TYPES:
         success, message = await coinbase_webhook_service.handle_payment_expired(
             db=db,
             payload=payload,
         )
         if not success:
             logger.warning(
-                "Error logging payment_link.payment.expired",
+                "Error logging checkout.payment.expired",
                 coinbase_payment_link_id=payment_link_id,
                 error=message,
             )
@@ -406,15 +406,16 @@ async def handle_coinbase_webhook(
     """
     Handle incoming Coinbase webhook events.
 
-    Supports both Payment Link API (new) and legacy Commerce Charge API formats.
-    Auto-detects the format based on the signature header:
-    - X-Hook0-Signature  → Payment Link API (payment_link.payment.*)
+    Supports the Coinbase Business Checkout/Payment-Link API and the legacy
+    Commerce Charge API. Auto-detects the format based on the signature header:
+    - X-Hook0-Signature  → Checkout API (checkout.payment.* / legacy payment_link.payment.*)
     - X-CC-Webhook-Signature → Legacy Commerce (charge:*)
 
-    Payment Link event types:
-    - payment_link.payment.success: Payment completed successfully
-    - payment_link.payment.failed: Payment failed
-    - payment_link.payment.expired: Payment link expired
+    Checkout event types:
+    - checkout.payment.success: Payment completed successfully
+    - checkout.payment.failed: Payment failed
+    - checkout.payment.expired: Checkout expired without payment
+    (Legacy payment_link.payment.* names are still accepted during migration.)
 
     Legacy event types (deprecated):
     - charge:confirmed: Payment confirmed

--- a/src/schemas/payment_link.py
+++ b/src/schemas/payment_link.py
@@ -33,8 +33,10 @@ class PaymentLinkResponse(BaseModel):
 
 
 class PaymentLinkListResponse(BaseModel):
-    """Paginated list of payment links."""
-    payment_links: List[Dict[str, Any]] = Field(default_factory=list, alias="paymentLinks")
+    """Paginated list of payment records (Checkouts API)."""
+    # Coinbase renamed the list key from `paymentLinks` to `checkouts` in the
+    # Checkouts API. `populate_by_name=True` still accepts the Python field name.
+    payment_links: List[Dict[str, Any]] = Field(default_factory=list, alias="checkouts")
     next_page_token: Optional[str] = Field(None, alias="nextPageToken")
 
     model_config = {"populate_by_name": True}

--- a/src/services/coinbase_payment_link_service.py
+++ b/src/services/coinbase_payment_link_service.py
@@ -1,10 +1,14 @@
 """
-Coinbase Business Payment Link API service.
+Coinbase Business Checkout API service.
 
 Provides CRUD operations for creating, listing, retrieving, and deactivating
-payment links via the Coinbase Business REST API.
+payment records via the Coinbase Business REST API. This targets the Checkouts
+API (`/api/v1/checkouts`), which superseded the Payment Link API
+(`/api/v1/payment-links`). Request/response schemas are identical between the
+two — only the URL path changed — so this is a base-path swap.
 
-API Reference: https://docs.cdp.coinbase.com/api-reference/business-api/rest-api/payment-links/introduction
+API Reference: https://docs.cdp.coinbase.com/api-reference/business-api/rest-api/checkouts/introduction
+Migration:     https://docs.cdp.coinbase.com/coinbase-business/checkout-apis/migrate/overview
 """
 from typing import Optional, Dict, Any
 
@@ -15,8 +19,9 @@ from src.core.logging_config import get_core_logger
 
 logger = get_core_logger()
 
-# Payment Link API base path (includes /sandbox prefix when CDP_SANDBOX=true)
-PAYMENT_LINKS_PATH = f"{CDP_PATH_PREFIX}/api/v1/payment-links"
+# Checkouts API base path (includes /sandbox prefix when CDP_SANDBOX=true).
+# Name kept as PAYMENT_LINKS_PATH to avoid churn; value migrated to /checkouts.
+PAYMENT_LINKS_PATH = f"{CDP_PATH_PREFIX}/api/v1/checkouts"
 
 # Default timeout for API calls (seconds)
 DEFAULT_TIMEOUT = 30.0

--- a/src/services/coinbase_webhook_service.py
+++ b/src/services/coinbase_webhook_service.py
@@ -32,10 +32,32 @@ class CoinbaseWebhookService:
 
     SOURCE_NAME = "coinbase"
 
-    # ── Payment Link API Event Types (New) ───────────────────────────────
+    # ── Checkout API Event Types (current) ───────────────────────────────
+    EVENT_TYPE_CHECKOUT_PAYMENT_SUCCESS = "checkout.payment.success"
+    EVENT_TYPE_CHECKOUT_PAYMENT_FAILED = "checkout.payment.failed"
+    EVENT_TYPE_CHECKOUT_PAYMENT_EXPIRED = "checkout.payment.expired"
+
+    # ── Legacy Payment Link API Event Types ──────────────────────────────
+    # Still recognized so an old `payment_link.*` subscription left running in
+    # parallel during the Checkouts migration doesn't drop payments. Safe to
+    # remove once the legacy subscription is deleted.
     EVENT_TYPE_PL_PAYMENT_SUCCESS = "payment_link.payment.success"
     EVENT_TYPE_PL_PAYMENT_FAILED = "payment_link.payment.failed"
     EVENT_TYPE_PL_PAYMENT_EXPIRED = "payment_link.payment.expired"
+
+    # Grouped by action so handlers accept either the Checkout or legacy name.
+    PAYMENT_SUCCESS_EVENT_TYPES = {
+        EVENT_TYPE_CHECKOUT_PAYMENT_SUCCESS,
+        EVENT_TYPE_PL_PAYMENT_SUCCESS,
+    }
+    PAYMENT_FAILED_EVENT_TYPES = {
+        EVENT_TYPE_CHECKOUT_PAYMENT_FAILED,
+        EVENT_TYPE_PL_PAYMENT_FAILED,
+    }
+    PAYMENT_EXPIRED_EVENT_TYPES = {
+        EVENT_TYPE_CHECKOUT_PAYMENT_EXPIRED,
+        EVENT_TYPE_PL_PAYMENT_EXPIRED,
+    }
 
     # ── Legacy Commerce Charge API Event Types (Deprecated) ──────────────
     EVENT_TYPE_CHARGE_CONFIRMED = "charge:confirmed"


### PR DESCRIPTION
Coinbase renamed the Payment Link API to the Checkouts API. Request and response schemas are identical, so this is a base-path swap plus webhook event-name update — the proxy-router's own HTTP endpoints are unchanged so the frontend continues to work with no changes.

- Point upstream calls at /api/v1/checkouts (was /api/v1/payment-links); the CDP JWT signs whatever path is passed, so auth follows automatically.
- Update the list response key alias paymentLinks -> checkouts.
- Accept checkout.payment.{success,failed,expired} webhook events while still recognizing the legacy payment_link.* names, so an old subscription left running in parallel during cutover doesn't drop payments. The existing transaction-id idempotency check prevents double-crediting.

Note: the admin-only GET /billing/admin/payment-links list now emits its items under the `checkouts` key (FastAPI serializes by alias).