### PR TITLE
fix(sessions): premium daylock close-truth + open-stake holds

### DIFF
--- a/alembic/versions/2026_08_05_0001_add_stake_daylock_to_routed_sessions.py
+++ b/alembic/versions/2026_08_05_0001_add_stake_daylock_to_routed_sessions.py
@@ -1,0 +1,36 @@
+"""Add stake_mor and daylock_mor to routed_sessions
+
+Persists on-chain escrow at open and receipt-true (or pro-rata fallback)
+daylock at close so ops can sum burn by model / lane. Premium gate uses
+stake_mor on OPEN/CLOSING premium rows as in-flight holds.
+
+Revision ID: add_stake_daylock
+Revises: add_deleted_users
+Create Date: 2026-08-05 00:01:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "add_stake_daylock"
+down_revision: Union[str, None] = "add_deleted_users"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "routed_sessions",
+        sa.Column("stake_mor", sa.Numeric(36, 18), nullable=True),
+    )
+    op.add_column(
+        "routed_sessions",
+        sa.Column("daylock_mor", sa.Numeric(36, 18), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("routed_sessions", "daylock_mor")
+    op.drop_column("routed_sessions", "stake_mor")

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -258,8 +258,9 @@ class Settings(BaseSettings):
 
     # --- Premium showcase lane ------------------------------------------------
     # Comma-separated model blockchain IDs exempt from the PPS gate but limited
-    # by SESSION_PREMIUM_DAILY_BUDGET_MOR (day-locked / used MOR, metered on
-    # session close, UTC day). Soft cap still applies (DEFAULT). Empty / budget
+    # by SESSION_PREMIUM_DAILY_BUDGET_MOR (day-locked MOR, UTC day). Gate uses
+    # Redis actuals (from close-tx / pro-rata) + SUM(stake_mor) on OPEN/CLOSING
+    # premium rows as holds. Soft cap still applies (DEFAULT). Empty / budget
     # 0 disables the premium lane (IDs would then hit the PPS gate like
     # standard models if listed).
     SESSION_PREMIUM_MODEL_IDS: str = Field(
@@ -268,10 +269,17 @@ class Settings(BaseSettings):
     SESSION_PREMIUM_DAILY_BUDGET_MOR: float = Field(
         default=float(os.getenv("SESSION_PREMIUM_DAILY_BUDGET_MOR", "0"))
     )
-    # Day-lock stake amplification used to estimate used MOR on close:
-    # daylock ≈ pps × elapsed_seconds × factor (observed ~338 on Base).
+    # Kept for stake-sizing / expensive-tier docs; premium daylock meter no
+    # longer uses max_pps × elapsed × factor (that inflated Redis vs chain).
     SESSION_STAKE_FACTOR: float = Field(
         default=float(os.getenv("SESSION_STAKE_FACTOR", "338"))
+    )
+    # Optional: decode close-tx MOR Transfer(to=consumer) for receipt-true
+    # daylock (= stake − returned). When unset, meter falls back to
+    # stake × lived / sched from getSession. Base mainnet MOR + C-Node wallet.
+    MOR_TOKEN_ADDRESS: str | None = Field(default=os.getenv("MOR_TOKEN_ADDRESS"))
+    SESSION_CONSUMER_WALLET_ADDRESS: str | None = Field(
+        default=os.getenv("SESSION_CONSUMER_WALLET_ADDRESS")
     )
 
     # --- Expensive-model session tier ---------------------------------------

--- a/src/db/models/routed_session.py
+++ b/src/db/models/routed_session.py
@@ -9,7 +9,7 @@ This model supports the Session Routing Service with:
 
 Note: Rows are only created after a session is successfully opened (no OPENING state).
 """
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, Index
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Index, Numeric
 from datetime import datetime, timezone
 import enum
 
@@ -68,6 +68,12 @@ class RoutedSession(Base):
     # On-chain provider address serving this session (0x hex). Used by
     # failover to exclude the failed provider when opening the retry session.
     provider_address = Column(String(42), nullable=True)
+
+    # On-chain escrow at open (MOR). Premium OPEN/CLOSING rows sum into the
+    # daily budget "hold". Nullable for rows opened before this column existed.
+    stake_mor = Column(Numeric(36, 18), nullable=True)
+    # Daylocked MOR attributed at close (receipt truth or pro-rata fallback).
+    daylock_mor = Column(Numeric(36, 18), nullable=True)
     
     # Indexes for efficient queries
     __table_args__ = (

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -129,10 +129,12 @@ class SessionPremiumBudgetError(SessionGatewayCapacityError):
         model_id: Optional[str] = None,
         spent_mor: float = 0,
         budget_mor: float = 0,
+        holds_mor: float = 0,
     ):
         super().__init__(message, model_id=model_id, category="premium_budget")
         self.spent_mor = spent_mor
         self.budget_mor = budget_mor
+        self.holds_mor = holds_mor
 
 
 class SessionAllowlistError(SessionGatewayCapacityError):
@@ -455,11 +457,39 @@ class SessionRoutingService:
                 event_type="premium_daylock_redis_write_error",
             )
 
+    async def _sum_premium_open_stake_mor(self) -> float:
+        """SUM(stake_mor) for premium sessions still OPEN or CLOSING (holds)."""
+        premium_ids = list(self._get_premium_models())
+        if not premium_ids:
+            return 0.0
+        try:
+            async with get_db() as db:
+                result = await db.execute(
+                    select(func.coalesce(func.sum(RoutedSession.stake_mor), 0))
+                    .where(
+                        RoutedSession.model_id.in_(premium_ids),
+                        RoutedSession.state.in_(
+                            [SessionState.OPEN.value, SessionState.CLOSING.value]
+                        ),
+                    )
+                )
+                raw = result.scalar_one()
+                return float(raw or 0.0)
+        except Exception as e:
+            logger.warning(
+                "Premium open-stake hold sum failed",
+                error=str(e),
+                event_type="premium_daylock_holds_sum_error",
+            )
+            return 0.0
+
     async def _ensure_premium_budget_allows_open(self, model_id: str) -> None:
-        """Refuse new premium opens when UTC-day daylock budget is exhausted.
+        """Refuse new premium opens when actual + open holds exhaust the budget.
 
         Non-premium models skip. Budget 0 disables the premium lane check
         (premium IDs would still need to pass PPS unless also warm).
+        Holds = SUM(stake_mor) on OPEN/CLOSING premium rows (max possible
+        daylock still in flight). Actual = Redis close-truth counter.
         """
         if not self._is_premium_model(model_id):
             return
@@ -477,11 +507,15 @@ class SessionRoutingService:
                 spent_mor=0,
                 budget_mor=budget,
             )
-        if spent >= budget:
+        holds = await self._sum_premium_open_stake_mor()
+        committed = float(spent) + float(holds)
+        if committed >= budget:
             logger.warning(
                 "Premium daily daylock budget exhausted; refusing open",
                 model_id=model_id,
                 spent_mor=spent,
+                holds_mor=holds,
+                committed_mor=committed,
                 budget_mor=budget,
                 event_type="session_premium_budget_exhausted",
             )
@@ -491,61 +525,224 @@ class SessionRoutingService:
                 model_id=model_id,
                 spent_mor=spent,
                 budget_mor=budget,
+                holds_mor=holds,
             )
 
-    async def _record_premium_daylock_on_close(self, session: RoutedSession) -> None:
-        """Meter estimated daylocked MOR for a premium session at close time."""
-        if not self._is_premium_model(session.model_id):
-            return
-        budget = float(settings.SESSION_PREMIUM_DAILY_BUDGET_MOR or 0)
-        if budget <= 0:
-            return
+    @staticmethod
+    def _parse_session_stake_mor(status: Any) -> Optional[float]:
+        """Stake from getSessionStatus body in MOR, or None."""
+        if not isinstance(status, dict):
+            return None
+        session = status.get("session") or status.get("Session") or status
+        if not isinstance(session, dict):
+            return None
+        raw = session.get("Stake", session.get("stake"))
+        if raw is None:
+            return None
+        try:
+            wei = int(str(raw).strip().strip('"'))
+            return wei / 1e18
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _parse_session_unix(status: Any, *keys: str) -> Optional[int]:
+        """First positive unix timestamp found under session for the given keys."""
+        if not isinstance(status, dict):
+            return None
+        session = status.get("session") or status.get("Session") or status
+        if not isinstance(session, dict):
+            return None
+        for key in keys:
+            raw = session.get(key)
+            if raw is None:
+                continue
+            try:
+                value = int(raw)
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                return value
+        return None
+
+    @staticmethod
+    def _daylock_prorata_mor(
+        stake_mor: float,
+        opened_at: Optional[int],
+        ends_at: Optional[int],
+        closed_at: Optional[int],
+    ) -> float:
+        """Pro-rata of escrow: stake * lived / sched (early-close daylock proxy)."""
+        if stake_mor <= 0:
+            return 0.0
+        if not opened_at or not ends_at or ends_at <= opened_at:
+            return 0.0
+        end = closed_at if closed_at and closed_at > 0 else int(
+            datetime.now(timezone.utc).timestamp()
+        )
+        # Late path / past endsAt with full unused return ≈ 0 when closed after
+        # endsAt and release window logic would unlock — approximate: if closed
+        # strictly after endsAt, treat as 0 daylock (stake already returned).
+        if end > ends_at:
+            return 0.0
+        lived = max(0, min(end, ends_at) - opened_at)
+        sched = max(1, ends_at - opened_at)
+        daylock = stake_mor * (lived / sched)
+        return max(0.0, min(stake_mor, daylock))
+
+    def _extract_close_tx_hash(self, close_result: Any) -> Optional[str]:
+        if not isinstance(close_result, dict):
+            return None
+        for key in ("tx", "Tx", "txHash", "TxHash", "hash"):
+            raw = close_result.get(key)
+            if isinstance(raw, str) and raw.startswith("0x") and len(raw) >= 66:
+                return raw
+        return None
+
+    async def _daylock_from_close_receipt(
+        self, tx_hash: str, stake_mor: float
+    ) -> Optional[float]:
+        """daylock = stake − MOR Transfer(to=consumer) on the close tx, or None."""
+        token = (settings.MOR_TOKEN_ADDRESS or "").strip()
+        consumer = (settings.SESSION_CONSUMER_WALLET_ADDRESS or "").strip()
+        rpc = (settings.WEB3_PROVIDER_URL or "").strip()
+        if not token or not consumer or not rpc or stake_mor <= 0:
+            return None
+
+        def _decode() -> Optional[float]:
+            from web3 import Web3
+
+            w3 = Web3(Web3.HTTPProvider(rpc))
+            receipt = w3.eth.get_transaction_receipt(tx_hash)
+            if receipt is None:
+                return None
+            status = int(receipt.get("status", 0) if hasattr(receipt, "get") else receipt["status"])
+            if status != 1:
+                return None
+            transfer_topic = Web3.keccak(text="Transfer(address,address,uint256)")
+            transfer_topic_hex = Web3.to_hex(transfer_topic).lower()
+            token_addr = Web3.to_checksum_address(token)
+            consumer_addr = Web3.to_checksum_address(consumer)
+            returned_wei = 0
+            for log in receipt["logs"]:
+                if Web3.to_checksum_address(log["address"]) != token_addr:
+                    continue
+                topics = log["topics"]
+                if not topics or len(topics) < 3:
+                    continue
+                if Web3.to_hex(topics[0]).lower() != transfer_topic_hex:
+                    continue
+                to_addr = Web3.to_checksum_address(
+                    "0x" + Web3.to_hex(topics[2])[-40:]
+                )
+                if to_addr != consumer_addr:
+                    continue
+                data = log["data"]
+                if isinstance(data, (bytes, bytearray)):
+                    returned_wei += int.from_bytes(data, "big")
+                else:
+                    returned_wei += int(str(data), 16)
+            returned_mor = returned_wei / 1e18
+            return max(0.0, stake_mor - returned_mor)
 
         try:
-            now = datetime.now(timezone.utc).replace(tzinfo=None)
-            created = session.created_at or now
-            if created.tzinfo is not None:
-                created = created.replace(tzinfo=None)
-            elapsed_s = max(0.0, (now - created).total_seconds())
+            return await asyncio.to_thread(_decode)
+        except Exception as e:
+            logger.warning(
+                "Close-tx daylock decode failed; will fallback",
+                tx_hash=tx_hash,
+                error=str(e),
+                event_type="daylock_receipt_decode_error",
+            )
+            return None
 
-            # Cap by scheduled session length when known.
-            sched_s = None
-            if session.expires_at and session.created_at:
-                exp = session.expires_at
-                if exp.tzinfo is not None:
-                    exp = exp.replace(tzinfo=None)
-                sched_s = max(1.0, (exp - created).total_seconds())
-            if sched_s is not None:
-                elapsed_s = min(elapsed_s, sched_s)
+    async def _record_daylock_on_close(
+        self,
+        session: RoutedSession,
+        close_result: Any = None,
+    ) -> None:
+        """Persist daylock_mor for any session; Redis-meter premium actuals.
 
-            max_pps = await self._get_model_max_price_per_second(session.model_id)
-            if max_pps is None or max_pps <= 0:
+        Prefer close-tx Transfer truth (stake − returned). Fallback: pro-rata
+        stake × lived / sched from getSession / row timestamps.
+        """
+        try:
+            status = None
+            try:
+                status = await proxy_router_service.getSessionStatus(session.id)
+            except Exception as e:
                 logger.warning(
-                    "Premium close meter skipped; no PPS",
+                    "getSessionStatus for daylock meter failed",
                     session_id=session.id,
-                    model_id=session.model_id,
-                    event_type="premium_daylock_meter_skip",
+                    error=str(e),
+                    event_type="daylock_meter_status_error",
                 )
-                return
 
-            factor = float(settings.SESSION_STAKE_FACTOR or 338)
-            daylock = max_pps * elapsed_s * factor
-            await self._add_premium_daylock_spent(daylock)
+            stake_mor = self._parse_session_stake_mor(status)
+            if stake_mor is None and session.stake_mor is not None:
+                stake_mor = float(session.stake_mor)
+            if stake_mor is None or stake_mor < 0:
+                stake_mor = 0.0
+
+            opened_at = self._parse_session_unix(
+                status, "OpenedAt", "openedAt"
+            )
+            ends_at = self._parse_session_unix(status, "EndsAt", "endsAt")
+            closed_at = self._parse_session_unix(
+                status, "ClosedAt", "closedAt"
+            )
+
+            daylock: Optional[float] = None
+            source = "prorata"
+            tx_hash = self._extract_close_tx_hash(close_result)
+            if tx_hash and stake_mor > 0:
+                daylock = await self._daylock_from_close_receipt(tx_hash, stake_mor)
+                if daylock is not None:
+                    source = "receipt"
+
+            if daylock is None:
+                if opened_at is None and session.created_at is not None:
+                    created = session.created_at
+                    if created.tzinfo is not None:
+                        created = created.replace(tzinfo=None)
+                    opened_at = int(created.replace(tzinfo=timezone.utc).timestamp())
+                if ends_at is None and session.expires_at is not None:
+                    exp = session.expires_at
+                    if exp.tzinfo is not None:
+                        exp = exp.replace(tzinfo=None)
+                    # expires_at includes SESSION_EXPIRY_BUFFER; still OK as sched proxy
+                    ends_at = int(exp.replace(tzinfo=timezone.utc).timestamp())
+                daylock = self._daylock_prorata_mor(
+                    stake_mor, opened_at, ends_at, closed_at
+                )
+                source = "prorata"
+
+            daylock = max(0.0, float(daylock or 0.0))
+            session.daylock_mor = daylock
+            if session.stake_mor is None and stake_mor > 0:
+                session.stake_mor = stake_mor
+
+            is_premium = self._is_premium_model(session.model_id)
+            budget = float(settings.SESSION_PREMIUM_DAILY_BUDGET_MOR or 0)
+            if is_premium and budget > 0 and daylock > 0:
+                await self._add_premium_daylock_spent(daylock)
+
             logger.info(
-                "Recorded premium daylock on close",
+                "Recorded session daylock on close",
                 session_id=session.id,
                 model_id=session.model_id,
-                elapsed_s=round(elapsed_s, 1),
-                max_pps=max_pps,
-                daylock_mor=round(daylock, 3),
-                event_type="premium_daylock_recorded",
+                stake_mor=round(stake_mor, 6),
+                daylock_mor=round(daylock, 6),
+                meter_source=source,
+                premium=is_premium,
+                event_type="daylock_recorded",
             )
         except Exception as e:
             logger.warning(
-                "Premium daylock meter failed",
+                "Daylock meter failed",
                 session_id=getattr(session, "id", None),
                 error=str(e),
-                event_type="premium_daylock_meter_error",
+                event_type="daylock_meter_error",
             )
 
     # =========================================================================
@@ -863,25 +1060,10 @@ class SessionRoutingService:
             invalidate_logger.warning("Session invalidated after prompt failure",
                                       reason=reason,
                                       event_type="session_invalidated")
-            # Meter premium daylock before background close (needs model_id /
-            # created_at from the row). Best-effort.
-            try:
-                row = await db.execute(
-                    select(RoutedSession).where(RoutedSession.id == session_id)
-                )
-                session_row = row.scalar_one_or_none()
-                if session_row is not None:
-                    await self._record_premium_daylock_on_close(session_row)
-            except Exception as e:
-                invalidate_logger.warning(
-                    "Premium meter on invalidate failed",
-                    error=str(e),
-                    event_type="premium_daylock_invalidate_meter_error",
-                )
             # Close on-chain in the background: close needs a (possibly
             # failing) provider-report RPC plus a blockchain tx — too slow
             # to block the user's retry on. closeSession tolerates
-            # already-closed sessions.
+            # already-closed sessions. Daylock is metered after close lands.
             task = asyncio.create_task(self._close_invalidated_session(session_id))
             self._background_close_tasks.add(task)
             task.add_done_callback(self._background_close_tasks.discard)
@@ -892,11 +1074,29 @@ class SessionRoutingService:
         try:
             # Same wallet/nonce sequence as opens -> route through the adaptive
             # throttle so a storm's closes don't collide with its opens.
-            await self._run_onchain(
+            close_result = await self._run_onchain(
                 lambda: proxy_router_service.closeSession(session_id),
                 op_name="closeSession",
                 op_logger=logger,
             )
+            try:
+                async with get_db() as db:
+                    row = await db.execute(
+                        select(RoutedSession).where(RoutedSession.id == session_id)
+                    )
+                    session_row = row.scalar_one_or_none()
+                    if session_row is not None:
+                        await self._record_daylock_on_close(
+                            session_row, close_result=close_result
+                        )
+                        await db.commit()
+            except Exception as e:
+                logger.warning(
+                    "Daylock meter on invalidate close failed",
+                    session_id=session_id,
+                    error=str(e),
+                    event_type="daylock_invalidate_meter_error",
+                )
             logger.info("Invalidated session closed on proxy router",
                         session_id=session_id,
                         event_type="invalidated_session_closed")
@@ -1161,6 +1361,7 @@ class SessionRoutingService:
             # (omitProvider) instead of possibly reopening on the same
             # impaired provider.
             provider_address = self._parse_provider_address(status)
+            stake_mor = self._parse_session_stake_mor(status)
 
             # Create session record only after successful open
             now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -1185,7 +1386,8 @@ class SessionRoutingService:
                     created_at=now,
                     updated_at=now,
                     endpoint=endpoint,
-                    provider_address=provider_address
+                    provider_address=provider_address,
+                    stake_mor=stake_mor,
                 )
                 db.add(session)
                 await db.commit()
@@ -1253,16 +1455,16 @@ class SessionRoutingService:
                          event_type="session_close_start")
         
         try:
-            # Meter premium daylock on close (used MOR), then close on-chain.
-            await self._record_premium_daylock_on_close(session)
-
             # Close on-chain via the adaptive throttle (shared wallet/nonce
             # with every other on-chain session op on this replica).
-            await self._run_onchain(
+            close_result = await self._run_onchain(
                 lambda: proxy_router_service.closeSession(session.id),
                 op_name="closeSession",
                 op_logger=close_logger,
             )
+
+            # Meter daylock after the close lands (receipt truth / pro-rata).
+            await self._record_daylock_on_close(session, close_result=close_result)
 
             # Mark as CLOSED
             session.state = SessionState.CLOSED
@@ -1678,8 +1880,6 @@ class SessionRoutingService:
                        expired_at=session.expires_at.isoformat(),
                        event_type="closing_expired_session")
 
-            await self._record_premium_daylock_on_close(session)
-            
             # Mark as EXPIRED rather than going through close flow
             session.state = SessionState.EXPIRED
             session.updated_at = now
@@ -1687,10 +1887,13 @@ class SessionRoutingService:
             # Still try to close on proxy router (via the adaptive throttle,
             # shared wallet/nonce with all other on-chain ops).
             try:
-                await self._run_onchain(
+                close_result = await self._run_onchain(
                     lambda: proxy_router_service.closeSession(session.id),
                     op_name="closeSession",
                     op_logger=logger,
+                )
+                await self._record_daylock_on_close(
+                    session, close_result=close_result
                 )
 
             except Exception as e:

--- a/tests/unit/test_session_premium_budget.py
+++ b/tests/unit/test_session_premium_budget.py
@@ -1,4 +1,4 @@
-"""Tests for premium showcase daily daylock budget (metered on close)."""
+"""Tests for premium showcase daylock budget (actual + open-stake holds)."""
 import os
 import sys
 from datetime import datetime, timedelta, timezone
@@ -41,6 +41,7 @@ async def test_budget_zero_skips(service):
 
 async def test_premium_allowed_under_budget(service):
     service._get_premium_daylock_spent = AsyncMock(return_value=1000.0)
+    service._sum_premium_open_stake_mor = AsyncMock(return_value=200.0)
 
     with patch("src.services.session_routing_service.settings") as mock_settings:
         mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
@@ -48,8 +49,9 @@ async def test_premium_allowed_under_budget(service):
         await service._ensure_premium_budget_allows_open("0xprem")
 
 
-async def test_premium_refused_at_budget(service):
-    service._get_premium_daylock_spent = AsyncMock(return_value=15000.0)
+async def test_premium_refused_when_actual_plus_holds_at_budget(service):
+    service._get_premium_daylock_spent = AsyncMock(return_value=14000.0)
+    service._sum_premium_open_stake_mor = AsyncMock(return_value=1000.0)
 
     with patch("src.services.session_routing_service.settings") as mock_settings:
         mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
@@ -59,42 +61,161 @@ async def test_premium_refused_at_budget(service):
 
     err = exc_info.value
     assert err.category == "premium_budget"
-    assert err.spent_mor == 15000.0
+    assert err.spent_mor == 14000.0
+    assert err.holds_mor == 1000.0
     assert "exhausted" in err.message
     assert "nodedocs.mor.org" in err.message
 
 
-async def test_record_premium_daylock_on_close(service):
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
+async def test_premium_allowed_when_actual_high_but_holds_zero(service):
+    """Early closes free holds; actual alone under budget still allows opens."""
+    service._get_premium_daylock_spent = AsyncMock(return_value=14999.0)
+    service._sum_premium_open_stake_mor = AsyncMock(return_value=0.0)
+
+    with patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
+        mock_settings.SESSION_PREMIUM_DAILY_BUDGET_MOR = 15000
+        await service._ensure_premium_budget_allows_open("0xprem")
+
+
+def test_daylock_prorata_early_close(service):
+    # stake 100, lived half of schedule → 50
+    daylock = service._daylock_prorata_mor(
+        stake_mor=100.0,
+        opened_at=1_000_000,
+        ends_at=1_000_000 + 1200,
+        closed_at=1_000_000 + 600,
+    )
+    assert daylock == pytest.approx(50.0)
+
+
+def test_daylock_prorata_full_duration(service):
+    daylock = service._daylock_prorata_mor(
+        stake_mor=100.0,
+        opened_at=1_000_000,
+        ends_at=1_000_000 + 1200,
+        closed_at=1_000_000 + 1200,
+    )
+    assert daylock == pytest.approx(100.0)
+
+
+def test_daylock_prorata_late_close_zero(service):
+    daylock = service._daylock_prorata_mor(
+        stake_mor=100.0,
+        opened_at=1_000_000,
+        ends_at=1_000_000 + 1200,
+        closed_at=1_000_000 + 1201,
+    )
+    assert daylock == 0.0
+
+
+async def test_record_daylock_premium_prorata_meters_redis(service):
+    now = int(datetime.now(timezone.utc).timestamp())
     session = MagicMock()
     session.id = "0xsid"
     session.model_id = "0xprem"
-    session.created_at = now - timedelta(seconds=600)
-    session.expires_at = now + timedelta(seconds=1200)
+    session.stake_mor = 100.0
+    session.daylock_mor = None
+    session.created_at = datetime.fromtimestamp(now - 600, tz=timezone.utc).replace(
+        tzinfo=None
+    )
+    session.expires_at = datetime.fromtimestamp(now + 600, tz=timezone.utc).replace(
+        tzinfo=None
+    )
 
-    service._get_model_max_price_per_second = AsyncMock(return_value=0.0005)
+    status = {
+        "session": {
+            "Stake": str(int(100 * 1e18)),
+            "OpenedAt": now - 600,
+            "EndsAt": now + 600,
+            "ClosedAt": now,
+        }
+    }
     service._add_premium_daylock_spent = AsyncMock()
+    service._daylock_from_close_receipt = AsyncMock(return_value=None)
 
-    with patch("src.services.session_routing_service.settings") as mock_settings:
+    with patch(
+        "src.services.session_routing_service.proxy_router_service.getSessionStatus",
+        new=AsyncMock(return_value=status),
+    ), patch("src.services.session_routing_service.settings") as mock_settings:
         mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
         mock_settings.SESSION_PREMIUM_DAILY_BUDGET_MOR = 15000
-        mock_settings.SESSION_STAKE_FACTOR = 338
-        await service._record_premium_daylock_on_close(session)
+        mock_settings.MOR_TOKEN_ADDRESS = None
+        mock_settings.SESSION_CONSUMER_WALLET_ADDRESS = None
+        mock_settings.WEB3_PROVIDER_URL = None
+        await service._record_daylock_on_close(session, close_result={"tx": "0x" + "ab" * 32})
 
-    # 0.0005 * 600 * 338 = 101.4
+    # lived 600 / sched 1200 * 100 = 50
+    assert float(session.daylock_mor) == pytest.approx(50.0)
     service._add_premium_daylock_spent.assert_awaited_once()
-    amount = service._add_premium_daylock_spent.await_args.args[0]
-    assert amount == pytest.approx(101.4, rel=1e-3)
+    assert service._add_premium_daylock_spent.await_args.args[0] == pytest.approx(50.0)
 
 
-async def test_record_skips_non_premium(service):
+async def test_record_daylock_warm_persists_but_skips_redis(service):
+    now = int(datetime.now(timezone.utc).timestamp())
     session = MagicMock()
-    session.model_id = "0xother"
+    session.id = "0xwarm"
+    session.model_id = "0xwarm"
+    session.stake_mor = 40.0
+    session.daylock_mor = None
+    session.created_at = None
+    session.expires_at = None
+
+    status = {
+        "session": {
+            "Stake": str(int(40 * 1e18)),
+            "OpenedAt": now - 300,
+            "EndsAt": now + 900,
+            "ClosedAt": now,
+        }
+    }
     service._add_premium_daylock_spent = AsyncMock()
 
-    with patch("src.services.session_routing_service.settings") as mock_settings:
+    with patch(
+        "src.services.session_routing_service.proxy_router_service.getSessionStatus",
+        new=AsyncMock(return_value=status),
+    ), patch("src.services.session_routing_service.settings") as mock_settings:
         mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
         mock_settings.SESSION_PREMIUM_DAILY_BUDGET_MOR = 15000
-        await service._record_premium_daylock_on_close(session)
+        mock_settings.MOR_TOKEN_ADDRESS = None
+        mock_settings.SESSION_CONSUMER_WALLET_ADDRESS = None
+        mock_settings.WEB3_PROVIDER_URL = None
+        await service._record_daylock_on_close(session)
 
+    assert float(session.daylock_mor) == pytest.approx(10.0)  # 300/1200 * 40
     service._add_premium_daylock_spent.assert_not_awaited()
+
+
+async def test_record_daylock_receipt_preferred(service):
+    now = int(datetime.now(timezone.utc).timestamp())
+    session = MagicMock()
+    session.id = "0xsid"
+    session.model_id = "0xprem"
+    session.stake_mor = 100.0
+    session.daylock_mor = None
+    session.created_at = None
+    session.expires_at = None
+
+    status = {
+        "session": {
+            "Stake": str(int(100 * 1e18)),
+            "OpenedAt": now - 600,
+            "EndsAt": now + 600,
+            "ClosedAt": now,
+        }
+    }
+    service._add_premium_daylock_spent = AsyncMock()
+    service._daylock_from_close_receipt = AsyncMock(return_value=33.5)
+
+    with patch(
+        "src.services.session_routing_service.proxy_router_service.getSessionStatus",
+        new=AsyncMock(return_value=status),
+    ), patch("src.services.session_routing_service.settings") as mock_settings:
+        mock_settings.SESSION_PREMIUM_MODEL_IDS = "0xprem"
+        mock_settings.SESSION_PREMIUM_DAILY_BUDGET_MOR = 15000
+        await service._record_daylock_on_close(
+            session, close_result={"tx": "0x" + "cd" * 32}
+        )
+
+    assert float(session.daylock_mor) == pytest.approx(33.5)
+    service._add_premium_daylock_spent.assert_awaited_once_with(33.5)


### PR DESCRIPTION
## Summary
- Meter daylock from close-tx truth (`stake − MOR Transfer` to consumer) with pro-rata `stake × lived / sched` fallback — drops the inflated `max_pps × elapsed × 338` Redis counter.
- Gate premium opens on `Redis actual + SUM(stake_mor)` for OPEN/CLOSING premium rows (holds = open escrow; early close frees headroom).
- Persist `stake_mor` / `daylock_mor` on all routed sessions for by-model / warm vs premium burn SQL.

## Test plan
- [x] `pytest tests/unit/test_session_premium_budget.py` (11 passed)
- [ ] Deploy to DEV; confirm alembic adds columns
- [ ] Open/close a short premium session; check `daylock_mor` and Redis `apigw:premium_daylock:*`
- [ ] After promote: if prd Redis still inflated, `DEL apigw:premium_daylock:YYYY-MM-DD`


Made with [Cursor](https://cursor.com)