### PR TITLE
fix(auth): re-raise HTTPException in get_current_user (R1 follow-up)

### DIFF
--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -241,6 +241,9 @@ async def get_current_user(
         
         return user
         
+    except HTTPException:
+        # Intentional 401/403 (tombstone, inactive, credentials) must not become 500.
+        raise
     except httpx.HTTPError as e:
         auth_logger.error("Could not fetch Cognito JWKS",
                          error=str(e),


### PR DESCRIPTION
## Summary
- Broader scan of #304 found that `get_current_user` catches all `Exception`s and converts them to 500.
- FastAPI `HTTPException` subclasses `Exception`, so R1 tombstone/inactive rejects (and existing credentials failures raised inside the try) never returned clean 401s.
- Match the existing pattern already used in `get_api_key_auth`: `except HTTPException: raise`.

## Test plan
- [ ] Tombstoned Cognito JWT → **401** `Account has been deleted` (not 500)
- [ ] `is_active=false` JWT → **401** `Account is inactive` (not 500)
- [ ] Normal JWT login still works


Made with [Cursor](https://cursor.com)