### PR TITLE
feat(sessions): curated allowlist + family aliases for APIGW

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -228,6 +228,21 @@ class Settings(BaseSettings):
         default=float(os.getenv("SESSION_MOR_BALANCE_CACHE_SECONDS", "15"))
     )
 
+    # --- Curated allowlist (APIGW taster catalog) -----------------------------
+    # Comma-separated blockchain IDs that may open on the hosted gateway after
+    # alias rewrite. Empty DISABLES (full catalog). Non-empty: anything else
+    # resolves to HTTP 503 model_unavailable + P2P off-ramp.
+    SESSION_ALLOWED_MODEL_IDS: str = Field(
+        default=os.getenv("SESSION_ALLOWED_MODEL_IDS", "")
+    )
+    # Deterministic family aliases applied BEFORE resolve/allowlist.
+    # Format: comma-separated "alias=target" (also accepts "->" / "→").
+    # Keys matched case-insensitively. Never map :web/:tee → base when a twin
+    # exists — keep Venice / SecretVM feature paths.
+    SESSION_MODEL_ALIASES: str = Field(
+        default=os.getenv("SESSION_MODEL_ALIASES", "")
+    )
+
     # --- Max-bid PPS hard gate (standard lane) --------------------------------
     # Refuse opens (and idle claims) when the model's HIGHEST rated bid PPS is
     # at/above this MOR/sec threshold. Equivalent to ~175 MOR escrow for a
@@ -235,6 +250,8 @@ class Settings(BaseSettings):
     #   175 / (1800 * 338) ≈ 0.00028764
     # Warm (SESSION_PREFERRED_MODELS) and premium showcase IDs skip this gate.
     # 0 DISABLES the gate — ships inert; enable per-env via secrets.
+    # Prefer SESSION_ALLOWED_MODEL_IDS as the primary catalog control; keep PPS
+    # as an optional backup when allowlist is empty.
     SESSION_MAX_BID_PPS_MOR: float = Field(
         default=float(os.getenv("SESSION_MAX_BID_PPS_MOR", "0"))
     )

--- a/src/core/model_errors.py
+++ b/src/core/model_errors.py
@@ -93,3 +93,33 @@ class ModelNearMissError(ModelRoutingError):
             "code": self.code,
         }
         super().__post_init__()
+
+
+@dataclass
+class ModelNotAllowlistedError(ModelRoutingError):
+    """Resolved model is outside the hosted-gateway curated allowlist."""
+
+    requested_model: Optional[str] = None
+    resolved_id: Optional[str] = None
+    message: str = (
+        "This model is not available on the hosted gateway. "
+        "For the full marketplace catalog, run a self-custody node: "
+        "https://nodedocs.mor.org/consumers/quickstart"
+    )
+    error_type: str = "model_unavailable"
+    code: str = "model_unavailable"
+    status_code: int = 503
+
+    def __post_init__(self):
+        if self.requested_model:
+            self.message = (
+                f"Model '{self.requested_model}' is not available on the hosted gateway. "
+                "For the full marketplace catalog, run a self-custody node: "
+                "https://nodedocs.mor.org/consumers/quickstart"
+            )
+        self.details = {
+            "requested_model": self.requested_model,
+            "resolved_id": self.resolved_id,
+            "code": self.code,
+        }
+        super().__post_init__()

--- a/src/core/model_routing.py
+++ b/src/core/model_routing.py
@@ -1,9 +1,13 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Set, Tuple
 
 from .direct_model_service import direct_model_service
 from .config import settings
 from .logging_config import get_models_logger
-from .model_errors import ModelNearMissError, ModelTypeMismatchError
+from .model_errors import (
+    ModelNearMissError,
+    ModelNotAllowlistedError,
+    ModelTypeMismatchError,
+)
 
 # Configure logger
 logger = get_models_logger()
@@ -13,6 +17,55 @@ DEFAULT_MODEL = getattr(settings, 'DEFAULT_FALLBACK_MODEL', "mistral-31-24b")
 DEFAULT_EMBEDDINGS_MODEL = getattr(settings, 'DEFAULT_FALLBACK_EMBEDDINGS_MODEL', "text-embedding-bge-m3")
 DEFAULT_TTS_MODEL = getattr(settings, 'DEFAULT_FALLBACK_TTS_MODEL', "tts-kokoro")
 DEFAULT_STT_MODEL = getattr(settings, 'DEFAULT_FALLBACK_STT_MODEL', "whisper-1")
+
+
+def parse_model_id_csv(raw: Optional[str]) -> Set[str]:
+    """Parse a comma-separated list of model blockchain IDs."""
+    if not raw:
+        return set()
+    return {m.strip() for m in raw.split(",") if m.strip()}
+
+
+def parse_model_aliases(raw: Optional[str]) -> Dict[str, str]:
+    """Parse SESSION_MODEL_ALIASES into lowercased alias → target map.
+
+    Accepts ``alias=target``, ``alias->target``, or ``alias→target`` pairs,
+    comma-separated. Values keep their configured casing (names or 0x IDs).
+    """
+    if not raw:
+        return {}
+    out: Dict[str, str] = {}
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        key: Optional[str] = None
+        value: Optional[str] = None
+        for sep in ("→", "->", "="):
+            if sep in part:
+                left, right = part.split(sep, 1)
+                key, value = left.strip(), right.strip()
+                break
+        if not key or not value:
+            continue
+        out[key.lower()] = value
+    return out
+
+
+def apply_model_alias(
+    requested_model: str,
+    aliases: Optional[Dict[str, str]] = None,
+) -> Tuple[str, Optional[str]]:
+    """Return (possibly rewritten name, matched alias key or None)."""
+    if aliases is None:
+        aliases = parse_model_aliases(getattr(settings, "SESSION_MODEL_ALIASES", "") or "")
+    if not aliases or not requested_model:
+        return requested_model, None
+    hit = aliases.get(requested_model.lower())
+    if hit:
+        return hit, requested_model.lower()
+    return requested_model, None
+
 
 class ModelRouter:
     """
@@ -31,6 +84,27 @@ class ModelRouter:
         logger.info("Initialized ModelRouter with DirectModelService",
                    event_type="model_router_init")
         # No initialization needed - DirectModelService handles all caching
+
+    def _allowed_model_ids(self) -> Set[str]:
+        return parse_model_id_csv(getattr(settings, "SESSION_ALLOWED_MODEL_IDS", "") or "")
+
+    def _ensure_allowlisted(self, requested_model: Optional[str], resolved_id: str) -> str:
+        """Raise ModelNotAllowlistedError when curated allowlist is active."""
+        allowed = self._allowed_model_ids()
+        if not allowed:
+            return resolved_id
+        if resolved_id in allowed:
+            return resolved_id
+        logger.warning(
+            "Resolved model is outside hosted-gateway allowlist",
+            requested_model=requested_model,
+            resolved_id=resolved_id,
+            event_type="model_not_allowlisted",
+        )
+        raise ModelNotAllowlistedError(
+            requested_model=requested_model,
+            resolved_id=resolved_id,
+        )
     
     async def get_target_model(self, requested_model: Optional[str], type: Optional[str] = "LLM") -> str:
         """
@@ -45,6 +119,7 @@ class ModelRouter:
         Raises:
             ModelTypeMismatchError: Model exists but is wrong type for the endpoint
             ModelNearMissError: Name not found, but close catalog matches exist
+            ModelNotAllowlistedError: Resolved ID outside SESSION_ALLOWED_MODEL_IDS
         """
         # return "0xe086adc275c99e32bb10b0aff5e8bfc391aad18cbb184727a75b2569149425c6"
         logger.info("Getting target model for requested model",
@@ -60,11 +135,21 @@ class ModelRouter:
             logger.info("Resolved to default model ID",
                        default_model_id=default_id,
                        event_type="default_model_resolved")
-            return default_id
+            return self._ensure_allowlisted(DEFAULT_MODEL, default_id)
+
+        aliased_model, alias_key = apply_model_alias(requested_model)
+        if alias_key:
+            logger.info(
+                "Applied model family alias",
+                requested_model=requested_model,
+                alias_key=alias_key,
+                aliased_model=aliased_model,
+                event_type="model_alias_applied",
+            )
             
         # Try to resolve using DirectModelService
         try:
-            resolved_id = await direct_model_service.resolve_model_id(requested_model)
+            resolved_id = await direct_model_service.resolve_model_id(aliased_model)
 
             # A resolved model must be usable by this endpoint type. Without
             # this check a chat completion naming an EMBEDDING model opens a
@@ -94,17 +179,20 @@ class ModelRouter:
             if resolved_id:
                 logger.info("Found model mapping",
                            requested_model=requested_model,
+                           aliased_model=aliased_model if alias_key else None,
                            resolved_id=resolved_id,
                            event_type="model_resolved")
-                return resolved_id
+                return self._ensure_allowlisted(requested_model, resolved_id)
 
             # Not found — if we have close matches, hard-fail with suggestions
             # so agents stop / alert instead of continuing on the default model.
-            # True unknowns (no near miss) still soft-fallback for operability.
+            # True unknowns (no near miss) still soft-fallback for operability
+            # unless a curated allowlist is active (then 503, no silent rewrite).
             logger.warning("Model not found in active models",
                           requested_model=requested_model,
+                          aliased_model=aliased_model if alias_key else None,
                           event_type="model_not_found")
-            suggestions = await direct_model_service.suggest_models(requested_model)
+            suggestions = await direct_model_service.suggest_models(aliased_model)
             if suggestions:
                 logger.warning("Near-miss model name; returning suggestions",
                               requested_model=requested_model,
@@ -113,6 +201,12 @@ class ModelRouter:
                 raise ModelNearMissError(
                     requested_model=requested_model,
                     suggestions=suggestions,
+                )
+
+            if self._allowed_model_ids():
+                raise ModelNotAllowlistedError(
+                    requested_model=requested_model,
+                    resolved_id=None,
                 )
 
             model_mapping = await direct_model_service.get_model_mapping()
@@ -128,13 +222,18 @@ class ModelRouter:
                           default_model_id=default_id,
                           event_type="default_model_fallback")
             return default_id
-        except (ModelTypeMismatchError, ModelNearMissError):
+        except (ModelTypeMismatchError, ModelNearMissError, ModelNotAllowlistedError):
             raise
         except Exception as e:
             logger.error("Error resolving model - using default fallback",
                         requested_model=requested_model,
                         error=str(e),
                         event_type="model_resolution_error")
+            if self._allowed_model_ids():
+                raise ModelNotAllowlistedError(
+                    requested_model=requested_model,
+                    resolved_id=None,
+                ) from e
             # Fall back to default model
             default_id = await self._get_default_model_id(type)
             logger.warning("Using default model ID due to error",

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -21,6 +21,7 @@ from .session_routing_service import (
     SessionMorReservedError,
     SessionPriceGateError,
     SessionPremiumBudgetError,
+    SessionAllowlistError,
 )
 
 __all__ = [
@@ -42,4 +43,5 @@ __all__ = [
     "SessionMorReservedError",
     "SessionPriceGateError",
     "SessionPremiumBudgetError",
+    "SessionAllowlistError",
 ]

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -135,6 +135,13 @@ class SessionPremiumBudgetError(SessionGatewayCapacityError):
         self.budget_mor = budget_mor
 
 
+class SessionAllowlistError(SessionGatewayCapacityError):
+    """Raised when model_id is outside SESSION_ALLOWED_MODEL_IDS."""
+
+    def __init__(self, message: str, model_id: Optional[str] = None):
+        super().__init__(message, model_id=model_id, category="allowlist")
+
+
 class SessionRoutingService:
     """
     Service for routing requests to sessions and managing session lifecycle.
@@ -201,6 +208,11 @@ class SessionRoutingService:
         raw = settings.SESSION_PREMIUM_MODEL_IDS or ""
         return {m.strip() for m in raw.split(",") if m.strip()}
 
+    def _get_allowed_models(self) -> set:
+        """Curated APIGW allowlist. Empty means disabled (full catalog)."""
+        raw = getattr(settings, "SESSION_ALLOWED_MODEL_IDS", "") or ""
+        return {m.strip() for m in raw.split(",") if m.strip()}
+
     def _is_warm_model(self, model_id: str) -> bool:
         """True if model_id is in SESSION_PREFERRED_MODELS (warm pool)."""
         return model_id in self._get_preferred_models()
@@ -208,6 +220,23 @@ class SessionRoutingService:
     def _is_premium_model(self, model_id: str) -> bool:
         """True if model_id is in SESSION_PREMIUM_MODEL_IDS (showcase lane)."""
         return model_id in self._get_premium_models()
+
+    async def _ensure_allowlist_allows_open(self, model_id: str) -> None:
+        """Refuse opens/claims when curated allowlist is set and ID is absent."""
+        allowed = self._get_allowed_models()
+        if not allowed:
+            return
+        if model_id in allowed:
+            return
+        logger.warning(
+            "Model outside hosted-gateway allowlist; refusing open",
+            model_id=model_id,
+            event_type="session_allowlist_refuse",
+        )
+        raise SessionAllowlistError(
+            f"This model is not available on the hosted gateway. {P2P_OFFRAMP_HINT}",
+            model_id=model_id,
+        )
 
     def _soft_cap_for_model(self, model_id: str) -> int:
         """Per-model OPEN soft cap. 0 means unlimited (cap disabled)."""
@@ -696,12 +725,16 @@ class SessionRoutingService:
             omit_provider=omit_provider,
         )
 
-        # Resolve model to blockchain ID
+        # Resolve model to blockchain ID (aliases + allowlist enforced in router)
         model_id = await model_router.get_target_model(requested_model, type=model_type)
         route_logger = route_logger.bind(model_id=model_id)
 
         route_logger.info("Routing request to session",
                          event_type="route_request_start")
+
+        # Defense in depth for automation / direct open paths; also blocks
+        # idle claim of leftover sessions after an allowlist shrink.
+        await self._ensure_allowlist_allows_open(model_id)
 
         # Standard-lane max-bid PPS gate runs before idle claim so leftover
         # over-gate sessions are not reused after the gate is enabled.
@@ -1046,7 +1079,9 @@ class SessionRoutingService:
         # Soft-cap + lane gates (request path also checks before calling here;
         # automation / preferred scale-up enters directly). Cap/watermark/
         # PPS/budget 0 = disabled for that gate. Warm skips LWM + PPS; premium
-        # skips PPS but is limited by daily daylock budget.
+        # skips PPS but is limited by daily daylock budget. Empty allowlist
+        # disables curated-catalog refusal.
+        await self._ensure_allowlist_allows_open(model_id)
         await self._ensure_soft_cap_allows_open(model_id)
         await self._ensure_mor_low_water_allows_open(model_id)
         await self._ensure_max_bid_pps_allows_open(model_id)

--- a/tests/unit/test_session_allowlist_aliases.py
+++ b/tests/unit/test_session_allowlist_aliases.py
@@ -1,0 +1,109 @@
+"""Tests for curated allowlist + family aliases."""
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.core.model_errors import ModelNotAllowlistedError
+from src.core.model_routing import (
+    ModelRouter,
+    apply_model_alias,
+    parse_model_aliases,
+    parse_model_id_csv,
+)
+from src.services.session_routing_service import (
+    SessionAllowlistError,
+    SessionRoutingService,
+)
+
+
+def test_parse_model_aliases_supports_separators():
+    raw = "claude-opus-4.8=Claude Opus 4.7,glm-5->glm-5.2,kimi-k2.5→Kimi K3"
+    aliases = parse_model_aliases(raw)
+    assert aliases["claude-opus-4.8"] == "Claude Opus 4.7"
+    assert aliases["glm-5"] == "glm-5.2"
+    assert aliases["kimi-k2.5"] == "Kimi K3"
+
+
+def test_apply_model_alias_case_insensitive():
+    aliases = {"claude opus 4.8": "Claude Opus 4.7", "glm-5:web": "glm-5.2:web"}
+    rewritten, key = apply_model_alias("Claude Opus 4.8", aliases)
+    assert rewritten == "Claude Opus 4.7"
+    assert key == "claude opus 4.8"
+    rewritten, key = apply_model_alias("GLM-5:web", aliases)
+    assert rewritten == "glm-5.2:web"
+    assert key == "glm-5:web"
+
+
+def test_parse_model_id_csv():
+    assert parse_model_id_csv(" 0xa ,0xb, ") == {"0xa", "0xb"}
+    assert parse_model_id_csv("") == set()
+    assert parse_model_id_csv(None) == set()
+
+
+@pytest.fixture
+def service():
+    return SessionRoutingService()
+
+
+async def test_allowlist_empty_skips(service):
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_ALLOWED_MODEL_IDS = ""
+        await service._ensure_allowlist_allows_open("0xanything")
+
+
+async def test_allowlist_refuses_unknown(service):
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_ALLOWED_MODEL_IDS = "0xallowed"
+        with pytest.raises(SessionAllowlistError) as exc_info:
+            await service._ensure_allowlist_allows_open("0xother")
+    assert exc_info.value.model_id == "0xother"
+    assert exc_info.value.category == "allowlist"
+    assert "nodedocs.mor.org" in exc_info.value.message
+
+
+async def test_allowlist_allows_listed(service):
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_ALLOWED_MODEL_IDS = "0xallowed,0xother"
+        await service._ensure_allowlist_allows_open("0xallowed")
+
+
+async def test_router_allowlist_and_alias():
+    router = ModelRouter()
+    with patch("src.core.model_routing.settings") as mock_settings, patch(
+        "src.core.model_routing.direct_model_service"
+    ) as mock_dms, patch(
+        "src.core.model_routing.apply_model_alias",
+        wraps=apply_model_alias,
+    ):
+        mock_settings.SESSION_ALLOWED_MODEL_IDS = "0xopus47"
+        mock_settings.SESSION_MODEL_ALIASES = "claude-opus-4.8=Claude Opus 4.7"
+        mock_dms.resolve_model_id = AsyncMock(return_value="0xopus47")
+        mock_dms.get_model_name_from_id = AsyncMock(return_value="Claude Opus 4.7")
+        mock_dms.get_model_mapping_type = AsyncMock(
+            return_value={"claude opus 4.7": "LLM"}
+        )
+
+        resolved = await router.get_target_model("claude-opus-4.8", type="LLM")
+        assert resolved == "0xopus47"
+        mock_dms.resolve_model_id.assert_awaited_once_with("Claude Opus 4.7")
+
+
+async def test_router_refuses_non_allowlisted():
+    router = ModelRouter()
+    with patch("src.core.model_routing.settings") as mock_settings, patch(
+        "src.core.model_routing.direct_model_service"
+    ) as mock_dms:
+        mock_settings.SESSION_ALLOWED_MODEL_IDS = "0xallowed"
+        mock_settings.SESSION_MODEL_ALIASES = ""
+        mock_dms.resolve_model_id = AsyncMock(return_value="0xother")
+        mock_dms.get_model_name_from_id = AsyncMock(return_value="other")
+        mock_dms.get_model_mapping_type = AsyncMock(return_value={"other": "LLM"})
+
+        with pytest.raises(ModelNotAllowlistedError) as exc_info:
+            await router.get_target_model("other", type="LLM")
+        assert exc_info.value.resolved_id == "0xother"
+        assert exc_info.value.status_code == 503


### PR DESCRIPTION
## Summary
- Add `SESSION_ALLOWED_MODEL_IDS` curated allowlist (empty = disabled / full catalog)
- Add `SESSION_MODEL_ALIASES` (`alias=target`) applied before resolve; preserves `:web` when a twin exists
- Non-allowlisted models → **503** `model_unavailable` + P2P off-ramp (same as LWM / premium budget)
- Soft-cap **429**, premium daylock budget, and optional PPS gate unchanged
- Unit tests for alias parsing + allowlist refusal

Pairs with Infra wiring (prd 19-ID catalog, warm×6, premium Opus 4.7 / GPT-5.4 / Sonnet 4.6 / Kimi K3). Plan: `Morpheus-Infra/.cursor/scripts/APIGW_MOR_LANES.md`.

## Test plan
- [ ] Empty allowlist → no behavior change
- [ ] Allowlisted model opens; non-listed → 503
- [ ] `claude-opus-4.8` / `glm-5:web` / `kimi-k2.5` alias to allowlisted targets
- [ ] Soft cap still 429; premium budget still 503 when exhausted
- [ ] Near-miss typos still 400 with suggestions


Made with [Cursor](https://cursor.com)