### PR TITLE
fix(pricing): raise unmatched-model default to $2/$8

### DIFF
--- a/models/prod_model_price.json
+++ b/models/prod_model_price.json
@@ -1,6 +1,6 @@
 {
-  "default_input_price_per_million": "0.50",
-  "default_output_price_per_million": "2.00",
+  "default_input_price_per_million": "2.00",
+  "default_output_price_per_million": "8.00",
   "models": {
     "glm-5.2": { "input": "1.25", "output": "4.40" },
     "glm-5.2:web": { "input": "1.25", "output": "4.40" },

--- a/src/services/pricing/hardcoded_provider.py
+++ b/src/services/pricing/hardcoded_provider.py
@@ -47,8 +47,8 @@ class HardcodedPricingProvider(PricingProvider):
 
     def __init__(self):
         self._pricing_cache: Dict[str, ModelPricing] = {}
-        self._default_input_price: Decimal = Decimal("0.50")
-        self._default_output_price: Decimal = Decimal("2.00")
+        self._default_input_price: Decimal = Decimal("2.00")
+        self._default_output_price: Decimal = Decimal("8.00")
         self._initialize_pricing()
 
     def _initialize_pricing(self) -> None:
@@ -56,8 +56,8 @@ class HardcodedPricingProvider(PricingProvider):
         config = load_model_prices()
         effective_date = datetime(2024, 12, 1)
 
-        self._default_input_price = Decimal(config.get("default_input_price_per_million", "0.50"))
-        self._default_output_price = Decimal(config.get("default_output_price_per_million", "2.00"))
+        self._default_input_price = Decimal(config.get("default_input_price_per_million", "2.00"))
+        self._default_output_price = Decimal(config.get("default_output_price_per_million", "8.00"))
 
         for name, prices in config.get("models", {}).items():
             pricing = ModelPricing(


### PR DESCRIPTION
## Summary
- Raise `default_input_price_per_million` / `default_output_price_per_million` from `$0.50/$2.00` → `$2.00/$8.00`.
- Align `HardcodedPricingProvider` hard-coded fallbacks with the same floor.

Unmatched names should be rare after catalog coverage, but the old default was a fleece floor for any new premium model.

## Test plan
- [ ] Unlisted model name bills at `$2/$8` (not `$0.50/$2`)
- [ ] Explicit catalog keys (e.g. `claude-opus-4.8`, `glm-4.7-flash`) unchanged


Made with [Cursor](https://cursor.com)