### PR TITLE
fix: do not expose source_ip in transactions response

### DIFF
--- a/src/schemas/billing.py
+++ b/src/schemas/billing.py
@@ -2,7 +2,7 @@
 Pydantic schemas for billing/credits API.
 """
 from typing import Optional, List, Annotated
-from pydantic import BaseModel, Field, ConfigDict, PlainSerializer
+from pydantic import BaseModel, Field, ConfigDict, PlainSerializer, field_validator
 from datetime import datetime, date
 from decimal import Decimal
 from enum import Enum
@@ -93,6 +93,29 @@ class BalanceResponse(BaseModel):
 
 # === Ledger Entry Schemas ===
 
+# payment_metadata is a free-form JSONB column that also carries server-side-only
+# data: the fraud-control source_ip (signup bonus), internal Stripe identifiers
+# (customer_id, payment_intent_id, subscription_id, client_reference_id), Coinbase
+# settlement economics (settlement_net / settlement_fee), and the raw `payments`
+# array from legacy Coinbase charges (payer wallet addresses and tx hashes).
+# Only the descriptive keys below may leave the API; everything else is redacted.
+PUBLIC_PAYMENT_METADATA_KEYS = frozenset({
+    "type",
+    "source",
+    "checkout_session_id",
+    "invoice_id",
+    "payment_link_id",
+    "charge_code",
+    "network",
+    "currency",
+    "status",
+    "description",
+    "created_at",
+    "updated_at",
+    "expires_at",
+})
+
+
 class LedgerEntryResponse(BaseModel):
     """Response for a single ledger entry."""
     id: uuid.UUID
@@ -111,7 +134,7 @@ class LedgerEntryResponse(BaseModel):
     external_transaction_id: Optional[str] = None  # For Stripe: checkout_session_id or invoice_id
     # For Coinbase: charge_id
     # For others: their primary transaction identifier
-    payment_metadata: Optional[dict] = None  # JSONB column for provider-specific metadata
+    payment_metadata: Optional[dict] = None  # Redacted view of the JSONB column (see PUBLIC_PAYMENT_METADATA_KEYS)
     
     # Usage metadata
     request_id: Optional[str] = None
@@ -133,6 +156,15 @@ class LedgerEntryResponse(BaseModel):
     updated_at: datetime
     
     model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("payment_metadata", mode="before")
+    @classmethod
+    def _redact_payment_metadata(cls, value):
+        """Strip server-side-only keys (source_ip, provider internals) from API output."""
+        if not isinstance(value, dict):
+            return None
+        public = {k: v for k, v in value.items() if k in PUBLIC_PAYMENT_METADATA_KEYS}
+        return public or None
 
 
 class LedgerListResponse(BaseModel):


### PR DESCRIPTION
## Summary

The billing transactions endpoint returned the `payment_metadata` JSONB column verbatim in `LedgerEntryResponse`. That column is a free-form, provider-specific store that also carries server-side-only data, so internal fields were leaking to API clients:

- `source_ip` — fraud-control IP captured on the signup bonus (PII)
- Stripe internals — `customer_id`, `payment_intent_id`, `subscription_id`, `client_reference_id`
- Coinbase settlement economics — `settlement_net` / `settlement_fee`
- the raw `payments` array from legacy Coinbase charges — payer wallet addresses and transaction hashes

## Fix

`payment_metadata` is now serialized through an explicit allow-list (`PUBLIC_PAYMENT_METADATA_KEYS`): only descriptive, client-relevant keys survive (`type`, `source`, `checkout_session_id`, `invoice_id`, `payment_link_id`, `charge_code`, `network`, `currency`, `status`, `description`, `created_at`, `updated_at`, `expires_at`). Everything else is dropped at the schema boundary by a `mode="before"` field validator, so any new server-side key added to the column in the future is redacted by default rather than exposed by default. Non-dict values and fully-redacted results serialize as `null`.

## Scope / impact

- Redaction happens at response serialization only — stored ledger rows are unchanged, and internal consumers of the ORM objects are unaffected.
- Applies to every response built from `LedgerEntryResponse` (single entry and paginated transaction listings).
- No API shape change: the field remains `payment_metadata: object | null`; clients only lose keys they should never have seen.

No migrations, no config changes.