### PR TITLE
Promote: embeddings usage billing fallback (test → main)

### DIFF
--- a/src/api/v1/embeddings/index.py
+++ b/src/api/v1/embeddings/index.py
@@ -46,6 +46,7 @@ router = APIRouter(tags=["Embeddings"])
 logger = get_api_logger()
 
 from .models import EmbeddingRequest, EmbeddingResponse
+from .usage import extract_embeddings_usage
 
 @router.post("/embeddings", response_model=EmbeddingResponse)
 async def create_embeddings(
@@ -524,12 +525,9 @@ async def _finalize_billing(
     updated_rate_limit_result = None
     
     try:
-        # Get token usage from response
-        usage = response_data.get("usage_from_provider", {})
-        tokens_input = usage.get("prompt_tokens", 0)
+        tokens_input, tokens_total, usage_source = extract_embeddings_usage(response_data)
         tokens_output = 0  # Embeddings don't have output tokens
-        tokens_total = usage.get("total_tokens", tokens_input)
-        
+
         # Record actual token usage for rate limiting
         if db_api_key and tokens_total > 0:
             user_identifier = f"key:{db_api_key.key_prefix}"
@@ -544,6 +542,7 @@ async def _finalize_billing(
                 "Recorded actual token usage for rate limiting",
                 tokens_input=tokens_input,
                 tokens_total=tokens_total,
+                usage_source=usage_source,
                 tpm_current=updated_rate_limit_result.tpm_current if updated_rate_limit_result else None,
                 event_type="rate_limit_tokens_recorded",
             )
@@ -566,6 +565,7 @@ async def _finalize_billing(
                 "Usage finalized",
                 tokens_input=tokens_input,
                 tokens_total=tokens_total,
+                usage_source=usage_source,
                 amount_total=str(finalize_response.amount_total),
                 event_type="usage_finalized",
             )

--- a/src/api/v1/embeddings/usage.py
+++ b/src/api/v1/embeddings/usage.py
@@ -1,0 +1,36 @@
+"""Token usage extraction for embeddings billing finalize."""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+
+def extract_embeddings_usage(response_data: Any) -> Tuple[int, int, str]:
+    """Pull embedding token counts from a proxy/OpenAI-style response body.
+
+    Prefer the node's chat-style ``usage_from_provider`` when present; fall back
+    to the OpenAI-compatible ``usage`` object that the embeddings path returns
+    today. Returns ``(tokens_input, tokens_total, source)`` where source is the
+    field name used, or ``"none"`` when neither yields countable tokens.
+    """
+    if not isinstance(response_data, dict):
+        return 0, 0, "none"
+
+    for key in ("usage_from_provider", "usage"):
+        usage = response_data.get(key)
+        if not isinstance(usage, dict):
+            continue
+        try:
+            tokens_input = int(usage.get("prompt_tokens") or 0)
+        except (TypeError, ValueError):
+            tokens_input = 0
+        try:
+            tokens_total = int(usage.get("total_tokens") or 0)
+        except (TypeError, ValueError):
+            tokens_total = 0
+        if tokens_total <= 0:
+            tokens_total = tokens_input
+        if tokens_input > 0 or tokens_total > 0:
+            return tokens_input, tokens_total, key
+
+    return 0, 0, "none"

--- a/tests/unit/test_embeddings_usage_extract.py
+++ b/tests/unit/test_embeddings_usage_extract.py
@@ -1,0 +1,45 @@
+"""Unit tests for embeddings usage extraction (billing finalize)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from src.api.v1.embeddings.usage import extract_embeddings_usage
+
+
+def test_prefers_usage_from_provider():
+    body = {
+        "usage_from_provider": {"prompt_tokens": 12, "total_tokens": 12},
+        "usage": {"prompt_tokens": 99, "total_tokens": 99},
+    }
+    assert extract_embeddings_usage(body) == (12, 12, "usage_from_provider")
+
+
+def test_falls_back_to_openai_usage():
+    """Node embeddings path returns OpenAI-style usage only (DJohnston gap)."""
+    body = {
+        "object": "list",
+        "data": [{"embedding": [0.1], "index": 0}],
+        "usage": {"prompt_tokens": 42, "total_tokens": 42},
+    }
+    assert extract_embeddings_usage(body) == (42, 42, "usage")
+
+
+def test_empty_usage_from_provider_falls_back():
+    body = {
+        "usage_from_provider": {},
+        "usage": {"prompt_tokens": 7, "total_tokens": 7},
+    }
+    assert extract_embeddings_usage(body) == (7, 7, "usage")
+
+
+def test_prompt_tokens_only_fills_total():
+    body = {"usage": {"prompt_tokens": 15}}
+    assert extract_embeddings_usage(body) == (15, 15, "usage")
+
+
+def test_missing_usage_returns_none():
+    assert extract_embeddings_usage({"data": []}) == (0, 0, "none")
+    assert extract_embeddings_usage({}) == (0, 0, "none")
+    assert extract_embeddings_usage(None) == (0, 0, "none")


### PR DESCRIPTION
## Summary
- Promote `test` → `main` for production (`api.mor.org`).
- Embeddings finalize falls back to OpenAI-compatible `usage` when `usage_from_provider` is absent, so hosted embedding charges get real `tokens_total` / credit amounts (PR #327 → #328).

## Test plan
- [x] Verified on **api.dev.mor.org** / test deploy: embeddings `usage_finalized` with non-zero tokens when provider returns `usage`
- [ ] After prod deploy: sample `text-embedding-bge-m3` charge has `tokens_total > 0` and non-zero `amount_paid` when usage is present
- [ ] Chat completions metering unchanged
- [ ] Failure path still voids embedding holds


Made with [Cursor](https://cursor.com)