### PR TITLE
fix(sessions): only open active.mor.org-healthy cheapest bids

### DIFF
--- a/src/core/direct_model_service.py
+++ b/src/core/direct_model_service.py
@@ -192,6 +192,41 @@ class DirectModelService:
         """
         await self._ensure_fresh_cache()
         return self._raw_models_data.copy()
+
+    async def get_healthy_bid_ids_for_model(self, model_id: str) -> Set[str]:
+        """Bid IDs active.mor.org reports as healthy for a model.
+
+        Used by session open to avoid knocking on providers that host-health
+        already excluded (stale proxy-router, unreachable endpoint, etc.).
+        Rated/on-chain bid lists can still contain those ghost bids.
+
+        Returns lowercase ``0x…`` bid IDs with ``bidDetail[].status == "healthy"``.
+        Empty when the model is missing or has no healthy bids — callers must
+        not fall back to unfiltered rated bids.
+        """
+        await self._ensure_fresh_cache()
+        want = (model_id or "").strip().lower()
+        if not want:
+            return set()
+
+        for model in self._raw_models_data:
+            if not isinstance(model, dict):
+                continue
+            mid = str(model.get("Id") or model.get("id") or "").strip().lower()
+            if mid != want:
+                continue
+            healthy: Set[str] = set()
+            for bid in model.get("bidDetail") or []:
+                if not isinstance(bid, dict):
+                    continue
+                status = str(bid.get("status") or "").strip().lower()
+                if status != "healthy":
+                    continue
+                bid_id = str(bid.get("bidId") or bid.get("bid_id") or "").strip().lower()
+                if bid_id.startswith("0x") and len(bid_id) >= 10:
+                    healthy.add(bid_id)
+            return healthy
+        return set()
     
     async def resolve_model_id(self, model_identifier: str) -> Optional[str]:
         """

--- a/src/services/session_routing_service.py
+++ b/src/services/session_routing_service.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..db.models import RoutedSession, SessionState
 from ..db.database import get_db, advisory_xact_lock
 from ..core.config import settings
+from ..core.direct_model_service import direct_model_service
 from ..core.model_routing import model_router
 from ..core.session_routing_policy import get_session_routing_policy
 from ..core.logging_config import get_api_logger
@@ -449,7 +450,12 @@ class SessionRoutingService:
         model_id: str,
         omit_provider: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Rated bids for model, cheapest PPS first (proxy rates by score, not price)."""
+        """Rated bids for model, cheapest PPS first (proxy rates by score, not price).
+
+        Only bids that active.mor.org marks ``healthy`` in ``bidDetail`` are
+        eligible. On-chain rated lists still include ghost/outdated hosts;
+        knocking on those doors is what trips session-creation alarms.
+        """
         try:
             response = await proxy_router_service.getRatedBids(model_id)
             result = response.json()
@@ -468,8 +474,19 @@ class SessionRoutingService:
             )
             return []
 
+        healthy_ids = await direct_model_service.get_healthy_bid_ids_for_model(model_id)
+        if not healthy_ids:
+            logger.warning(
+                "No active.mor.org healthy bids for model; refusing rated-bid open",
+                model_id=model_id,
+                rated_bid_count=len(bids) if isinstance(bids, list) else 0,
+                event_type="cheapest_bid_no_active_healthy",
+            )
+            return []
+
         omit = (omit_provider or "").strip().lower()
         parsed: List[Dict[str, Any]] = []
+        skipped_unhealthy = 0
         for bid in bids:
             if not isinstance(bid, dict):
                 continue
@@ -480,6 +497,10 @@ class SessionRoutingService:
             pps_raw = inner.get("PricePerSecond")
             provider = inner.get("Provider") or ""
             if not bid_id or pps_raw is None:
+                continue
+            bid_id_l = str(bid_id).strip().lower()
+            if bid_id_l not in healthy_ids:
+                skipped_unhealthy += 1
                 continue
             if omit and str(provider).strip().lower() == omit:
                 continue
@@ -494,6 +515,15 @@ class SessionRoutingService:
                     "provider": str(provider) if provider else None,
                     "score": bid.get("Score"),
                 }
+            )
+        if skipped_unhealthy:
+            logger.info(
+                "Filtered rated bids not healthy on active.mor.org",
+                model_id=model_id,
+                skipped_unhealthy=skipped_unhealthy,
+                kept=len(parsed),
+                active_healthy=len(healthy_ids),
+                event_type="cheapest_bid_unhealthy_filtered",
             )
         parsed.sort(key=lambda b: b["pps"])
         return parsed

--- a/tests/unit/test_active_healthy_bids.py
+++ b/tests/unit/test_active_healthy_bids.py
@@ -1,0 +1,42 @@
+"""Unit tests for active.mor.org healthy bidId extraction."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.core.direct_model_service import DirectModelService
+
+
+@pytest.mark.asyncio
+async def test_get_healthy_bid_ids_filters_status():
+    svc = DirectModelService()
+    svc._cache_expiry = __import__("datetime").datetime.now() + __import__(
+        "datetime"
+    ).timedelta(hours=1)
+    svc._raw_models_data = [
+        {
+            "Id": "0xMODEL",
+            "Name": "demo",
+            "bidDetail": [
+                {"bidId": "0xAAA", "status": "healthy"},
+                {"bidId": "0xBBB", "status": "unhealthy"},
+                {"bidId": "0xCCC", "status": "Healthy"},
+                {"bidId": "0xDDD", "status": "degraded"},
+            ],
+        }
+    ]
+    got = await svc.get_healthy_bid_ids_for_model("0xmodel")
+    assert got == {"0xaaa", "0xccc"}
+
+
+@pytest.mark.asyncio
+async def test_get_healthy_bid_ids_missing_model():
+    svc = DirectModelService()
+    svc._cache_expiry = __import__("datetime").datetime.now() + __import__(
+        "datetime"
+    ).timedelta(hours=1)
+    svc._raw_models_data = [{"Id": "0xother", "bidDetail": [{"bidId": "0xaaa", "status": "healthy"}]}]
+    assert await svc.get_healthy_bid_ids_for_model("0xmissing") == set()

--- a/tests/unit/test_session_routing_policy.py
+++ b/tests/unit/test_session_routing_policy.py
@@ -49,6 +49,24 @@ def service():
     return SessionRoutingService()
 
 
+def _patch_cheapest(healthy_ids, rated_resp, *, max_stake=700):
+    """Common patches for cheapest-bid selection + active healthy filter."""
+    return (
+        patch(
+            "src.services.session_routing_service.get_session_routing_policy"
+        ),
+        patch(
+            "src.services.session_routing_service.proxy_router_service.getRatedBids",
+            new=AsyncMock(return_value=rated_resp),
+        ),
+        patch(
+            "src.services.session_routing_service.direct_model_service.get_healthy_bid_ids_for_model",
+            new=AsyncMock(return_value={b.lower() for b in healthy_ids}),
+        ),
+        patch("src.services.session_routing_service.settings"),
+    )
+
+
 @pytest.mark.asyncio
 async def test_cheapest_bid_under_fuse_picks_low_pps(service):
     bids = {
@@ -75,15 +93,11 @@ async def test_cheapest_bid_under_fuse_picks_low_pps(service):
     }
     resp = MagicMock()
     resp.json.return_value = bids
+    p_policy, p_rated, p_healthy, p_settings = _patch_cheapest(
+        {"0xbid_hi", "0xbid_lo"}, resp
+    )
 
-    with patch(
-        "src.services.session_routing_service.get_session_routing_policy"
-    ) as mock_policy, patch(
-        "src.services.session_routing_service.proxy_router_service.getRatedBids",
-        new=AsyncMock(return_value=resp),
-    ), patch(
-        "src.services.session_routing_service.settings"
-    ) as mock_settings:
+    with p_policy as mock_policy, p_rated, p_healthy, p_settings as mock_settings:
         mock_policy.return_value.max_stake_mor = 700
         mock_settings.SESSION_STAKE_FACTOR = 338
         chosen = await service._select_cheapest_bid_under_fuse(
@@ -94,6 +108,42 @@ async def test_cheapest_bid_under_fuse_picks_low_pps(service):
     assert chosen["bid_id"] == "0xbid_lo"
     # 0.0003 * 1800 * 338 = 182.52
     assert chosen["stake_mor"] == pytest.approx(182.52, rel=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_cheapest_bid_skips_active_unhealthy_ghost(service):
+    """Ghost cheapest bid not on active.mor.org healthy list must be ignored."""
+    bids = {
+        "bids": [
+            {
+                "Bid": {
+                    "Id": "0xghost_cheap",
+                    "Provider": "0xdeadhost",
+                    "PricePerSecond": str(int(0.0001 * 1e18)),
+                }
+            },
+            {
+                "Bid": {
+                    "Id": "0xhealthy",
+                    "Provider": "0xgood",
+                    "PricePerSecond": str(int(0.0003 * 1e18)),
+                }
+            },
+        ]
+    }
+    resp = MagicMock()
+    resp.json.return_value = bids
+    p_policy, p_rated, p_healthy, p_settings = _patch_cheapest({"0xhealthy"}, resp)
+
+    with p_policy as mock_policy, p_rated, p_healthy, p_settings as mock_settings:
+        mock_policy.return_value.max_stake_mor = 700
+        mock_settings.SESSION_STAKE_FACTOR = 338
+        chosen = await service._select_cheapest_bid_under_fuse(
+            model_id="0xmodel",
+            session_duration=1800,
+        )
+
+    assert chosen["bid_id"] == "0xhealthy"
 
 
 @pytest.mark.asyncio
@@ -111,15 +161,9 @@ async def test_cheapest_bid_over_fuse_refused(service):
     }
     resp = MagicMock()
     resp.json.return_value = bids
+    p_policy, p_rated, p_healthy, p_settings = _patch_cheapest({"0xbid_hi"}, resp)
 
-    with patch(
-        "src.services.session_routing_service.get_session_routing_policy"
-    ) as mock_policy, patch(
-        "src.services.session_routing_service.proxy_router_service.getRatedBids",
-        new=AsyncMock(return_value=resp),
-    ), patch(
-        "src.services.session_routing_service.settings"
-    ) as mock_settings:
+    with p_policy as mock_policy, p_rated, p_healthy, p_settings as mock_settings:
         mock_policy.return_value.max_stake_mor = 700
         mock_settings.SESSION_STAKE_FACTOR = 338
         with pytest.raises(SessionStakeFuseError) as exc:
@@ -137,13 +181,36 @@ async def test_cheapest_bid_over_fuse_refused(service):
 async def test_cheapest_bid_no_bids(service):
     resp = MagicMock()
     resp.json.return_value = {"bids": []}
-    with patch(
-        "src.services.session_routing_service.get_session_routing_policy"
-    ) as mock_policy, patch(
-        "src.services.session_routing_service.proxy_router_service.getRatedBids",
-        new=AsyncMock(return_value=resp),
-    ):
+    p_policy, p_rated, p_healthy, _ = _patch_cheapest(set(), resp)
+    with p_policy as mock_policy, p_rated, p_healthy:
         mock_policy.return_value.max_stake_mor = 700
+        with pytest.raises(SessionOpenError):
+            await service._select_cheapest_bid_under_fuse(
+                model_id="0xmodel",
+                session_duration=1800,
+            )
+
+
+@pytest.mark.asyncio
+async def test_cheapest_bid_no_active_healthy_refuses(service):
+    """Rated bids exist but none are active-healthy → do not open any."""
+    bids = {
+        "bids": [
+            {
+                "Bid": {
+                    "Id": "0xghost",
+                    "Provider": "0xdead",
+                    "PricePerSecond": str(int(0.0001 * 1e18)),
+                }
+            }
+        ]
+    }
+    resp = MagicMock()
+    resp.json.return_value = bids
+    p_policy, p_rated, p_healthy, p_settings = _patch_cheapest(set(), resp)
+    with p_policy as mock_policy, p_rated, p_healthy, p_settings as mock_settings:
+        mock_policy.return_value.max_stake_mor = 700
+        mock_settings.SESSION_STAKE_FACTOR = 338
         with pytest.raises(SessionOpenError):
             await service._select_cheapest_bid_under_fuse(
                 model_id="0xmodel",


### PR DESCRIPTION
## Summary
- Cheapest-bid open path now intersects C-Node `getRatedBids` with `active.mor.org` `bidDetail` entries whose `status` is `healthy`.
- Ghost/outdated hosts (e.g. deepseek-v4-pro bid on `82.67.174.173`) are never selected, so we do not knock on doors host-health already excluded.
- If a model has no healthy active bids, open is refused (`cheapest_bid_no_active_healthy`) rather than falling back to unfiltered rated bids.

## Test plan
- [ ] Unit: `tests/unit/test_session_routing_policy.py` (ghost skipped; no-active-healthy refuses)
- [ ] Unit: `tests/unit/test_active_healthy_bids.py`
- [ ] DEV: warm scale-up for `deepseek-v4-pro` selects a bid present in active `bidDetail` (not `0x6ac57652…`)
- [ ] DEV/PRD: `cheapest_bid_unhealthy_filtered` / no `provider healthcheck ping failed` storm on that ghost bid


Made with [Cursor](https://cursor.com)