### PR TITLE
feat(sessions): MOR lanes — PPS gate, premium budget, P2P offramp

### DIFF
--- a/src/api/v1/chat/chat_exceptions.py
+++ b/src/api/v1/chat/chat_exceptions.py
@@ -155,12 +155,13 @@ class ModelBusyError(ChatError):
 
 @dataclass
 class ModelUnavailableError(ChatError):
-    """Raised when a non-warm model open is blocked by the MOR low-water mark."""
+    """Raised for hosted-gateway capacity/price refusals (LWM, PPS gate, premium budget)."""
 
     model_id: Optional[str] = None
     message: str = (
-        "This model is temporarily unavailable; "
-        "capacity is reserved for priority models."
+        "This model is temporarily unavailable on the hosted gateway. "
+        "For higher volume or the full marketplace catalog, run a self-custody node: "
+        "https://nodedocs.mor.org/consumers/quickstart"
     )
     status_code: int = status.HTTP_503_SERVICE_UNAVAILABLE
     error_type: str = "model_unavailable"

--- a/src/api/v1/chat/index.py
+++ b/src/api/v1/chat/index.py
@@ -28,7 +28,7 @@ from ....services import (
     NoSessionAvailableError,
     SessionOpenError,
     SessionPoolBusyError,
-    SessionMorReservedError,
+    SessionGatewayCapacityError,
 )
 from ....services.billing_service import billing_service
 from ....services.token_estimation_service import token_estimation_service
@@ -363,7 +363,8 @@ async def _resolve_session(
             open_count=e.open_count,
             message=e.message,
         ) from e
-    except SessionMorReservedError as e:
+    except SessionGatewayCapacityError as e:
+        # LWM warm reserve, max-bid PPS gate, or premium daily budget.
         raise ModelUnavailableError(
             model_id=e.model_id,
             message=e.message,

--- a/src/api/v1/embeddings/index.py
+++ b/src/api/v1/embeddings/index.py
@@ -21,7 +21,7 @@ from ....services import (
     NoSessionAvailableError,
     SessionOpenError,
     SessionPoolBusyError,
-    SessionMorReservedError,
+    SessionGatewayCapacityError,
 )
 from ....services import proxy_router_service
 from ....services.billing_service import billing_service
@@ -155,12 +155,13 @@ async def create_embeddings(
                 detail=e.message,
                 headers={"Retry-After": str(e.retry_after)},
             )
-        except SessionMorReservedError as e:
+        except SessionGatewayCapacityError as e:
             embeddings_logger.warning(
-                "Model unavailable (MOR low-water reserve)",
+                "Model unavailable (gateway capacity / price lane)",
                 request_id=request_id,
                 error=str(e),
-                event_type="session_mor_reserved",
+                category=getattr(e, "category", None),
+                event_type="session_gateway_capacity",
             )
             await _void_billing_hold(user.id, ledger_entry_id, "model_unavailable", str(e), embeddings_logger)
             raise HTTPException(

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -218,7 +218,7 @@ class Settings(BaseSettings):
     # opens. When balance <= this value, non-warm models cannot open new
     # on-chain sessions (idle claims still succeed). Warm models skip the gate.
     # 0 DISABLES the check — ships inert; turn on per-env via secrets
-    # (prod target ~30000 MOR). Distinct from soft caps (session count vs MOR).
+    # (prod target ~15000 MOR). Distinct from soft caps (session count vs MOR).
     SESSION_MOR_LOW_WATER_MARK_MOR: float = Field(
         default=float(os.getenv("SESSION_MOR_LOW_WATER_MARK_MOR", "0"))
     )
@@ -226,6 +226,35 @@ class Settings(BaseSettings):
     # C-Node. Per-replica only.
     SESSION_MOR_BALANCE_CACHE_SECONDS: float = Field(
         default=float(os.getenv("SESSION_MOR_BALANCE_CACHE_SECONDS", "15"))
+    )
+
+    # --- Max-bid PPS hard gate (standard lane) --------------------------------
+    # Refuse opens (and idle claims) when the model's HIGHEST rated bid PPS is
+    # at/above this MOR/sec threshold. Equivalent to ~175 MOR escrow for a
+    # 30-minute session under day-lock stake factor ~338:
+    #   175 / (1800 * 338) ≈ 0.00028764
+    # Warm (SESSION_PREFERRED_MODELS) and premium showcase IDs skip this gate.
+    # 0 DISABLES the gate — ships inert; enable per-env via secrets.
+    SESSION_MAX_BID_PPS_MOR: float = Field(
+        default=float(os.getenv("SESSION_MAX_BID_PPS_MOR", "0"))
+    )
+
+    # --- Premium showcase lane ------------------------------------------------
+    # Comma-separated model blockchain IDs exempt from the PPS gate but limited
+    # by SESSION_PREMIUM_DAILY_BUDGET_MOR (day-locked / used MOR, metered on
+    # session close, UTC day). Soft cap still applies (DEFAULT). Empty / budget
+    # 0 disables the premium lane (IDs would then hit the PPS gate like
+    # standard models if listed).
+    SESSION_PREMIUM_MODEL_IDS: str = Field(
+        default=os.getenv("SESSION_PREMIUM_MODEL_IDS", "")
+    )
+    SESSION_PREMIUM_DAILY_BUDGET_MOR: float = Field(
+        default=float(os.getenv("SESSION_PREMIUM_DAILY_BUDGET_MOR", "0"))
+    )
+    # Day-lock stake amplification used to estimate used MOR on close:
+    # daylock ≈ pps × elapsed_seconds × factor (observed ~338 on Base).
+    SESSION_STAKE_FACTOR: float = Field(
+        default=float(os.getenv("SESSION_STAKE_FACTOR", "338"))
     )
 
     # --- Expensive-model session tier ---------------------------------------

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -17,7 +17,10 @@ from .session_routing_service import (
     NoSessionAvailableError,
     SessionOpenError,
     SessionPoolBusyError,
+    SessionGatewayCapacityError,
     SessionMorReservedError,
+    SessionPriceGateError,
+    SessionPremiumBudgetError,
 )
 
 __all__ = [
@@ -35,5 +38,8 @@ __all__ = [
     "NoSessionAvailableError",
     "SessionOpenError",
     "SessionPoolBusyError",
+    "SessionGatewayCapacityError",
     "SessionMorReservedError",
+    "SessionPriceGateError",
+    "SessionPremiumBudgetError",
 ]

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -70,7 +70,27 @@ class SessionPoolBusyError(SessionRoutingError):
         self.open_count = open_count
 
 
-class SessionMorReservedError(SessionRoutingError):
+# Shared off-ramp copy for hosted-gateway capacity / price refusals (503).
+P2P_OFFRAMP_HINT = (
+    "For higher volume or the full marketplace catalog, run a self-custody node: "
+    "https://nodedocs.mor.org/consumers/quickstart"
+)
+
+
+class SessionGatewayCapacityError(SessionRoutingError):
+    """Hosted-gateway capacity / price refusal (HTTP 503 model_unavailable)."""
+
+    def __init__(
+        self,
+        message: str,
+        model_id: Optional[str] = None,
+        category: str = "capacity",
+    ):
+        super().__init__(message, model_id=model_id)
+        self.category = category  # warm_reserve | price_gate | premium_budget
+
+
+class SessionMorReservedError(SessionGatewayCapacityError):
     """Raised when liquid wallet MOR is at/below the warm-model low-water mark."""
 
     def __init__(
@@ -80,9 +100,39 @@ class SessionMorReservedError(SessionRoutingError):
         balance_mor: Optional[float] = None,
         low_water_mark_mor: float = 0,
     ):
-        super().__init__(message, model_id=model_id)
+        super().__init__(message, model_id=model_id, category="warm_reserve")
         self.balance_mor = balance_mor
         self.low_water_mark_mor = low_water_mark_mor
+
+
+class SessionPriceGateError(SessionGatewayCapacityError):
+    """Raised when max rated-bid PPS exceeds the standard-lane hard gate."""
+
+    def __init__(
+        self,
+        message: str,
+        model_id: Optional[str] = None,
+        max_pps: Optional[float] = None,
+        gate_pps: float = 0,
+    ):
+        super().__init__(message, model_id=model_id, category="price_gate")
+        self.max_pps = max_pps
+        self.gate_pps = gate_pps
+
+
+class SessionPremiumBudgetError(SessionGatewayCapacityError):
+    """Raised when the UTC-day premium showcase daylock budget is exhausted."""
+
+    def __init__(
+        self,
+        message: str,
+        model_id: Optional[str] = None,
+        spent_mor: float = 0,
+        budget_mor: float = 0,
+    ):
+        super().__init__(message, model_id=model_id, category="premium_budget")
+        self.spent_mor = spent_mor
+        self.budget_mor = budget_mor
 
 
 class SessionRoutingService:
@@ -133,6 +183,10 @@ class SessionRoutingService:
         # (monotonic_expiry, balance_mor). Per-replica; fail-open on miss/error.
         self._mor_balance_cache: Optional[tuple] = None
 
+        # Per-replica fallback for premium daylock counters when Redis is down.
+        # Keyed by UTC date string -> spent MOR. Prefer Redis in multi-replica.
+        self._premium_daylock_local: Dict[str, float] = {}
+
         logger.info("SessionRoutingService initialized",
                    event_type="session_routing_service_init")
     
@@ -142,15 +196,31 @@ class SessionRoutingService:
             return set()
         return set(m.strip() for m in settings.SESSION_PREFERRED_MODELS.split(",") if m.strip())
 
+    def _get_premium_models(self) -> set:
+        """Showcase model IDs exempt from PPS gate, limited by daily daylock budget."""
+        raw = settings.SESSION_PREMIUM_MODEL_IDS or ""
+        return {m.strip() for m in raw.split(",") if m.strip()}
+
     def _is_warm_model(self, model_id: str) -> bool:
         """True if model_id is in SESSION_PREFERRED_MODELS (warm pool)."""
         return model_id in self._get_preferred_models()
+
+    def _is_premium_model(self, model_id: str) -> bool:
+        """True if model_id is in SESSION_PREMIUM_MODEL_IDS (showcase lane)."""
+        return model_id in self._get_premium_models()
 
     def _soft_cap_for_model(self, model_id: str) -> int:
         """Per-model OPEN soft cap. 0 means unlimited (cap disabled)."""
         if self._is_warm_model(model_id):
             return max(0, int(settings.SESSION_SOFT_CAP_WARM))
         return max(0, int(settings.SESSION_SOFT_CAP_DEFAULT))
+
+    @staticmethod
+    def _utc_day_key(when: Optional[datetime] = None) -> str:
+        dt = when or datetime.now(timezone.utc)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%d")
 
     async def _count_open_sessions(self, db: AsyncSession, model_id: str) -> int:
         """Count OPEN sessions for a model (utilized + idle)."""
@@ -273,11 +343,180 @@ class SessionRoutingService:
                 event_type="session_mor_low_water_reserved",
             )
             raise SessionMorReservedError(
-                "This model is temporarily unavailable; "
-                "capacity is reserved for priority models.",
+                "Hosted capacity is reserved for priority (warm) models right now. "
+                + P2P_OFFRAMP_HINT,
                 model_id=model_id,
                 balance_mor=balance,
                 low_water_mark_mor=watermark,
+            )
+
+    async def _ensure_max_bid_pps_allows_open(self, model_id: str) -> None:
+        """Refuse standard-lane models whose max rated bid PPS is at/above the gate.
+
+        Warm and premium showcase models skip this gate. Gate 0 disables it.
+        Missing price (lookup failure / no bids) fails open so we don't brick
+        routing when the C-Node bid read is unavailable — soft-cap / open will
+        still fail naturally if there is no usable bid.
+        """
+        gate = float(settings.SESSION_MAX_BID_PPS_MOR or 0)
+        if gate <= 0:
+            return
+        if self._is_warm_model(model_id) or self._is_premium_model(model_id):
+            return
+
+        max_pps = await self._get_model_max_price_per_second(model_id)
+        if max_pps is None:
+            return
+        if max_pps >= gate:
+            logger.warning(
+                "Max-bid PPS gate refusing model",
+                model_id=model_id,
+                max_pps=max_pps,
+                gate_pps=gate,
+                event_type="session_max_bid_pps_refused",
+            )
+            raise SessionPriceGateError(
+                "This model is too expensive for the hosted API Gateway right now. "
+                + P2P_OFFRAMP_HINT,
+                model_id=model_id,
+                max_pps=max_pps,
+                gate_pps=gate,
+            )
+
+    async def _get_premium_daylock_spent(self) -> Optional[float]:
+        """UTC-day premium daylock spent (MOR), or None if unreadable."""
+        day = self._utc_day_key()
+        try:
+            from .cache_service import cache_service
+            redis = await cache_service._acquire_redis()
+            if redis is not None:
+                raw = await redis.get(f"apigw:premium_daylock:{day}")
+                if raw is None:
+                    return 0.0
+                return float(raw)
+        except Exception as e:
+            logger.warning(
+                "Premium daylock Redis read failed; using local fallback",
+                error=str(e),
+                event_type="premium_daylock_redis_read_error",
+            )
+        return float(self._premium_daylock_local.get(day, 0.0))
+
+    async def _add_premium_daylock_spent(self, amount_mor: float) -> None:
+        """Add used/daylocked MOR to today's premium counter (close path)."""
+        if amount_mor <= 0:
+            return
+        day = self._utc_day_key()
+        self._premium_daylock_local[day] = (
+            float(self._premium_daylock_local.get(day, 0.0)) + amount_mor
+        )
+        try:
+            from .cache_service import cache_service
+            redis = await cache_service._acquire_redis()
+            if redis is not None:
+                key = f"apigw:premium_daylock:{day}"
+                await redis.incrbyfloat(key, amount_mor)
+                # Expire a bit after the UTC day rolls (48h safety).
+                await redis.expire(key, 48 * 3600)
+        except Exception as e:
+            logger.warning(
+                "Premium daylock Redis write failed; local counter only",
+                error=str(e),
+                amount_mor=amount_mor,
+                event_type="premium_daylock_redis_write_error",
+            )
+
+    async def _ensure_premium_budget_allows_open(self, model_id: str) -> None:
+        """Refuse new premium opens when UTC-day daylock budget is exhausted.
+
+        Non-premium models skip. Budget 0 disables the premium lane check
+        (premium IDs would still need to pass PPS unless also warm).
+        """
+        if not self._is_premium_model(model_id):
+            return
+        budget = float(settings.SESSION_PREMIUM_DAILY_BUDGET_MOR or 0)
+        if budget <= 0:
+            return
+
+        spent = await self._get_premium_daylock_spent()
+        if spent is None:
+            # Cannot meter — fail closed for premium to protect the bank.
+            raise SessionPremiumBudgetError(
+                "Daily premium showcase capacity on the hosted gateway is unavailable. "
+                + P2P_OFFRAMP_HINT,
+                model_id=model_id,
+                spent_mor=0,
+                budget_mor=budget,
+            )
+        if spent >= budget:
+            logger.warning(
+                "Premium daily daylock budget exhausted; refusing open",
+                model_id=model_id,
+                spent_mor=spent,
+                budget_mor=budget,
+                event_type="session_premium_budget_exhausted",
+            )
+            raise SessionPremiumBudgetError(
+                "Daily premium showcase capacity on the hosted gateway is exhausted. "
+                + P2P_OFFRAMP_HINT,
+                model_id=model_id,
+                spent_mor=spent,
+                budget_mor=budget,
+            )
+
+    async def _record_premium_daylock_on_close(self, session: RoutedSession) -> None:
+        """Meter estimated daylocked MOR for a premium session at close time."""
+        if not self._is_premium_model(session.model_id):
+            return
+        budget = float(settings.SESSION_PREMIUM_DAILY_BUDGET_MOR or 0)
+        if budget <= 0:
+            return
+
+        try:
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            created = session.created_at or now
+            if created.tzinfo is not None:
+                created = created.replace(tzinfo=None)
+            elapsed_s = max(0.0, (now - created).total_seconds())
+
+            # Cap by scheduled session length when known.
+            sched_s = None
+            if session.expires_at and session.created_at:
+                exp = session.expires_at
+                if exp.tzinfo is not None:
+                    exp = exp.replace(tzinfo=None)
+                sched_s = max(1.0, (exp - created).total_seconds())
+            if sched_s is not None:
+                elapsed_s = min(elapsed_s, sched_s)
+
+            max_pps = await self._get_model_max_price_per_second(session.model_id)
+            if max_pps is None or max_pps <= 0:
+                logger.warning(
+                    "Premium close meter skipped; no PPS",
+                    session_id=session.id,
+                    model_id=session.model_id,
+                    event_type="premium_daylock_meter_skip",
+                )
+                return
+
+            factor = float(settings.SESSION_STAKE_FACTOR or 338)
+            daylock = max_pps * elapsed_s * factor
+            await self._add_premium_daylock_spent(daylock)
+            logger.info(
+                "Recorded premium daylock on close",
+                session_id=session.id,
+                model_id=session.model_id,
+                elapsed_s=round(elapsed_s, 1),
+                max_pps=max_pps,
+                daylock_mor=round(daylock, 3),
+                event_type="premium_daylock_recorded",
+            )
+        except Exception as e:
+            logger.warning(
+                "Premium daylock meter failed",
+                session_id=getattr(session, "id", None),
+                error=str(e),
+                event_type="premium_daylock_meter_error",
             )
 
     # =========================================================================
@@ -464,6 +703,10 @@ class SessionRoutingService:
         route_logger.info("Routing request to session",
                          event_type="route_request_start")
 
+        # Standard-lane max-bid PPS gate runs before idle claim so leftover
+        # over-gate sessions are not reused after the gate is enabled.
+        await self._ensure_max_bid_pps_allows_open(model_id)
+
         # FAST PATH (lock-free): atomically claim an idle OPEN session for this
         # model with a single UPDATE ... FOR UPDATE SKIP LOCKED on its own
         # short-lived connection. The DB row lock (not an in-process lock) hands
@@ -478,13 +721,14 @@ class SessionRoutingService:
             return claimed_id
 
         # OPEN PATH: no idle session -> open a new paid on-chain session, unless
-        # soft-capped (429) or MOR low-water reserves capacity for warm models
-        # (503). Checks run before the wallet-serialized open so we don't burn
-        # a nonce on a session we refuse to keep. The session is created
-        # already assigned (active_requests=1), so it is never momentarily
-        # visible as idle between insert and use.
+        # soft-capped (429), MOR low-water / PPS / premium budget (503). Checks
+        # run before the wallet-serialized open so we don't burn a nonce on a
+        # session we refuse to keep. The session is created already assigned
+        # (active_requests=1), so it is never momentarily visible as idle
+        # between insert and use.
         await self._ensure_soft_cap_allows_open(model_id)
         await self._ensure_mor_low_water_allows_open(model_id)
+        await self._ensure_premium_budget_allows_open(model_id)
 
         route_logger.info("No idle session for model, opening a new one",
                          event_type="no_idle_session")
@@ -586,6 +830,21 @@ class SessionRoutingService:
             invalidate_logger.warning("Session invalidated after prompt failure",
                                       reason=reason,
                                       event_type="session_invalidated")
+            # Meter premium daylock before background close (needs model_id /
+            # created_at from the row). Best-effort.
+            try:
+                row = await db.execute(
+                    select(RoutedSession).where(RoutedSession.id == session_id)
+                )
+                session_row = row.scalar_one_or_none()
+                if session_row is not None:
+                    await self._record_premium_daylock_on_close(session_row)
+            except Exception as e:
+                invalidate_logger.warning(
+                    "Premium meter on invalidate failed",
+                    error=str(e),
+                    event_type="premium_daylock_invalidate_meter_error",
+                )
             # Close on-chain in the background: close needs a (possibly
             # failing) provider-report RPC plus a blockchain tx — too slow
             # to block the user's retry on. closeSession tolerates
@@ -784,11 +1043,14 @@ class SessionRoutingService:
         open_logger.info("Opening new session for model",
                         event_type="session_open_start")
 
-        # Soft-cap + MOR low-water gates (request path also checks before
-        # calling here; automation / preferred scale-up enters directly).
-        # Cap/watermark 0 = disabled. Warm models skip the MOR gate.
+        # Soft-cap + lane gates (request path also checks before calling here;
+        # automation / preferred scale-up enters directly). Cap/watermark/
+        # PPS/budget 0 = disabled for that gate. Warm skips LWM + PPS; premium
+        # skips PPS but is limited by daily daylock budget.
         await self._ensure_soft_cap_allows_open(model_id)
         await self._ensure_mor_low_water_allows_open(model_id)
+        await self._ensure_max_bid_pps_allows_open(model_id)
+        await self._ensure_premium_budget_allows_open(model_id)
 
         # Expensive models open with a shorter duration so the amplified
         # on-chain stake pulled per session stays small (more concurrent
@@ -956,6 +1218,9 @@ class SessionRoutingService:
                          event_type="session_close_start")
         
         try:
+            # Meter premium daylock on close (used MOR), then close on-chain.
+            await self._record_premium_daylock_on_close(session)
+
             # Close on-chain via the adaptive throttle (shared wallet/nonce
             # with every other on-chain session op on this replica).
             await self._run_onchain(
@@ -1377,6 +1642,8 @@ class SessionRoutingService:
                        session_id=session.id,
                        expired_at=session.expires_at.isoformat(),
                        event_type="closing_expired_session")
+
+            await self._record_premium_daylock_on_close(session)
             
             # Mark as EXPIRED rather than going through close flow
             session.state = SessionState.EXPIRED

--- a/tests/unit/test_session_mor_low_water.py
+++ b/tests/unit/test_session_mor_low_water.py
@@ -87,7 +87,8 @@ async def test_non_warm_refused_at_or_below_watermark(service):
     assert err.model_id == "0xcold"
     assert err.balance_mor == 25000.0
     assert err.low_water_mark_mor == 30000
-    assert "priority models" in err.message
+    assert "priority" in err.message.lower()
+    assert "nodedocs.mor.org" in err.message
 
 
 async def test_non_warm_allowed_above_watermark(service):

--- a/tests/unit/test_session_premium_budget.py
+++ b/tests/unit/test_session_premium_budget.py
@@ -1,0 +1,100 @@
+"""Tests for premium showcase daily daylock budget (metered on close)."""
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.services.session_routing_service import (
+    SessionPremiumBudgetError,
+    SessionRoutingService,
+)
+
+
+@pytest.fixture
+def service():
+    return SessionRoutingService()
+
+
+async def test_non_premium_skips_budget(service):
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
+        mock_settings.SESSION_PREMIUM_DAILY_BUDGET_MOR = 15000
+        service._get_premium_daylock_spent = AsyncMock(
+            side_effect=AssertionError("should not read budget for non-premium")
+        )
+        await service._ensure_premium_budget_allows_open("0xother")
+
+
+async def test_budget_zero_skips(service):
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
+        mock_settings.SESSION_PREMIUM_DAILY_BUDGET_MOR = 0
+        service._get_premium_daylock_spent = AsyncMock(
+            side_effect=AssertionError("budget 0 disables")
+        )
+        await service._ensure_premium_budget_allows_open("0xprem")
+
+
+async def test_premium_allowed_under_budget(service):
+    service._get_premium_daylock_spent = AsyncMock(return_value=1000.0)
+
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
+        mock_settings.SESSION_PREMIUM_DAILY_BUDGET_MOR = 15000
+        await service._ensure_premium_budget_allows_open("0xprem")
+
+
+async def test_premium_refused_at_budget(service):
+    service._get_premium_daylock_spent = AsyncMock(return_value=15000.0)
+
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
+        mock_settings.SESSION_PREMIUM_DAILY_BUDGET_MOR = 15000
+        with pytest.raises(SessionPremiumBudgetError) as exc_info:
+            await service._ensure_premium_budget_allows_open("0xprem")
+
+    err = exc_info.value
+    assert err.category == "premium_budget"
+    assert err.spent_mor == 15000.0
+    assert "exhausted" in err.message
+    assert "nodedocs.mor.org" in err.message
+
+
+async def test_record_premium_daylock_on_close(service):
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    session = MagicMock()
+    session.id = "0xsid"
+    session.model_id = "0xprem"
+    session.created_at = now - timedelta(seconds=600)
+    session.expires_at = now + timedelta(seconds=1200)
+
+    service._get_model_max_price_per_second = AsyncMock(return_value=0.0005)
+    service._add_premium_daylock_spent = AsyncMock()
+
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
+        mock_settings.SESSION_PREMIUM_DAILY_BUDGET_MOR = 15000
+        mock_settings.SESSION_STAKE_FACTOR = 338
+        await service._record_premium_daylock_on_close(session)
+
+    # 0.0005 * 600 * 338 = 101.4
+    service._add_premium_daylock_spent.assert_awaited_once()
+    amount = service._add_premium_daylock_spent.await_args.args[0]
+    assert amount == pytest.approx(101.4, rel=1e-3)
+
+
+async def test_record_skips_non_premium(service):
+    session = MagicMock()
+    session.model_id = "0xother"
+    service._add_premium_daylock_spent = AsyncMock()
+
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
+        mock_settings.SESSION_PREMIUM_DAILY_BUDGET_MOR = 15000
+        await service._record_premium_daylock_on_close(session)
+
+    service._add_premium_daylock_spent.assert_not_awaited()

--- a/tests/unit/test_session_price_gate.py
+++ b/tests/unit/test_session_price_gate.py
@@ -1,0 +1,89 @@
+"""Tests for max-bid PPS hard gate (standard lane)."""
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.services.session_routing_service import (
+    SessionPriceGateError,
+    SessionRoutingService,
+)
+
+
+@pytest.fixture
+def service():
+    return SessionRoutingService()
+
+
+async def test_pps_gate_zero_skips(service):
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_MAX_BID_PPS_MOR = 0
+        mock_settings.SESSION_PREFERRED_MODELS = ""
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = ""
+        service._get_model_max_price_per_second = AsyncMock(
+            side_effect=AssertionError("should not lookup when gate disabled")
+        )
+        await service._ensure_max_bid_pps_allows_open("0xcold")
+
+
+async def test_warm_skips_pps_gate(service):
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_MAX_BID_PPS_MOR = 0.00028764
+        mock_settings.SESSION_PREFERRED_MODELS = "0xwarm"
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = ""
+        service._get_model_max_price_per_second = AsyncMock(
+            side_effect=AssertionError("warm skips PPS lookup")
+        )
+        await service._ensure_max_bid_pps_allows_open("0xwarm")
+
+
+async def test_premium_skips_pps_gate(service):
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_MAX_BID_PPS_MOR = 0.00028764
+        mock_settings.SESSION_PREFERRED_MODELS = ""
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
+        service._get_model_max_price_per_second = AsyncMock(
+            side_effect=AssertionError("premium skips PPS lookup")
+        )
+        await service._ensure_max_bid_pps_allows_open("0xprem")
+
+
+async def test_over_gate_refused(service):
+    service._get_model_max_price_per_second = AsyncMock(return_value=0.001)
+
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_MAX_BID_PPS_MOR = 0.00028764
+        mock_settings.SESSION_PREFERRED_MODELS = ""
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = ""
+        with pytest.raises(SessionPriceGateError) as exc_info:
+            await service._ensure_max_bid_pps_allows_open("0xexpensive")
+
+    err = exc_info.value
+    assert err.model_id == "0xexpensive"
+    assert err.max_pps == 0.001
+    assert err.category == "price_gate"
+    assert "too expensive" in err.message
+    assert "nodedocs.mor.org" in err.message
+
+
+async def test_under_gate_allowed(service):
+    service._get_model_max_price_per_second = AsyncMock(return_value=0.0001)
+
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_MAX_BID_PPS_MOR = 0.00028764
+        mock_settings.SESSION_PREFERRED_MODELS = ""
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = ""
+        await service._ensure_max_bid_pps_allows_open("0xcheap")
+
+
+async def test_missing_price_fail_open(service):
+    service._get_model_max_price_per_second = AsyncMock(return_value=None)
+
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_MAX_BID_PPS_MOR = 0.00028764
+        mock_settings.SESSION_PREFERRED_MODELS = ""
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = ""
+        await service._ensure_max_bid_pps_allows_open("0xunknown")


### PR DESCRIPTION
## Summary
- Add standard-lane **max-bid PPS hard gate** (`SESSION_MAX_BID_PPS_MOR`) so over-priced / junk max bids cannot open on APIGW (warm + premium IDs exempt).
- Add **premium showcase lane** (`SESSION_PREMIUM_MODEL_IDS` + `SESSION_PREMIUM_DAILY_BUDGET_MOR`) with UTC-day daylock budget **metered on session close**.
- Map capacity/price refusals to **503** `model_unavailable` with self-custody / P2P off-ramp copy; soft caps remain **429**.

Companion Infra config (soft caps 8/2, LWM 15k, PPS 0.00028764, Sonnet 4.6 + Opus 4.6 @ 15k/day) lives in Morpheus-Infra — apply after this ships to the target env.

## Test plan
- [x] Unit tests: `test_session_price_gate`, `test_session_premium_budget`, `test_session_mor_low_water`
- [ ] After deploy to dev: confirm over-gate model → 503; warm still opens near LWM; premium opens until budget then 503
- [ ] Confirm soft cap still returns 429 (not 503)


Made with [Cursor](https://cursor.com)