### PR TITLE
fix(security): R5 oauth2-redirect XSS + R1 deleted-account JWT recreate

### DIFF
--- a/alembic/versions/2026_08_04_0001_add_deleted_users_tombstone.py
+++ b/alembic/versions/2026_08_04_0001_add_deleted_users_tombstone.py
@@ -1,0 +1,37 @@
+"""Add deleted_users tombstone table for auth revocation
+
+Revision ID: add_deleted_users
+Revises: add_provider_address
+Create Date: 2026-08-04 00:01:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "add_deleted_users"
+down_revision: Union[str, None] = "add_provider_address"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "deleted_users",
+        sa.Column("cognito_user_id", sa.String(), nullable=False),
+        sa.Column("former_user_id", sa.Integer(), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        sa.PrimaryKeyConstraint("cognito_user_id"),
+    )
+    op.create_index(
+        "ix_deleted_users_deleted_at",
+        "deleted_users",
+        ["deleted_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_deleted_users_deleted_at", table_name="deleted_users")
+    op.drop_table("deleted_users")

--- a/src/api/v1/auth/index.py
+++ b/src/api/v1/auth/index.py
@@ -14,6 +14,7 @@ from ....schemas.api_key import APIKeyCreate, APIKeyResponse, APIKeyDB
 from ....dependencies import CurrentUser, get_current_user
 from ....db.models import User
 from ....services.cognito_service import cognito_service
+from ....services.cache_service import cache_service
 from ....core.config import settings
 from ....core.logging_config import get_auth_logger
 
@@ -191,10 +192,14 @@ async def delete_user_account(
     """
     Delete the current user's account and all associated data.
 
-    Always: deletes API keys, user record (cascades: wallet_links, chats, etc.).
-    Cognito: only in production (ENVIRONMENT in production|prod|prd) do we delete
-    the Cognito user. In dev/test/non-prod we leave the Cognito identity intact so
-    "Delete account" in TEST cannot accidentally nuke the user's real identity.
+    Always:
+      - deletes API keys and the user record (cascades: wallet_links, chats, etc.)
+      - writes a Cognito-id tombstone so lingering JWTs cannot recreate the user
+      - Cognito AdminUserGlobalSignOut (invalidates refresh tokens)
+    Cognito AdminDeleteUser: only in production (ENVIRONMENT in production|prod|prd).
+    In dev/test/non-prod the Cognito identity is preserved so "Delete account" in
+    TEST cannot accidentally nuke a shared real identity — but the tombstone still
+    blocks API access for that sub until cleared.
 
     Requires JWT Bearer authentication.
     """
@@ -207,14 +212,20 @@ async def delete_user_account(
                            event_type="user_deletion_start")
     
     try:
-        # 1. Delete all API keys manually (no cascade relationship)
+        # 1. Tombstone first so concurrent JWT auth cannot recreate mid-delete.
+        await user_crud.tombstone_deleted_user(
+            db, cognito_user_id=cognito_user_id, former_user_id=user_id
+        )
+        await cache_service.delete("user", cognito_user_id)
+
+        # 2. Delete all API keys manually (no cascade relationship)
         delete_user_logger.info("Deleting user API keys", event_type="user_api_keys_deletion_start")
         api_keys_deleted = await api_key_crud.delete_all_user_api_keys(db, user_id)
         delete_user_logger.info("User API keys deleted",
                                api_keys_deleted=api_keys_deleted,
                                event_type="user_api_keys_deleted")
         
-        # 2. Delete the user (this will cascade delete related data)
+        # 3. Delete the user (this will cascade delete related data)
         delete_user_logger.info("Deleting user record", event_type="user_record_deletion_start")
         deleted_user = await user_crud.delete_user(db, user_id)
         
@@ -229,7 +240,7 @@ async def delete_user_account(
         delete_user_logger.info("User record deleted successfully",
                                event_type="user_record_deleted")
 
-        # 3. Delete Cognito user only in production; in dev/test leave identity intact
+        # 4. Revoke Cognito sessions; delete Cognito user only in production
         env_lower = (settings.ENVIRONMENT or "").strip().lower()
         is_production = env_lower in ("production", "prod", "prd")
         if is_production:
@@ -238,13 +249,17 @@ async def delete_user_account(
                                    event_type="cognito_deletion_start")
             cognito_deletion_result = await cognito_service.delete_user(cognito_user_id)
         else:
-            delete_user_logger.info("Skipping Cognito delete (non-production); identity preserved",
-                                   environment=settings.ENVIRONMENT,
-                                   event_type="cognito_deletion_skipped")
+            delete_user_logger.info(
+                "Non-production: global sign-out only; Cognito identity preserved",
+                environment=settings.ENVIRONMENT,
+                event_type="cognito_deletion_skipped",
+            )
+            sign_out = await cognito_service.global_sign_out(cognito_user_id)
             cognito_deletion_result = {
                 "success": True,
                 "skipped": True,
                 "reason": "non_production",
+                "global_sign_out": sign_out,
             }
 
         # Prepare response data

--- a/src/crud/user.py
+++ b/src/crud/user.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.db.models import User
+from src.db.models import User, DeletedUser
 from src.services.cache_service import cache_service
 from src.core.logging_config import get_auth_logger
 
@@ -18,8 +18,58 @@ async def get_user_by_cognito_id(db: AsyncSession, cognito_user_id: str) -> Opti
     result = await db.execute(select(User).where(User.cognito_user_id == cognito_user_id))
     return result.scalars().first()
 
+
+async def is_cognito_id_tombstoned(db: AsyncSession, cognito_user_id: str) -> bool:
+    """Return True if this Cognito identity was previously deleted."""
+    result = await db.execute(
+        select(DeletedUser.cognito_user_id).where(
+            DeletedUser.cognito_user_id == cognito_user_id
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def tombstone_deleted_user(
+    db: AsyncSession, *, cognito_user_id: str, former_user_id: Optional[int]
+) -> DeletedUser:
+    """Record a deletion tombstone so JWT auth cannot recreate the user."""
+    existing = await db.execute(
+        select(DeletedUser).where(DeletedUser.cognito_user_id == cognito_user_id)
+    )
+    row = existing.scalars().first()
+    if row:
+        return row
+
+    row = DeletedUser(
+        cognito_user_id=cognito_user_id,
+        former_user_id=former_user_id,
+        deleted_at=datetime.utcnow(),
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    logger.info(
+        "User deletion tombstone recorded",
+        cognito_user_id=cognito_user_id,
+        former_user_id=former_user_id,
+        event_type="user_tombstone_created",
+    )
+    return row
+
+
 async def create_user_from_cognito(db: AsyncSession, cognito_user_id: str) -> User:
-    """Create a new user row keyed by cognito_user_id (no PII stored)."""
+    """Create a new user row keyed by cognito_user_id (no PII stored).
+
+    Raises ValueError if the cognito_user_id is tombstoned (deleted account).
+    """
+    if await is_cognito_id_tombstoned(db, cognito_user_id):
+        logger.warning(
+            "Refusing to create user for tombstoned Cognito identity",
+            cognito_user_id=cognito_user_id,
+            event_type="user_create_blocked_tombstone",
+        )
+        raise ValueError("cognito_user_id is tombstoned")
+
     db_user = User(
         cognito_user_id=cognito_user_id,
         is_active=True,

--- a/src/db/models/__init__.py
+++ b/src/db/models/__init__.py
@@ -11,6 +11,7 @@ from .base import Base
 # User and authentication models
 from .user import User
 from .api_key import APIKey
+from .deleted_user import DeletedUser
 
 # Session models
 from .routed_session import RoutedSession, SessionState
@@ -37,6 +38,7 @@ __all__ = [
     # User models
     "User",
     "APIKey",
+    "DeletedUser",
     # Session
     "RoutedSession",
     "SessionState",

--- a/src/db/models/deleted_user.py
+++ b/src/db/models/deleted_user.py
@@ -1,0 +1,19 @@
+"""Tombstone for deleted Cognito identities.
+
+Prevents JWT auth from auto-recreating a user row after account deletion
+while an access token is still valid.
+"""
+from sqlalchemy import Column, Integer, String, DateTime
+from datetime import datetime
+
+from .base import Base
+
+
+class DeletedUser(Base):
+    """Immutable tombstone keyed by cognito_user_id."""
+
+    __tablename__ = "deleted_users"
+
+    cognito_user_id = Column(String, primary_key=True, nullable=False)
+    former_user_id = Column(Integer, nullable=True)
+    deleted_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -45,8 +45,11 @@ async def get_current_user(
 ) -> User:
     """
     Validate Cognito JWT token and return the associated user.
-    Creates user record if first time login.
-    
+
+    First-time login creates a user row only when the Cognito identity is not
+    tombstoned. Deleted accounts cannot be recreated from a lingering JWT.
+    Inactive users are rejected.
+
     In local testing mode, bypasses Cognito and returns test user.
     """
     # Local testing bypass
@@ -152,6 +155,20 @@ async def get_current_user(
                              event_type="jwt_validation_error")
             raise credentials_exception
             
+        # Reject deleted identities even if the JWT is still cryptographically valid.
+        if await user_crud.is_cognito_id_tombstoned(db, cognito_user_id):
+            auth_logger.warning(
+                "Rejected JWT for tombstoned Cognito identity",
+                cognito_user_id=cognito_user_id,
+                event_type="user_tombstoned",
+            )
+            await cache_service.delete("user", cognito_user_id)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Account has been deleted",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
         # Try to get user from cache first
         cached_user = await cache_service.get("user", cognito_user_id)
         if cached_user:
@@ -183,7 +200,15 @@ async def get_current_user(
                 await cache_service.set("user", cognito_user_id, user_cache_data, ttl_seconds=600)
         
         if not user:
-            user = await user_crud.create_user_from_cognito(db, cognito_user_id)
+            # First-time login only — never recreate tombstoned identities.
+            try:
+                user = await user_crud.create_user_from_cognito(db, cognito_user_id)
+            except ValueError:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Account has been deleted",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
             auth_logger.info("Created new user from Cognito token",
                            cognito_user_id=cognito_user_id,
                            event_type="user_creation")
@@ -199,6 +224,20 @@ async def get_current_user(
                 'rate_limit_multiplier': user.rate_limit_multiplier,
             }
             await cache_service.set("user", cognito_user_id, user_cache_data, ttl_seconds=600)
+
+        if not getattr(user, "is_active", True):
+            auth_logger.warning(
+                "Rejected JWT for inactive user",
+                user_id=getattr(user, "id", None),
+                cognito_user_id=cognito_user_id,
+                event_type="user_inactive",
+            )
+            await cache_service.delete("user", cognito_user_id)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Account is inactive",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
         
         return user
         

--- a/src/main.py
+++ b/src/main.py
@@ -926,237 +926,197 @@ async def cors_check(request: Request):
 @app.get("/docs/oauth2-redirect", include_in_schema=False)
 async def swagger_ui_oauth2_redirect(request: Request):
     """
-    OAuth2 redirect endpoint that automatically exchanges code for token and integrates with Swagger UI.
+    OAuth2 redirect for Swagger UI.
+
+    Security (R5): never interpolate raw query params into JavaScript/HTML.
+    Values are embedded only via json.dumps (JS-safe) / html.escape (HTML-safe).
+    The page reads code/state from location.search as a second line of defense.
     """
+    import html
+    import json
     import httpx
-    
-    # Extract the authorization code and state
+
     code = request.query_params.get("code")
     state = request.query_params.get("state")
     error = request.query_params.get("error")
-    
+    error_description = request.query_params.get("error_description", "Unknown error")
+
     if error:
-        return HTMLResponse(content=f"""
-        <!DOCTYPE html>
-        <html>
-        <head><title>OAuth2 Error</title></head>
-        <body>
-            <h1>OAuth2 Authentication Error</h1>
-            <p><strong>Error:</strong> {error}</p>
-            <p><strong>Description:</strong> {request.query_params.get("error_description", "Unknown error")}</p>
-            <p><a href="/docs">Return to API Documentation</a></p>
-        </body>
-        </html>
-        """)
-    
-    # If we have a code, exchange it for an access token
+        safe_error = html.escape(error, quote=True)
+        safe_desc = html.escape(error_description, quote=True)
+        return HTMLResponse(
+            content=f"""<!DOCTYPE html>
+<html lang="en-US">
+<head><meta charset="utf-8"><title>OAuth2 Error</title></head>
+<body>
+  <h1>OAuth2 Authentication Error</h1>
+  <p><strong>Error:</strong> {safe_error}</p>
+  <p><strong>Description:</strong> {safe_desc}</p>
+  <p><a href="/docs">Return to API Documentation</a></p>
+</body>
+</html>""",
+            headers={
+                "Content-Security-Policy": "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'",
+                "X-Content-Type-Options": "nosniff",
+                "Referrer-Policy": "no-referrer",
+            },
+        )
+
     access_token = None
-    token_error = None
     if code:
         try:
-            # Exchange the authorization code for tokens
             token_url = f"https://{settings.COGNITO_DOMAIN}/oauth2/token"
-            
             data = {
                 "grant_type": "authorization_code",
                 "client_id": settings.COGNITO_CLIENT_ID,
                 "code": code,
-                "redirect_uri": f"{settings.BASE_URL}/docs/oauth2-redirect"
+                "redirect_uri": f"{settings.BASE_URL}/docs/oauth2-redirect",
             }
-            
-            headers = {
-                "Content-Type": "application/x-www-form-urlencoded"
-            }
-            
             async with httpx.AsyncClient() as client:
-                response = await client.post(token_url, data=data, headers=headers)
-                
+                response = await client.post(
+                    token_url,
+                    data=data,
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                )
             if response.status_code == 200:
-                tokens = response.json()
-                access_token = tokens.get("access_token")
+                access_token = response.json().get("access_token")
                 auth_logger.info("Token exchange successful", event_type="oauth_token_exchange")
             else:
-                error_body = response.text
-                auth_logger.warning("Token exchange failed",
-                                   status_code=response.status_code,
-                                   event_type="oauth_token_exchange_failed")
-                token_error = f"HTTP {response.status_code}: {error_body}"
-                
+                auth_logger.warning(
+                    "Token exchange failed",
+                    status_code=response.status_code,
+                    event_type="oauth_token_exchange_failed",
+                )
         except Exception as e:
-            auth_logger.error("Token exchange exception",
-                            error=str(e),
-                            event_type="oauth_token_exchange_error")
-            token_error = str(e)
-    
-    # Build the HTML with proper JavaScript variable interpolation
-    js_access_token = f'"{access_token}"' if access_token else '""'
-    js_auth_code = f'"{code}"' if code else '""'
-    js_state = f'"{state}"' if state else '""'
-    
-    html_content = f"""
-    <!DOCTYPE html>
-    <html lang="en-US">
-    <head>
-        <title>OAuth2 Redirect</title>
-        <style>
-            body {{ 
-                font-family: Arial, sans-serif; 
-                padding: 40px; 
-                text-align: center;
-                background: #f8f9fa;
-            }}
-            .success {{ color: #28a745; }}
-            .spinner {{ 
-                border: 4px solid #f3f3f3; 
-                border-top: 4px solid #28a745; 
-                border-radius: 50%; 
-                width: 40px; 
-                height: 40px; 
-                animation: spin 1s linear infinite; 
-                margin: 20px auto; 
-            }}
-            @keyframes spin {{ 
-                0% {{ transform: rotate(0deg); }} 
-                100% {{ transform: rotate(360deg); }} 
-            }}
-            .token-display {{
-                background: #f8f9fa;
-                border: 2px solid #28a745;
-                border-radius: 8px;
-                padding: 15px;
-                margin: 20px auto;
-                max-width: 600px;
-                word-break: break-all;
-                font-family: monospace;
-                font-size: 12px;
-            }}
-        </style>
-    </head>
-    <body>
-        <h1 class="success">✅ Authentication Successful!</h1>
-        <div class="spinner" id="spinner"></div>
-        <p id="status">Processing OAuth2 authentication...</p>
-        
-        <script>
-            'use strict';
-            
-            const accessToken = {js_access_token};
-            const authCode = {js_auth_code};
-            const authState = {js_state};
-            
-            function run() {{
-                console.log('🔍 OAuth2 redirect processing...');
-                console.log('🔑 Access token available:', accessToken ? 'Yes' : 'No');
-                console.log('🔍 Authorization code:', authCode ? 'Present' : 'Missing');
-                console.log('🪟 Window opener:', window.opener ? 'Present' : 'Null');
-                
-                // Hide spinner
-                document.getElementById('spinner').style.display = 'none';
-                
-                // Try to handle as popup first
-                console.log('🔍 Popup detection:', {{
-                    hasOpener: !!window.opener,
-                    hasSwaggerCallback: !!(window.opener && window.opener.swaggerUIRedirectOauth2)
-                }});
-                
-                if (window.opener && window.opener.swaggerUIRedirectOauth2) {{
-                    console.log('🔄 Handling as popup window');
-                    try {{
-                        const oauth2 = window.opener.swaggerUIRedirectOauth2;
-                        
-                        // If we have an access token, pass it directly
-                        if (accessToken) {{
-                            console.log('✅ Passing access token to Swagger UI');
-                            oauth2.callback({{
-                                auth: oauth2.auth,
-                                token: {{
-                                    access_token: accessToken,
-                                    token_type: 'Bearer'
-                                }},
-                                redirectUrl: oauth2.redirectUrl
-                            }});
-                        }} else {{
-                            // Fall back to code-based flow
-                            oauth2.callback({{
-                                auth: oauth2.auth,
-                                code: authCode,
-                                state: authState,
-                                redirectUrl: oauth2.redirectUrl
-                            }});
-                        }}
-                        
-                        document.getElementById('status').innerHTML = `
-                            <div>
-                                <h2 style="color: #28a745;">✅ Authentication Complete!</h2>
-                                <p>Token has been applied to the main window.</p>
-                                <button onclick="window.close()" style="background: #007bff; color: white; padding: 12px 24px; border: none; border-radius: 6px; font-size: 16px; cursor: pointer; margin-top: 15px;">
-                                    Close Window
-                                </button>
-                                <p style="color: #6c757d; margin-top: 10px; font-size: 14px;">Window will close automatically in 3 seconds...</p>
-                            </div>
-                        `;
-                        setTimeout(() => window.close(), 3000);
-                        return;
-                    }} catch (e) {{
-                        console.error('❌ Popup callback error:', e);
-                    }}
-                }}
-                
-                // Handle as new tab OR popup - simplified approach
-                console.log('🔄 Handling authentication completion');
-                
-                if (accessToken) {{
-                    // Store token in localStorage 
-                    console.log('✅ Storing token in localStorage...');
-                    localStorage.setItem('swagger_oauth_token', accessToken);
-                    localStorage.setItem('swagger_oauth_token_timestamp', Date.now().toString());
-                    
-                    // Always show close button - no redirect, no detection needed
-                    console.log('🔄 Showing close button');
-                    document.getElementById('status').innerHTML = `
-                        <div>
-                            <h2 style="color: #28a745;">✅ Authentication Complete!</h2>
-                            <p>Token has been applied to the main window.</p>
-                            <button onclick="window.close()" style="background: #6c757d; color: white; padding: 12px 24px; border: none; border-radius: 6px; font-size: 16px; cursor: pointer; margin-top: 15px;">
-                                Close Window
-                            </button>
-                            <p style="color: #6c757d; margin-top: 10px; font-size: 14px;">Window will close automatically in 3 seconds...</p>
-                        </div>
-                    `;
-                    
-                    // Auto-close after 3 seconds using the same code as the button
-                    setTimeout(() => {{
-                        window.close();
-                    }}, 3000);
-                }} else {{
-                    // No token - show error
-                    document.getElementById('status').innerHTML = `
-                        <div>
-                            <h2 style="color: #dc3545;">❌ Token Exchange Failed</h2>
-                            <p>Authentication succeeded but automatic token exchange failed.</p>
-                            <p>Authorization code: <code>${{authCode || "None"}}</code></p>
-                            <p>Please try the manual process or contact support.</p>
-                            <p style="margin-top: 30px;">
-                                <a href="/docs" style="background: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">Return to API Docs</a>
-                            </p>
-                        </div>
-                    `;
-                }}
-            }}
-            
-            if (document.readyState !== 'loading') {{
-                run();
+            auth_logger.error(
+                "Token exchange exception",
+                error=str(e),
+                event_type="oauth_token_exchange_error",
+            )
+
+    # JSON embedding is XSS-safe for string values; also neutralize HTML breakout
+    # sequences that json.dumps does not escape by default (e.g. </script>).
+    boot_json = (
+        json.dumps(
+            {
+                "accessToken": access_token or "",
+                "authCode": code or "",
+                "authState": state or "",
+            },
+            ensure_ascii=True,
+        )
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+    html_content = f"""<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8">
+  <title>OAuth2 Redirect</title>
+  <style>
+    body {{ font-family: Arial, sans-serif; padding: 40px; text-align: center; background: #f8f9fa; }}
+    .success {{ color: #28a745; }}
+    .spinner {{
+      border: 4px solid #f3f3f3; border-top: 4px solid #28a745; border-radius: 50%;
+      width: 40px; height: 40px; animation: spin 1s linear infinite; margin: 20px auto;
+    }}
+    @keyframes spin {{ 0% {{ transform: rotate(0deg); }} 100% {{ transform: rotate(360deg); }} }}
+  </style>
+</head>
+<body>
+  <h1 class="success">Authentication Successful</h1>
+  <div class="spinner" id="spinner"></div>
+  <p id="status">Processing OAuth2 authentication...</p>
+  <script id="oauth-boot" type="application/json">{boot_json}</script>
+  <script>
+    'use strict';
+    (function () {{
+      function readBoot() {{
+        try {{
+          var el = document.getElementById('oauth-boot');
+          return el ? JSON.parse(el.textContent || '{{}}') : {{}};
+        }} catch (e) {{
+          return {{}};
+        }}
+      }}
+      // Prefer server-provided JSON; fall back to location.search (never eval query strings).
+      var boot = readBoot();
+      var params = new URLSearchParams(window.location.search);
+      var accessToken = boot.accessToken || '';
+      var authCode = boot.authCode || params.get('code') || '';
+      var authState = boot.authState || params.get('state') || '';
+
+      function setStatus(html) {{
+        document.getElementById('status').innerHTML = html;
+      }}
+
+      function run() {{
+        document.getElementById('spinner').style.display = 'none';
+
+        if (window.opener && window.opener.swaggerUIRedirectOauth2) {{
+          try {{
+            var oauth2 = window.opener.swaggerUIRedirectOauth2;
+            if (accessToken) {{
+              oauth2.callback({{
+                auth: oauth2.auth,
+                token: {{ access_token: accessToken, token_type: 'Bearer' }},
+                redirectUrl: oauth2.redirectUrl
+              }});
             }} else {{
-                document.addEventListener('DOMContentLoaded', function () {{
-                    run();
-                }});
+              oauth2.callback({{
+                auth: oauth2.auth,
+                code: authCode,
+                state: authState,
+                redirectUrl: oauth2.redirectUrl
+              }});
             }}
-        </script>
-    </body>
-    </html>
-    """
-    
-    return HTMLResponse(content=html_content)
+            setStatus('<div><h2 style="color:#28a745;">Authentication Complete</h2><p>You can close this window.</p></div>');
+            setTimeout(function () {{ window.close(); }}, 2000);
+            return;
+          }} catch (e) {{
+            console.error('Popup callback error', e);
+          }}
+        }}
+
+        if (accessToken) {{
+          localStorage.setItem('swagger_oauth_token', accessToken);
+          localStorage.setItem('swagger_oauth_token_timestamp', Date.now().toString());
+          setStatus('<div><h2 style="color:#28a745;">Authentication Complete</h2><p>Token stored for Swagger UI.</p><p><a href="/docs">Return to API Docs</a></p></div>');
+          setTimeout(function () {{ window.close(); }}, 2000);
+        }} else {{
+          setStatus('<div><h2 style="color:#dc3545;">Token Exchange Failed</h2><p>Please return to the docs and try again.</p><p><a href="/docs">Return to API Docs</a></p></div>');
+        }}
+      }}
+
+      if (document.readyState !== 'loading') {{
+        run();
+      }} else {{
+        document.addEventListener('DOMContentLoaded', run);
+      }}
+    }})();
+  </script>
+</body>
+</html>"""
+
+    return HTMLResponse(
+        content=html_content,
+        headers={
+            # Inline script required for Swagger popup callback; boot data is JSON-encoded.
+            "Content-Security-Policy": (
+                "default-src 'none'; "
+                "script-src 'unsafe-inline'; "
+                "style-src 'unsafe-inline'; "
+                "base-uri 'none'; "
+                "form-action 'none'; "
+                "frame-ancestors 'none'"
+            ),
+            "X-Content-Type-Options": "nosniff",
+            "Referrer-Policy": "no-referrer",
+            "X-Frame-Options": "DENY",
+        },
+    )
 
 # Note: Custom OAuth2 login endpoint removed - now using standard Swagger UI OAuth2 flow
 

--- a/src/services/cognito_service.py
+++ b/src/services/cognito_service.py
@@ -68,6 +68,69 @@ class CognitoUserService:
                           event_type="cognito_get_user_unexpected_error")
             return None
 
+    async def global_sign_out(self, cognito_user_id: str) -> Dict[str, Any]:
+        """
+        Invalidate all refresh tokens for the user (AdminUserGlobalSignOut).
+
+        Outstanding access tokens remain cryptographically valid until expiry;
+        callers must also tombstone / deactivate the app user so JWT auth fails.
+        """
+        sign_out_logger = logger.bind(cognito_user_id=cognito_user_id)
+        try:
+            sign_out_logger.info(
+                "Attempting Cognito global sign-out",
+                user_pool_id=settings.COGNITO_USER_POOL_ID,
+                event_type="cognito_global_sign_out_start",
+            )
+            self.cognito_client.admin_user_global_sign_out(
+                UserPoolId=settings.COGNITO_USER_POOL_ID,
+                Username=cognito_user_id,
+            )
+            sign_out_logger.info(
+                "Cognito global sign-out succeeded",
+                event_type="cognito_global_sign_out_success",
+            )
+            return {"success": True, "cognito_user_id": cognito_user_id}
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_message = e.response["Error"]["Message"]
+            if error_code == "UserNotFoundException":
+                sign_out_logger.warning(
+                    "Cognito user not found for global sign-out",
+                    error_code=error_code,
+                    event_type="cognito_global_sign_out_not_found",
+                )
+                return {
+                    "success": True,
+                    "cognito_user_id": cognito_user_id,
+                    "warning": True,
+                    "message": "User not found in Cognito",
+                }
+            sign_out_logger.error(
+                "Cognito global sign-out failed",
+                error_code=error_code,
+                error_message=error_message,
+                event_type="cognito_global_sign_out_failed",
+            )
+            return {
+                "success": False,
+                "cognito_user_id": cognito_user_id,
+                "error": error_message,
+                "error_code": error_code,
+            }
+        except Exception as e:
+            sign_out_logger.error(
+                "Unexpected error during Cognito global sign-out",
+                error=str(e),
+                event_type="cognito_global_sign_out_unexpected_error",
+            )
+            return {
+                "success": False,
+                "cognito_user_id": cognito_user_id,
+                "error": str(e),
+                "error_code": "UnknownError",
+            }
+
     async def delete_user(self, cognito_user_id: str) -> Dict[str, Any]:
         """
         Delete a user from Cognito User Pool (admin operation using task role).
@@ -77,6 +140,9 @@ class CognitoUserService:
             delete_logger.info("Attempting to delete Cognito user",
                               user_pool_id=settings.COGNITO_USER_POOL_ID,
                               event_type="cognito_user_deletion_start")
+
+            # Invalidate refresh tokens before removing the identity.
+            await self.global_sign_out(cognito_user_id)
             
             response = self.cognito_client.admin_delete_user(
                 UserPoolId=settings.COGNITO_USER_POOL_ID,


### PR DESCRIPTION
## Summary
- **R5:** Stop reflecting raw OAuth `code`/`state`/`error` into the Swagger `/docs/oauth2-redirect` HTML/JS. Boot data is JSON-encoded (with HTML breakout neutralization), error text is `html.escape`d, and response headers add a tight CSP / nosniff / no-referrer.
- **R1:** On account delete, write a `deleted_users` Cognito-sub tombstone, clear the user cache, and GlobalSignOut before Cognito delete (prod). JWT auth rejects tombstoned subs and refuses auto-recreate; inactive users are also rejected.
- Alembic migration `add_deleted_users` adds the tombstone table.

## Test plan
- [ ] Hit `/docs/oauth2-redirect?error=<script>alert(1)</script>` — error page shows escaped text, no script execution
- [ ] Hit `/docs/oauth2-redirect?code=x";alert(1)//&state=y` — page loads without JS breakout; token exchange fails cleanly
- [ ] Delete account with valid JWT → subsequent JWT calls return 401 "Account has been deleted"
- [ ] Same Cognito identity cannot recreate app user via first-login path while tombstoned
- [ ] Migration applies cleanly on deploy (`deleted_users` table present)
- [ ] Swagger OAuth login still completes in a happy-path popup/new-tab flow


Made with [Cursor](https://cursor.com)