### PR TITLE
feat(sessions): open-native routing policy + cheapest-bid stake fuse

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -239,8 +239,14 @@ class Settings(BaseSettings):
     # Format: comma-separated "alias=target" (also accepts "->" / "→").
     # Keys matched case-insensitively. Never map :web/:tee → base when a twin
     # exists — keep Venice / SecretVM feature paths.
+    # Prefer SESSION_ROUTING_POLICY_JSON.aliases when that env is set.
     SESSION_MODEL_ALIASES: str = Field(
         default=os.getenv("SESSION_MODEL_ALIASES", "")
+    )
+    # Open-native routing policy JSON: aliases, preferences, deny, max_stake_mor.
+    # See Morpheus-Infra session_routing_policy + APIGW_MOR_LANES.md.
+    SESSION_ROUTING_POLICY_JSON: str = Field(
+        default=os.getenv("SESSION_ROUTING_POLICY_JSON", "")
     )
 
     # --- Max-bid PPS hard gate (standard lane) --------------------------------

--- a/src/core/model_errors.py
+++ b/src/core/model_errors.py
@@ -123,3 +123,36 @@ class ModelNotAllowlistedError(ModelRoutingError):
             "code": self.code,
         }
         super().__post_init__()
+
+
+@dataclass
+class ModelDeniedError(ModelRoutingError):
+    """Resolved model is on the hosted-gateway deny list."""
+
+    requested_model: Optional[str] = None
+    resolved_id: Optional[str] = None
+    resolved_model: Optional[str] = None
+    message: str = (
+        "This model is not available on the hosted gateway. "
+        "For the full marketplace catalog, run a self-custody node: "
+        "https://nodedocs.mor.org/consumers/quickstart"
+    )
+    error_type: str = "model_unavailable"
+    code: str = "model_unavailable"
+    status_code: int = 503
+
+    def __post_init__(self):
+        label = self.requested_model or self.resolved_model or self.resolved_id
+        if label:
+            self.message = (
+                f"Model '{label}' is not available on the hosted gateway. "
+                "For the full marketplace catalog, run a self-custody node: "
+                "https://nodedocs.mor.org/consumers/quickstart"
+            )
+        self.details = {
+            "requested_model": self.requested_model,
+            "resolved_id": self.resolved_id,
+            "resolved_model": self.resolved_model,
+            "code": self.code,
+        }
+        super().__post_init__()

--- a/src/core/model_routing.py
+++ b/src/core/model_routing.py
@@ -4,10 +4,12 @@ from .direct_model_service import direct_model_service
 from .config import settings
 from .logging_config import get_models_logger
 from .model_errors import (
+    ModelDeniedError,
     ModelNearMissError,
     ModelNotAllowlistedError,
     ModelTypeMismatchError,
 )
+from .session_routing_policy import get_session_routing_policy
 
 # Configure logger
 logger = get_models_logger()
@@ -52,13 +54,21 @@ def parse_model_aliases(raw: Optional[str]) -> Dict[str, str]:
     return out
 
 
+def _effective_aliases() -> Dict[str, str]:
+    """Prefer JSON policy aliases; fall back to legacy CSV SESSION_MODEL_ALIASES."""
+    policy = get_session_routing_policy()
+    if policy.aliases:
+        return dict(policy.aliases)
+    return parse_model_aliases(getattr(settings, "SESSION_MODEL_ALIASES", "") or "")
+
+
 def apply_model_alias(
     requested_model: str,
     aliases: Optional[Dict[str, str]] = None,
 ) -> Tuple[str, Optional[str]]:
     """Return (possibly rewritten name, matched alias key or None)."""
     if aliases is None:
-        aliases = parse_model_aliases(getattr(settings, "SESSION_MODEL_ALIASES", "") or "")
+        aliases = _effective_aliases()
     if not aliases or not requested_model:
         return requested_model, None
     hit = aliases.get(requested_model.lower())
@@ -105,7 +115,45 @@ class ModelRouter:
             requested_model=requested_model,
             resolved_id=resolved_id,
         )
-    
+
+    async def _ensure_not_denied(
+        self,
+        requested_model: Optional[str],
+        resolved_id: str,
+    ) -> str:
+        """Raise ModelDeniedError when resolved identity is on the deny list."""
+        policy = get_session_routing_policy()
+        native_name = await direct_model_service.get_model_name_from_id(resolved_id)
+        if (
+            policy.is_denied_id(resolved_id)
+            or policy.is_denied_name(requested_model)
+            or policy.is_denied_name(native_name)
+        ):
+            logger.warning(
+                "Resolved model is on hosted-gateway deny list",
+                requested_model=requested_model,
+                resolved_id=resolved_id,
+                resolved_model=native_name,
+                event_type="model_denied",
+            )
+            raise ModelDeniedError(
+                requested_model=requested_model,
+                resolved_id=resolved_id,
+                resolved_model=native_name,
+            )
+        return resolved_id
+
+    async def _resolve_preference_or_name(self, label: str) -> Optional[str]:
+        """Resolve a preference/alias target that may already be a 0x ID."""
+        if not label:
+            return None
+        if label.startswith("0x") and len(label) >= 10:
+            # Prefer exact blockchain id when configured.
+            ids = await direct_model_service.get_blockchain_ids()
+            if label in ids:
+                return label
+        return await direct_model_service.resolve_model_id(label)
+
     async def get_target_model(self, requested_model: Optional[str], type: Optional[str] = "LLM") -> str:
         """
         Get the target blockchain ID for the requested model.
@@ -146,10 +194,28 @@ class ModelRouter:
                 aliased_model=aliased_model,
                 event_type="model_alias_applied",
             )
-            
-        # Try to resolve using DirectModelService
+
+        policy = get_session_routing_policy()
+        preference_target = (
+            policy.preference_target(requested_model)
+            or policy.preference_target(aliased_model)
+        )
+        if preference_target:
+            logger.info(
+                "Applied model preference",
+                requested_model=requested_model,
+                preference_target=preference_target,
+                event_type="model_preference_applied",
+            )
+
+        # Try to resolve using DirectModelService (preferences win on collisions).
         try:
-            resolved_id = await direct_model_service.resolve_model_id(aliased_model)
+            if preference_target:
+                resolved_id = await self._resolve_preference_or_name(preference_target)
+            elif aliased_model.startswith("0x"):
+                resolved_id = await self._resolve_preference_or_name(aliased_model)
+            else:
+                resolved_id = await direct_model_service.resolve_model_id(aliased_model)
 
             # A resolved model must be usable by this endpoint type. Without
             # this check a chat completion naming an EMBEDDING model opens a
@@ -180,8 +246,10 @@ class ModelRouter:
                 logger.info("Found model mapping",
                            requested_model=requested_model,
                            aliased_model=aliased_model if alias_key else None,
+                           preference_target=preference_target,
                            resolved_id=resolved_id,
                            event_type="model_resolved")
+                await self._ensure_not_denied(requested_model, resolved_id)
                 return self._ensure_allowlisted(requested_model, resolved_id)
 
             # Not found — if we have close matches, hard-fail with suggestions
@@ -222,7 +290,12 @@ class ModelRouter:
                           default_model_id=default_id,
                           event_type="default_model_fallback")
             return default_id
-        except (ModelTypeMismatchError, ModelNearMissError, ModelNotAllowlistedError):
+        except (
+            ModelTypeMismatchError,
+            ModelNearMissError,
+            ModelNotAllowlistedError,
+            ModelDeniedError,
+        ):
             raise
         except Exception as e:
             logger.error("Error resolving model - using default fallback",

--- a/src/core/session_routing_policy.py
+++ b/src/core/session_routing_policy.py
@@ -1,0 +1,146 @@
+"""Hosted-gateway session routing policy (JSON from SESSION_ROUTING_POLICY_JSON).
+
+Open-native catalog with:
+  - aliases / preferences (steer)
+  - deny names + ids (block)
+  - max_stake_mor (per-open fuse on the bid we would open)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+from .config import settings
+from .logging_config import get_models_logger
+
+logger = get_models_logger()
+
+
+@dataclass(frozen=True)
+class SessionRoutingPolicy:
+    aliases: Dict[str, str] = field(default_factory=dict)
+    preferences: Dict[str, str] = field(default_factory=dict)
+    deny_names: Set[str] = field(default_factory=set)
+    deny_ids: Set[str] = field(default_factory=set)
+    max_stake_mor: float = 0.0
+
+    def alias_target(self, requested: str) -> Optional[str]:
+        if not requested:
+            return None
+        return self.aliases.get(requested.strip().lower())
+
+    def preference_target(self, requested: str) -> Optional[str]:
+        if not requested:
+            return None
+        return self.preferences.get(requested.strip().lower())
+
+    def is_denied_name(self, name: Optional[str]) -> bool:
+        if not name:
+            return False
+        key = name.strip().lower()
+        return key in self.deny_names
+
+    def is_denied_id(self, model_id: Optional[str]) -> bool:
+        if not model_id:
+            return False
+        return model_id.strip() in self.deny_ids
+
+
+_EMPTY = SessionRoutingPolicy()
+_cached_raw: Optional[str] = None
+_cached_policy: SessionRoutingPolicy = _EMPTY
+
+
+def _as_str_dict(value: Any) -> Dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    out: Dict[str, str] = {}
+    for k, v in value.items():
+        if k is None or v is None:
+            continue
+        key = str(k).strip().lower()
+        val = str(v).strip()
+        if key and val:
+            out[key] = val
+    return out
+
+
+def _as_str_set(value: Any) -> Set[str]:
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        parts = [p.strip() for p in value.split(",")]
+        return {p for p in parts if p}
+    if isinstance(value, (list, tuple, set)):
+        return {str(x).strip() for x in value if str(x).strip()}
+    return set()
+
+
+def parse_session_routing_policy(raw: Optional[str]) -> SessionRoutingPolicy:
+    """Parse SESSION_ROUTING_POLICY_JSON. Invalid/empty → empty policy."""
+    text = (raw or "").strip()
+    if not text:
+        return _EMPTY
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        logger.error(
+            "SESSION_ROUTING_POLICY_JSON is invalid JSON; ignoring policy",
+            error=str(e),
+            event_type="session_routing_policy_parse_error",
+        )
+        return _EMPTY
+    if not isinstance(data, dict):
+        logger.error(
+            "SESSION_ROUTING_POLICY_JSON must be an object; ignoring policy",
+            event_type="session_routing_policy_parse_error",
+        )
+        return _EMPTY
+
+    deny = data.get("deny") or {}
+    if not isinstance(deny, dict):
+        deny = {}
+
+    deny_names = {n.strip().lower() for n in _as_str_set(deny.get("names"))}
+    deny_ids = {i.strip() for i in _as_str_set(deny.get("ids"))}
+
+    try:
+        max_stake = float(data.get("max_stake_mor") or 0)
+    except (TypeError, ValueError):
+        max_stake = 0.0
+
+    return SessionRoutingPolicy(
+        aliases=_as_str_dict(data.get("aliases")),
+        preferences=_as_str_dict(data.get("preferences")),
+        deny_names=deny_names,
+        deny_ids=deny_ids,
+        max_stake_mor=max(0.0, max_stake),
+    )
+
+
+def get_session_routing_policy() -> SessionRoutingPolicy:
+    """Return the current policy (re-parses when env string changes)."""
+    global _cached_raw, _cached_policy
+    raw = getattr(settings, "SESSION_ROUTING_POLICY_JSON", "") or ""
+    if raw != _cached_raw:
+        _cached_policy = parse_session_routing_policy(raw)
+        _cached_raw = raw
+        logger.info(
+            "Loaded session routing policy",
+            alias_count=len(_cached_policy.aliases),
+            preference_count=len(_cached_policy.preferences),
+            deny_name_count=len(_cached_policy.deny_names),
+            deny_id_count=len(_cached_policy.deny_ids),
+            max_stake_mor=_cached_policy.max_stake_mor,
+            event_type="session_routing_policy_loaded",
+        )
+    return _cached_policy
+
+
+def reset_session_routing_policy_cache() -> None:
+    """Test helper."""
+    global _cached_raw, _cached_policy
+    _cached_raw = None
+    _cached_policy = _EMPTY

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -22,6 +22,7 @@ from .session_routing_service import (
     SessionPriceGateError,
     SessionPremiumBudgetError,
     SessionAllowlistError,
+    SessionStakeFuseError,
 )
 
 __all__ = [
@@ -44,4 +45,5 @@ __all__ = [
     "SessionPriceGateError",
     "SessionPremiumBudgetError",
     "SessionAllowlistError",
+    "SessionStakeFuseError",
 ]

--- a/src/services/proxy_router_service.py
+++ b/src/services/proxy_router_service.py
@@ -690,6 +690,51 @@ async def createBidSession(
         raise ProxyRouterServiceError(f"Failed to create bid session: {str(e)}")
 
 
+async def openSessionByBid(
+    *,
+    bid_id: str,
+    session_duration: int = 3600,
+) -> Dict[str, Any]:
+    """Open a session on a specific bid (cheapest-bid path for APIGW)."""
+    if not bid_id or not str(bid_id).startswith("0x"):
+        raise ProxyRouterServiceError(
+            f"Invalid bid ID format: {bid_id}. Expected hex string starting with '0x'",
+            status_code=400,
+            error_type="validation_error",
+        )
+
+    logger.info(
+        "Opening proxy router session by bid",
+        bid_id=bid_id,
+        session_duration=session_duration,
+        event_type="bid_session_open_start",
+    )
+    try:
+        response = await _execute_request(
+            "POST",
+            f"blockchain/bids/{bid_id}/session",
+            headers={"Content-Type": "application/json"},
+            json_data={"sessionDuration": session_duration},
+            max_retries=3,
+        )
+        result = response.json()
+        logger.info(
+            "Bid session opened successfully",
+            bid_id=bid_id,
+            session_id=result.get("sessionID"),
+            event_type="bid_session_opened",
+        )
+        return result
+    except Exception as e:
+        logger.error(
+            "Error opening session by bid",
+            bid_id=bid_id,
+            error=str(e),
+            event_type="bid_session_open_error",
+        )
+        raise ProxyRouterServiceError(f"Failed to open bid session: {str(e)}")
+
+
 async def getModels(headers: Optional[Dict[str, str]] = None) -> httpx.Response:
     """Call the proxy router /v1/models endpoint and return the response.
 

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -28,6 +28,7 @@ from ..db.models import RoutedSession, SessionState
 from ..db.database import get_db, advisory_xact_lock
 from ..core.config import settings
 from ..core.model_routing import model_router
+from ..core.session_routing_policy import get_session_routing_policy
 from ..core.logging_config import get_api_logger
 from ..services import proxy_router_service
 
@@ -87,7 +88,7 @@ class SessionGatewayCapacityError(SessionRoutingError):
         category: str = "capacity",
     ):
         super().__init__(message, model_id=model_id)
-        self.category = category  # warm_reserve | price_gate | premium_budget
+        self.category = category  # warm_reserve | price_gate | premium_budget | stake_fuse
 
 
 class SessionMorReservedError(SessionGatewayCapacityError):
@@ -142,6 +143,23 @@ class SessionAllowlistError(SessionGatewayCapacityError):
 
     def __init__(self, message: str, model_id: Optional[str] = None):
         super().__init__(message, model_id=model_id, category="allowlist")
+
+
+class SessionStakeFuseError(SessionGatewayCapacityError):
+    """Raised when the cheapest openable bid stake exceeds max_stake_mor."""
+
+    def __init__(
+        self,
+        message: str,
+        model_id: Optional[str] = None,
+        stake_mor: float = 0,
+        max_stake_mor: float = 0,
+        bid_id: Optional[str] = None,
+    ):
+        super().__init__(message, model_id=model_id, category="stake_fuse")
+        self.stake_mor = stake_mor
+        self.max_stake_mor = max_stake_mor
+        self.bid_id = bid_id
 
 
 class SessionRoutingService:
@@ -388,6 +406,9 @@ class SessionRoutingService:
         Missing price (lookup failure / no bids) fails open so we don't brick
         routing when the C-Node bid read is unavailable — soft-cap / open will
         still fail naturally if there is no usable bid.
+
+        Prefer SESSION_ROUTING_POLICY_JSON.max_stake_mor (chosen-bid fuse).
+        This PPS gate remains as an optional legacy backup.
         """
         gate = float(settings.SESSION_MAX_BID_PPS_MOR or 0)
         if gate <= 0:
@@ -413,6 +434,133 @@ class SessionRoutingService:
                 max_pps=max_pps,
                 gate_pps=gate,
             )
+
+    def _session_duration_for_open(self, is_expensive: bool) -> int:
+        if is_expensive:
+            return int(settings.SESSION_EXPENSIVE_DEFAULT_DURATION_SECONDS)
+        return int(settings.SESSION_DEFAULT_DURATION_SECONDS)
+
+    def _stake_mor_for_pps(self, pps_mor: float, session_duration: int) -> float:
+        factor = float(settings.SESSION_STAKE_FACTOR or 338)
+        return float(pps_mor) * float(session_duration) * factor
+
+    async def _list_rated_bids_cheapest_first(
+        self,
+        model_id: str,
+        omit_provider: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Rated bids for model, cheapest PPS first (proxy rates by score, not price)."""
+        try:
+            response = await proxy_router_service.getRatedBids(model_id)
+            result = response.json()
+            if isinstance(result, dict):
+                bids = result.get("bids", []) or []
+            elif isinstance(result, list):
+                bids = result
+            else:
+                bids = []
+        except Exception as e:
+            logger.warning(
+                "Rated-bid list failed for cheapest-bid selection",
+                model_id=model_id,
+                error=str(e),
+                event_type="cheapest_bid_lookup_error",
+            )
+            return []
+
+        omit = (omit_provider or "").strip().lower()
+        parsed: List[Dict[str, Any]] = []
+        for bid in bids:
+            if not isinstance(bid, dict):
+                continue
+            inner = bid.get("Bid") if isinstance(bid.get("Bid"), dict) else bid
+            if not isinstance(inner, dict):
+                continue
+            bid_id = inner.get("Id") or inner.get("ID") or bid.get("ID") or bid.get("Id")
+            pps_raw = inner.get("PricePerSecond")
+            provider = inner.get("Provider") or ""
+            if not bid_id or pps_raw is None:
+                continue
+            if omit and str(provider).strip().lower() == omit:
+                continue
+            try:
+                pps = int(str(pps_raw)) / 1e18
+            except (ValueError, TypeError):
+                continue
+            parsed.append(
+                {
+                    "bid_id": str(bid_id),
+                    "pps": pps,
+                    "provider": str(provider) if provider else None,
+                    "score": bid.get("Score"),
+                }
+            )
+        parsed.sort(key=lambda b: b["pps"])
+        return parsed
+
+    async def _select_cheapest_bid_under_fuse(
+        self,
+        model_id: str,
+        session_duration: int,
+        omit_provider: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Pick cheapest rated bid whose implied stake is under max_stake_mor.
+
+        max_stake_mor 0 disables the fuse (still returns cheapest rated bid).
+        Raises SessionStakeFuseError when every rated bid is over the fuse.
+        Raises SessionOpenError when no rated bids are available.
+        """
+        policy = get_session_routing_policy()
+        max_stake = float(policy.max_stake_mor or 0)
+        bids = await self._list_rated_bids_cheapest_first(
+            model_id, omit_provider=omit_provider
+        )
+        if not bids:
+            raise SessionOpenError(
+                "No rated bids available for model",
+                model_id=model_id,
+            )
+
+        under: List[Dict[str, Any]] = []
+        for bid in bids:
+            stake = self._stake_mor_for_pps(bid["pps"], session_duration)
+            row = {**bid, "stake_mor": stake, "session_duration": session_duration}
+            if max_stake <= 0 or stake <= max_stake:
+                under.append(row)
+
+        if not under:
+            cheapest = bids[0]
+            stake = self._stake_mor_for_pps(cheapest["pps"], session_duration)
+            logger.warning(
+                "Cheapest rated bid exceeds max stake fuse",
+                model_id=model_id,
+                bid_id=cheapest["bid_id"],
+                stake_mor=round(stake, 6),
+                max_stake_mor=max_stake,
+                session_duration=session_duration,
+                event_type="session_stake_fuse_refused",
+            )
+            raise SessionStakeFuseError(
+                "This model is too expensive for the hosted API Gateway right now. "
+                + P2P_OFFRAMP_HINT,
+                model_id=model_id,
+                stake_mor=stake,
+                max_stake_mor=max_stake,
+                bid_id=str(cheapest["bid_id"]),
+            )
+
+        chosen = under[0]
+        logger.info(
+            "Selected cheapest rated bid under stake fuse",
+            model_id=model_id,
+            bid_id=chosen["bid_id"],
+            pps=chosen["pps"],
+            stake_mor=round(float(chosen["stake_mor"]), 6),
+            max_stake_mor=max_stake,
+            candidate_count=len(under),
+            event_type="cheapest_bid_selected",
+        )
+        return chosen
 
     async def _get_premium_daylock_spent(self) -> Optional[float]:
         """UTC-day premium daylock spent (MOR), or None if unreadable."""
@@ -1307,7 +1455,8 @@ class SessionRoutingService:
         # automation / preferred scale-up enters directly). Cap/watermark/
         # PPS/budget 0 = disabled for that gate. Warm skips LWM + PPS; premium
         # skips PPS but is limited by daily daylock budget. Empty allowlist
-        # disables curated-catalog refusal.
+        # disables curated-catalog refusal. Stake fuse runs on the chosen bid
+        # immediately before open (all lanes).
         await self._ensure_allowlist_allows_open(model_id)
         await self._ensure_soft_cap_allows_open(model_id)
         await self._ensure_mor_low_water_allows_open(model_id)
@@ -1320,14 +1469,18 @@ class SessionRoutingService:
         # if the tier is disabled or the price can't be read, use the global
         # default duration.
         is_expensive = await self._is_expensive_model(model_id)
-        session_duration = (
-            settings.SESSION_EXPENSIVE_DEFAULT_DURATION_SECONDS
-            if is_expensive
-            else settings.SESSION_DEFAULT_DURATION_SECONDS
+        session_duration = self._session_duration_for_open(is_expensive)
+        chosen_bid = await self._select_cheapest_bid_under_fuse(
+            model_id=model_id,
+            session_duration=session_duration,
+            omit_provider=omit_provider,
         )
+        bid_id = str(chosen_bid["bid_id"])
         open_logger = open_logger.bind(
             expensive_tier=is_expensive,
             session_duration=session_duration,
+            bid_id=bid_id,
+            selected_stake_mor=round(float(chosen_bid["stake_mor"]), 6),
         )
         # Fallback ONLY. The authoritative expiry is the actual on-chain endsAt,
         # read back after the open (see below). This call-start estimate is used
@@ -1341,9 +1494,9 @@ class SessionRoutingService:
         )
 
         try:
-            # Call proxy router to open session
-            # Uses user's private key if provided, otherwise uses fallback key
-            open_logger.info("Calling proxy router to open session",
+            # Open the specific cheapest-under-fuse bid (not model-level open,
+            # which ranks by proxy score and can pick an expensive peer).
+            open_logger.info("Calling proxy router to open session by bid",
                            user_id=user_id,
                            event_type="proxy_open_session_start")
 
@@ -1353,14 +1506,11 @@ class SessionRoutingService:
             # uses its own short-lived session), so a throttled queue can grow
             # without exhausting the DB pool.
             response = await self._run_onchain(
-                lambda: proxy_router_service.openSession(
-                    target_model=model_id,
+                lambda: proxy_router_service.openSessionByBid(
+                    bid_id=bid_id,
                     session_duration=session_duration,
-                    failover=False,
-                    direct_payment=False,
-                    omit_provider=omit_provider,
                 ),
-                op_name="openSession",
+                op_name="openSessionByBid",
                 op_logger=open_logger,
             )
 

--- a/tests/unit/test_session_routing_policy.py
+++ b/tests/unit/test_session_routing_policy.py
@@ -1,0 +1,151 @@
+"""Unit tests for SESSION_ROUTING_POLICY_JSON parsing + cheapest-bid fuse."""
+
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.core.session_routing_policy import (
+    parse_session_routing_policy,
+    reset_session_routing_policy_cache,
+)
+from src.services.session_routing_service import (
+    SessionOpenError,
+    SessionRoutingService,
+    SessionStakeFuseError,
+)
+
+
+def test_parse_policy_aliases_preferences_deny_stake():
+    raw = json.dumps(
+        {
+            "aliases": {"Claude Opus 4.8": "Claude Opus 4.7", "kimi-k2.5": "Kimi K3"},
+            "preferences": {"gpt-5.4": "0x95980c8a9ea2a7542e3fd9857df3932443e45ff9f6cdb2cf332cd3221ed16edb"},
+            "deny": {"names": ["claude-haiku-4.5", "GLM-4.7-flash"], "ids": ["0xdead"]},
+            "max_stake_mor": 700,
+        }
+    )
+    policy = parse_session_routing_policy(raw)
+    assert policy.alias_target("claude opus 4.8") == "Claude Opus 4.7"
+    assert policy.preference_target("GPT-5.4").startswith("0x95980")
+    assert policy.is_denied_name("claude-haiku-4.5")
+    assert policy.is_denied_name("glm-4.7-flash")
+    assert policy.is_denied_id("0xdead")
+    assert policy.max_stake_mor == 700
+
+
+def test_parse_policy_invalid_json_empty():
+    assert parse_session_routing_policy("{not-json").max_stake_mor == 0
+    assert parse_session_routing_policy("").aliases == {}
+
+
+@pytest.fixture
+def service():
+    reset_session_routing_policy_cache()
+    return SessionRoutingService()
+
+
+@pytest.mark.asyncio
+async def test_cheapest_bid_under_fuse_picks_low_pps(service):
+    bids = {
+        "bids": [
+            {
+                "ID": "0xbid_hi",
+                "Score": 9.0,
+                "Bid": {
+                    "Id": "0xbid_hi",
+                    "Provider": "0xprovhi",
+                    "PricePerSecond": str(int(0.002 * 1e18)),
+                },
+            },
+            {
+                "ID": "0xbid_lo",
+                "Score": 1.0,
+                "Bid": {
+                    "Id": "0xbid_lo",
+                    "Provider": "0xprovlo",
+                    "PricePerSecond": str(int(0.0003 * 1e18)),
+                },
+            },
+        ]
+    }
+    resp = MagicMock()
+    resp.json.return_value = bids
+
+    with patch(
+        "src.services.session_routing_service.get_session_routing_policy"
+    ) as mock_policy, patch(
+        "src.services.session_routing_service.proxy_router_service.getRatedBids",
+        new=AsyncMock(return_value=resp),
+    ), patch(
+        "src.services.session_routing_service.settings"
+    ) as mock_settings:
+        mock_policy.return_value.max_stake_mor = 700
+        mock_settings.SESSION_STAKE_FACTOR = 338
+        chosen = await service._select_cheapest_bid_under_fuse(
+            model_id="0xmodel",
+            session_duration=1800,
+        )
+
+    assert chosen["bid_id"] == "0xbid_lo"
+    # 0.0003 * 1800 * 338 = 182.52
+    assert chosen["stake_mor"] == pytest.approx(182.52, rel=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_cheapest_bid_over_fuse_refused(service):
+    bids = {
+        "bids": [
+            {
+                "Bid": {
+                    "Id": "0xbid_hi",
+                    "Provider": "0xprov",
+                    "PricePerSecond": str(int(0.01 * 1e18)),
+                }
+            }
+        ]
+    }
+    resp = MagicMock()
+    resp.json.return_value = bids
+
+    with patch(
+        "src.services.session_routing_service.get_session_routing_policy"
+    ) as mock_policy, patch(
+        "src.services.session_routing_service.proxy_router_service.getRatedBids",
+        new=AsyncMock(return_value=resp),
+    ), patch(
+        "src.services.session_routing_service.settings"
+    ) as mock_settings:
+        mock_policy.return_value.max_stake_mor = 700
+        mock_settings.SESSION_STAKE_FACTOR = 338
+        with pytest.raises(SessionStakeFuseError) as exc:
+            await service._select_cheapest_bid_under_fuse(
+                model_id="0xmodel",
+                session_duration=1800,
+            )
+
+    # 0.01 * 1800 * 338 = 6084
+    assert exc.value.stake_mor == pytest.approx(6084.0, rel=1e-3)
+    assert exc.value.max_stake_mor == 700
+
+
+@pytest.mark.asyncio
+async def test_cheapest_bid_no_bids(service):
+    resp = MagicMock()
+    resp.json.return_value = {"bids": []}
+    with patch(
+        "src.services.session_routing_service.get_session_routing_policy"
+    ) as mock_policy, patch(
+        "src.services.session_routing_service.proxy_router_service.getRatedBids",
+        new=AsyncMock(return_value=resp),
+    ):
+        mock_policy.return_value.max_stake_mor = 700
+        with pytest.raises(SessionOpenError):
+            await service._select_cheapest_bid_under_fuse(
+                model_id="0xmodel",
+                session_duration=1800,
+            )


### PR DESCRIPTION
## Summary
- Add `SESSION_ROUTING_POLICY_JSON` parser (aliases, preferences, deny, `max_stake_mor`)
- Resolve preferences before catalog name map (fixes `gpt-5.4` collision)
- Deny post-steer by native name / model ID
- Open via cheapest rated bid (`openSessionByBid`) and refuse when implied stake exceeds fuse (all lanes, no exemption)
- Legacy CSV aliases still work when JSON aliases are empty; allowlist remains optional

## Test plan
- [x] `tests/unit/test_session_routing_policy.py` (parse + cheapest/fuse selection)
- [ ] Deploy with Infra `session_routing_policy.json` (`max_stake_mor=700`) after API promote
- [ ] Smoke: `GPT-5.4` / `gpt-5.4` → premium parent; junk deny names → 503; expensive sole bid → stake fuse 503
- [ ] Confirm opens log `cheapest_bid_selected` with stake ≤ 700


Made with [Cursor](https://cursor.com)