### PR TITLE
fix(chat): forward provider extras like venice_parameters

### DIFF
--- a/src/api/v1/chat/chat_models.py
+++ b/src/api/v1/chat/chat_models.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ImageUrl(BaseModel):
@@ -100,8 +100,17 @@ class ToolChoice(BaseModel):
 class ChatCompletionRequest(BaseModel):
     """Request payload for chat completions.
 
-    Note: Field defaults and names must remain unchanged for API parity.
+    Known OpenAI-compatible fields are validated. Provider-specific extras
+    (e.g. ``venice_parameters``, ``stream_options``) are accepted and forwarded
+    to the proxy-router unchanged — the router already preserves unknown keys
+    via OpenAICompletionRequestExtra.
+
+    Note: Field defaults and names for the typed fields must remain unchanged
+    for API parity.
     """
+
+    # Keep typed validation for known fields; do not drop vendor extensions.
+    model_config = ConfigDict(extra="allow")
 
     model: Optional[str] = None
     messages: List[ChatMessage]

--- a/src/schemas/openai.py
+++ b/src/schemas/openai.py
@@ -1,5 +1,5 @@
 from typing import List, Optional, Dict, Any, Union, Literal
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime
 from enum import Enum
 
@@ -54,7 +54,13 @@ class ChatMessage(BaseModel):
 
 
 class ChatCompletionRequest(BaseModel):
-    """OpenAI chat completion request schema"""
+    """OpenAI chat completion request schema.
+
+    Provider-specific extras (e.g. venice_parameters) are allowed for parity
+    with the live chat endpoint schema in api.v1.chat.chat_models.
+    """
+    model_config = ConfigDict(extra="allow")
+
     model: Optional[str] = None
     messages: List[ChatMessage]
     temperature: Optional[float] = 1.0

--- a/tests/unit/test_chat_request_passthrough.py
+++ b/tests/unit/test_chat_request_passthrough.py
@@ -1,0 +1,44 @@
+"""Ensure chat request schema forwards provider-specific extras."""
+
+from pydantic import ValidationError
+import pytest
+
+from src.api.v1.chat.chat_models import ChatCompletionRequest
+
+
+def test_venice_parameters_and_unknown_extras_survive_dump():
+    raw = {
+        "model": "Venice Uncensored 1.2",
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "who are you?"},
+        ],
+        "temperature": 0.7,
+        "max_tokens": 2000,
+        "stream": False,
+        "venice_parameters": {"enable_web_search": "on"},
+        "stream_options": {"include_usage": True},
+    }
+    req = ChatCompletionRequest.model_validate(raw)
+    dumped = req.model_dump(exclude_none=True)
+
+    assert dumped["venice_parameters"] == {"enable_web_search": "on"}
+    assert dumped["stream_options"] == {"include_usage": True}
+    assert dumped["messages"][0]["role"] == "system"
+    assert dumped["messages"][0]["content"] == "You are a helpful assistant."
+    assert dumped["temperature"] == 0.7
+
+
+def test_known_field_types_still_validated():
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": "not-an-int",
+            }
+        )
+
+
+def test_missing_messages_still_rejected():
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest.model_validate({"model": "x", "venice_parameters": {}})


### PR DESCRIPTION
## Summary
- Allow unknown fields on `ChatCompletionRequest` (`extra="allow"`) so provider-specific params (`venice_parameters`, `stream_options`, etc.) survive `model_dump` and reach proxy-router.
- Keep typed validation for known OpenAI fields; `session_id` / `stream` / `model` handling unchanged.
- Add unit coverage that extras round-trip and bad typed fields still 422.

## Context
Live A/B showed `api.mor.org` echoing `enable_web_search: "off"` / no citations while Uplink/proxy-router preserved `"on"`. Root cause was APIGW schema drop, not the router.

## Test plan
- [ ] Unit: `pytest tests/unit/test_chat_request_passthrough.py`
- [ ] After deploy to test/prd: Venice Uncensored with `venice_parameters.enable_web_search: "on"` echoes `"on"` and returns citations (parity with Uplink)
- [ ] Sanity: normal chat without extras still works; invalid `max_tokens` still 422


Made with [Cursor](https://cursor.com)